### PR TITLE
Restart cluster loader on error

### DIFF
--- a/packages/databricks-vscode/src/cluster/ClusterLoader.ts
+++ b/packages/databricks-vscode/src/cluster/ClusterLoader.ts
@@ -167,6 +167,12 @@ export class ClusterLoader implements Disposable {
                 await this._load();
             } catch (e) {
                 let err = e;
+
+                /*
+                Standard Error class has message and stack fields set as non enumerable.
+                To correctly account for all such fields, we iterate over all own-properties of
+                the error object and accumulate them as enumerable fields in the final err object.
+                */
                 if (Object(err) === err) {
                     err = {
                         ...Object.getOwnPropertyNames(err).reduce((acc, i) => {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -44,6 +44,11 @@ export function activate(context: ExtensionContext): PublicApi {
         true
     );
 
+    /** 
+    This logger collects all the logs in the extension.
+    
+    TODO Make this logger log to a seperate (or common?) output console in vscode
+    */
     NamedLogger.getOrCreate(
         "Extension",
         {


### PR DESCRIPTION
Cluster loader hanged when there was an error, with no way of restarting it except restarting the extension (check video below). 

This PR fixes that. Now cluster loader just catches and logs the error and keeps working normally. 

https://user-images.githubusercontent.com/88345179/196408124-80751e22-48e3-40ec-a687-7f231c1cfebd.mov

