### PR TITLE
Implement basic credential provider

### DIFF
--- a/packages/databricks-sdk-js/package.json
+++ b/packages/databricks-sdk-js/package.json
@@ -26,15 +26,19 @@
         "test:integ": "ts-mocha --type-check 'src/**/*.integ.ts'"
     },
     "dependencies": {
+        "ini": "^3.0.0",
         "node-fetch": "^2.6.7"
     },
     "devDependencies": {
+        "@types/ini": "^1.3.31",
         "@types/node-fetch": "^2.6.2",
+        "@types/tmp": "^0.2.3",
         "@types/uuid": "^8.3.4",
         "eslint": "^8.18.0",
         "eslint-config-prettier": "^8.5.0",
         "mocha": "^10.0.0",
         "prettier": "^2.7.1",
+        "tmp-promise": "^3.0.3",
         "ts-loader": "^9.3.0",
         "ts-mocha": "^10.0.0",
         "typescript": "^4.7.4",

--- a/packages/databricks-sdk-js/src/api-client.test.ts
+++ b/packages/databricks-sdk-js/src/api-client.test.ts
@@ -1,8 +1,8 @@
 import {equal} from "assert";
 import {ApiClient} from "./api-client";
 
-describe("API Client", () => {
+describe(__filename, () => {
     it("create an instance of the client", () => {
-        let client = new ApiClient("https://databricks.com", "PAT");
+        let client = new ApiClient();
     });
 });

--- a/packages/databricks-sdk-js/src/api-client.ts
+++ b/packages/databricks-sdk-js/src/api-client.ts
@@ -1,34 +1,25 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import fetch from "node-fetch";
-//import {Event, EventEmitter} from "vscode";
+import {fromDefaultChain} from "./auth/fromChain";
 
 type HttpMethod = "POST" | "GET";
 
 export class ApiClient {
-    private host!: string;
-    private token!: string;
-
-    constructor(host: string, token: string) {
-        this.updateConfiguration(host, token);
-    }
-
-    updateConfiguration(host: string, token: string) {
-        this.host = host;
-        this.token = token;
-    }
+    constructor(private credentialProvider = fromDefaultChain) {}
 
     async request(
         path: string,
         method: HttpMethod,
         payload?: any
     ): Promise<Object> {
+        const credentials = await this.credentialProvider();
         const headers = {
-            "Authorization": `Bearer ${this.token}`,
+            "Authorization": `Bearer ${credentials.token}`,
             "User-Agent": `vscode-notebook`,
             "Content-Type": "text/json",
         };
 
-        let url = new URL(this.host);
+        let url = credentials.host;
         url.pathname = path;
 
         let options: any = {

--- a/packages/databricks-sdk-js/src/auth/CredentialProvider.ts
+++ b/packages/databricks-sdk-js/src/auth/CredentialProvider.ts
@@ -1,0 +1,19 @@
+/**
+ * An object representing temporary or permanent AWS credentials.
+ */
+export interface Credentials {
+    readonly token: string;
+    readonly host: URL;
+}
+
+/**
+ * A function that, when invoked, returns a promise that will be fulfilled with
+ * a value of type T.
+ */
+export interface Provider<T> {
+    (): Promise<T>;
+}
+
+export type CredentialProvider = Provider<Credentials>;
+
+export class CredentialsProviderError extends Error {}

--- a/packages/databricks-sdk-js/src/auth/fromChain.ts
+++ b/packages/databricks-sdk-js/src/auth/fromChain.ts
@@ -1,0 +1,32 @@
+import {
+    CredentialProvider,
+    CredentialsProviderError,
+} from "./CredentialProvider";
+import {fromEnv} from "./fromEnv";
+import {fromConfigFile} from "./fromConfigFile";
+
+export const fromChain = (
+    chain: Array<CredentialProvider>
+): CredentialProvider => {
+    let cachedProvider: CredentialProvider;
+
+    return async () => {
+        if (cachedProvider) {
+            return await cachedProvider();
+        }
+
+        for (const provider of chain) {
+            try {
+                let credentials = await provider();
+                cachedProvider = provider;
+                return credentials;
+            } catch (e) {}
+        }
+
+        throw new CredentialsProviderError(
+            "No valid credential provider found"
+        );
+    };
+};
+
+export const fromDefaultChain = fromChain([fromEnv(), fromConfigFile()]);

--- a/packages/databricks-sdk-js/src/auth/fromConfigFile.test.ts
+++ b/packages/databricks-sdk-js/src/auth/fromConfigFile.test.ts
@@ -1,0 +1,50 @@
+import assert = require("node:assert");
+import {writeFile} from "node:fs/promises";
+import {withFile} from "tmp-promise";
+import {DEFAULT_PROFILE, fromConfigFile} from "./fromConfigFile";
+
+describe(__dirname, () => {
+    it("should load from config file", async () => {
+        await withFile(async ({path}) => {
+            await writeFile(
+                path,
+                `[DEFAULT]
+host = https://cloud.databricks.com/
+token = dapitest1234 `
+            );
+
+            const provider = fromConfigFile(DEFAULT_PROFILE, path);
+            const credentials = await provider();
+            assert.equal(
+                credentials.host.href,
+                "https://cloud.databricks.com/"
+            );
+            assert.equal(credentials.token, "dapitest1234");
+        });
+    });
+
+    it("should load non DEFAULT profile from config file", async () => {
+        await withFile(async ({path}) => {
+            await writeFile(
+                path,
+                `[DEFAULT]
+host = https://cloud.databricks.com/
+token = dapitest1234
+
+[STAGING]
+host = https://staging.cloud.databricks.com/
+token = dapitest54321`
+            );
+
+            const provider = fromConfigFile("STAGING", path);
+            const credentials = await provider();
+            assert.equal(
+                credentials.host.href,
+                "https://staging.cloud.databricks.com/"
+            );
+            assert.equal(credentials.token, "dapitest54321");
+        });
+    });
+});
+
+//let stub = sinon.stub(process.env, 'FOO').value('bar');

--- a/packages/databricks-sdk-js/src/auth/fromConfigFile.ts
+++ b/packages/databricks-sdk-js/src/auth/fromConfigFile.ts
@@ -1,0 +1,32 @@
+import {
+    CredentialProvider,
+    Credentials,
+    CredentialsProviderError,
+} from "./CredentialProvider";
+import {loadConfigFile} from "../configFile";
+
+export const DEFAULT_PROFILE = "DEFAULT";
+
+export const fromConfigFile = (
+    profile: string = DEFAULT_PROFILE,
+    configFile?: string
+): CredentialProvider => {
+    let cachedValue: Credentials;
+
+    return async () => {
+        if (cachedValue) {
+            return cachedValue;
+        }
+
+        const config = await loadConfigFile(configFile);
+
+        if (config[profile].host && config[profile].token) {
+            cachedValue = config[profile];
+            return cachedValue;
+        }
+
+        throw new CredentialsProviderError(
+            "Can't load credentials from config file"
+        );
+    };
+};

--- a/packages/databricks-sdk-js/src/auth/fromEnv.test.ts
+++ b/packages/databricks-sdk-js/src/auth/fromEnv.test.ts
@@ -1,0 +1,34 @@
+import assert = require("node:assert");
+import {CredentialsProviderError} from "./CredentialProvider";
+import {fromEnv} from "./fromEnv";
+
+describe(__filename, () => {
+    let origEnv: any;
+    beforeEach(() => {
+        origEnv = process.env;
+        process.env = {};
+    });
+
+    afterEach(() => {
+        process.env = origEnv;
+    });
+
+    it("should load config from environment variables", async () => {
+        process.env["DATABRICKS_HOST"] = "https://cloud.databricks.com/";
+        process.env["DATABRICKS_TOKEN"] = "dapitest1234";
+
+        const provider = fromEnv();
+        const credentials = await provider();
+
+        assert.equal(credentials.host.href, "https://cloud.databricks.com/");
+        assert.equal(credentials.token, "dapitest1234");
+    });
+
+    it("should throw if environment variables are not set", async () => {
+        const provider = fromEnv();
+
+        assert.rejects(async () => {
+            await provider();
+        }, CredentialsProviderError);
+    });
+});

--- a/packages/databricks-sdk-js/src/auth/fromEnv.ts
+++ b/packages/databricks-sdk-js/src/auth/fromEnv.ts
@@ -1,0 +1,22 @@
+import {
+    CredentialProvider,
+    CredentialsProviderError,
+} from "./CredentialProvider";
+
+export const fromEnv = (): CredentialProvider => {
+    return async () => {
+        const host = process.env["DATABRICKS_HOST"];
+        const token = process.env["DATABRICKS_TOKEN"];
+
+        if (host && token) {
+            return {
+                token: token,
+                host: new URL(host),
+            };
+        }
+
+        throw new CredentialsProviderError(
+            "Can't find databricks environment variables"
+        );
+    };
+};

--- a/packages/databricks-sdk-js/src/configFile.test.ts
+++ b/packages/databricks-sdk-js/src/configFile.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import assert = require("node:assert");
+import {loadConfigFile, resolveConfigFilePath} from "./configFile";
+import {writeFile} from "node:fs/promises";
+import {withFile} from "tmp-promise";
+import {homedir} from "node:os";
+import path = require("node:path");
+
+describe(__filename, () => {
+    beforeEach(() => {
+        delete process.env.DATABRICKS_CONFIG_FILE;
+    });
+
+    it("should load file from default location", () => {
+        assert.equal(
+            resolveConfigFilePath(),
+            path.join(homedir(), ".databrickscfg")
+        );
+    });
+
+    it("should load file location defined in environment variable", () => {
+        process.env.DATABRICKS_CONFIG_FILE = "/tmp/databrickscfg.yml";
+        assert.equal(resolveConfigFilePath(), "/tmp/databrickscfg.yml");
+    });
+
+    it("should load file from passed in location", () => {
+        assert.equal(
+            resolveConfigFilePath("/tmp/.databrickscfg"),
+            "/tmp/.databrickscfg"
+        );
+    });
+
+    it("should parse a config file", async () => {
+        await withFile(async ({path}) => {
+            await writeFile(
+                path,
+                `[DEFAULT]
+host = https://cloud.databricks.com/
+token = dapitest1234
+
+[STAGING]
+host = https://staging.cloud.databricks.com/
+token = dapitest54321`
+            );
+
+            const profiles = await loadConfigFile(path);
+
+            assert.equal(Object.keys(profiles).length, 2);
+            assert.equal(
+                profiles.DEFAULT.host.href,
+                "https://cloud.databricks.com/"
+            );
+            assert.equal(profiles.DEFAULT.token, "dapitest1234");
+            assert.equal(
+                profiles.STAGING.host.href,
+                "https://staging.cloud.databricks.com/"
+            );
+            assert.equal(profiles.STAGING.token, "dapitest54321");
+        });
+    });
+});

--- a/packages/databricks-sdk-js/src/configFile.ts
+++ b/packages/databricks-sdk-js/src/configFile.ts
@@ -1,0 +1,55 @@
+import path = require("node:path");
+import {readFile, stat} from "node:fs/promises";
+import {parse} from "ini";
+import {homedir} from "node:os";
+
+export type Profiles = Record<
+    string,
+    {
+        host: URL;
+        token: string;
+    }
+>;
+
+export class ConfigFileError extends Error {}
+
+export function resolveConfigFilePath(filePath?: string): string {
+    if (!filePath) {
+        if (process.env.DATABRICKS_CONFIG_FILE) {
+            filePath = process.env.DATABRICKS_CONFIG_FILE;
+        } else {
+            filePath = path.join(homedir(), ".databrickscfg");
+        }
+    }
+
+    return filePath;
+}
+
+export async function loadConfigFile(filePath?: string): Promise<Profiles> {
+    filePath = resolveConfigFilePath(filePath);
+
+    let fileContents: string;
+    try {
+        await stat(filePath);
+        fileContents = await readFile(filePath, {encoding: "utf-8"});
+    } catch (e) {
+        throw new ConfigFileError(`Can't find ${filePath}`);
+    }
+
+    let config: any;
+    try {
+        config = parse(fileContents);
+    } catch (e) {
+        throw new ConfigFileError(`Can't parse ${filePath}`);
+    }
+
+    let profiles: Profiles = {};
+    for (let profile in config) {
+        profiles[profile] = {
+            host: new URL(config[profile].host),
+            token: config[profile].token,
+        };
+    }
+
+    return profiles;
+}

--- a/packages/databricks-sdk-js/src/index.ts
+++ b/packages/databricks-sdk-js/src/index.ts
@@ -10,3 +10,8 @@ export * from "./apis/dbfs";
 
 export * from "./services/Command";
 export * from "./services/ExecutionContext";
+
+export * from "./auth/CredentialProvider";
+export * from "./auth/fromEnv";
+export * from "./auth/fromChain";
+export * from "./auth/fromConfigFile";

--- a/packages/databricks-sdk-js/src/sdk.integ.ts
+++ b/packages/databricks-sdk-js/src/sdk.integ.ts
@@ -11,6 +11,7 @@ import {
 } from ".";
 import assert = require("assert");
 import {v4 as uuidv4} from "uuid";
+import {fromEnv} from "./auth/fromEnv";
 
 describe("Integration tests for the Databricks SDK", function () {
     let client: ApiClient;
@@ -22,13 +23,7 @@ describe("Integration tests for the Databricks SDK", function () {
 
     before(async () => {
         testRunId = uuidv4();
-        let host = process.env["DATABRICKS_HOST"];
-        let token = process.env["DATABRICKS_TOKEN"];
-
-        assert(host, "Environment variable 'DATABRICKS_HOST' must be set");
-        assert(token, "Environment variable 'DATABRICKS_TOKEN' must be set");
-
-        client = new ApiClient(host, token);
+        client = new ApiClient(fromEnv());
         let clustersApi = new ClustersApi(client);
 
         if (process.env["DATABRICKS_CLUSTER_ID"]) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,13 +9,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@databricks/databricks-sdk@workspace:packages/databricks-sdk-js"
   dependencies:
+    "@types/ini": ^1.3.31
     "@types/node-fetch": ^2.6.2
+    "@types/tmp": ^0.2.3
     "@types/uuid": ^8.3.4
     eslint: ^8.18.0
     eslint-config-prettier: ^8.5.0
+    ini: ^3.0.0
     mocha: ^10.0.0
     node-fetch: ^2.6.7
     prettier: ^2.7.1
+    tmp-promise: ^3.0.3
     ts-loader: ^9.3.0
     ts-mocha: ^10.0.0
     typescript: ^4.7.4
@@ -223,6 +227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ini@npm:^1.3.31":
+  version: 1.3.31
+  resolution: "@types/ini@npm:1.3.31"
+  checksum: aca4fed0cd68f6693fd64e1b7d188a9c8c6f5823b2e3501b0570135555d4184d7d0dfba2c1afb3514c94cb21ece732f4467ea98c827d1b1b98716827ac9de680
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -272,6 +283,13 @@ __metadata:
   version: 16.11.41
   resolution: "@types/node@npm:16.11.41"
   checksum: 808e4d65757bb13cf25e88dfa4e65880efef06652b04baecb051eb90cf090dda9812aa3505b31e963a48041eed7dbe0fc59c44c7c5e117da952ff951bf3a584a
+  languageName: node
+  linkType: hard
+
+"@types/tmp@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "@types/tmp@npm:0.2.3"
+  checksum: 0ca45e99b3b3c6959d5c4f4555f73c8007db540cfb0fbbb9373217f9ab85e67eef75193f51a1d6564b0ee6c6f5ffa259d1034d7f7530a5b7ce80acb94cfc4daa
   languageName: node
   linkType: hard
 
@@ -2260,6 +2278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ini@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "ini@npm:3.0.0"
+  checksum: e92b6b0835ac369e58c677e7faa8db6019ac667d7404887978fb86b181d658e50f1742ecbba7d81eb5ff917b3ae4d63a48e1ef3a9f8a0527bd7605fe1a9995d4
+  languageName: node
+  linkType: hard
+
 "ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
@@ -3821,7 +3846,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.1":
+"tmp-promise@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: ^0.2.0
+  checksum: f854f5307dcee6455927ec3da9398f139897faf715c5c6dcee6d9471ae85136983ea06662eba2edf2533bdcb0fca66d16648e79e14381e30c7fb20be9c1aa62c
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.0, tmp@npm:^0.2.1":
   version: 0.2.1
   resolution: "tmp@npm:0.2.1"
   dependencies:


### PR DESCRIPTION
- inspired by the AWS SDK v3 credential providers https://www.npmjs.com/package/@aws-sdk/credential-providers
- decouple API client from credentials
- add credential providers for environment variables and config files
- add default provider chain 