### PR TITLE
Rename extension from `databricks-vscode` to `databricks`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,7 +53,8 @@ jobs:
             - run: mkdir -p packages/databricks-vscode/artifacts
 
             - name: Build VSIX
-              run: yarn workspace databricks-vscode package -o artifacts -t darwin-x64
+              run: yarn package -o artifacts -t darwin-x64
+              working-directory: packages/databricks-vscode
 
             - name: Upload artifacts
               uses: actions/upload-artifact@v3

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "databricks-vscode",
+    "name": "databricks",
     "displayName": "Databricks for Visual Studio Code",
     "description": "IDE support for Databricks",
     "publisher": "databricks",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3169,9 +3169,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"databricks-vscode@workspace:packages/databricks-vscode":
+"databricks@workspace:packages/databricks-vscode":
   version: 0.0.0-use.local
-  resolution: "databricks-vscode@workspace:packages/databricks-vscode"
+  resolution: "databricks@workspace:packages/databricks-vscode"
   dependencies:
     "@databricks/databricks-sdk": "workspace:^"
     "@databricks/databricks-vscode-types": "workspace:^"


### PR DESCRIPTION
This change is needed because MS changed their policies for extension names. Now extension names must be unique even when the publisher is different.