### PR TITLE
UI tweaks

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -271,29 +271,39 @@
             ],
             "view/item/context": [
                 {
+                    "command": "databricks.utils.openExternal",
+                    "when": "view == configurationView && viewItem == workspace || view == configurationView && viewItem =~ /^.*cluster.*$/ || view == configurationView && viewItem =~ /^sync.*$/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "databricks.utils.openExternal",
+                    "when": "view == clusterView && viewItem == cluster",
+                    "group": "inline@1"
+                },
+                {
                     "command": "databricks.connection.attachCluster",
                     "when": "view == clusterView",
-                    "group": "inline@1"
+                    "group": "inline@2"
                 },
                 {
                     "command": "databricks.connection.configureWorkspace",
                     "when": "view == configurationView && viewItem == workspace",
-                    "group": "inline@1"
+                    "group": "inline@2"
                 },
                 {
                     "command": "databricks.connection.attachClusterQuickPick",
                     "when": "view == configurationView && viewItem == clusterDetached || view == configurationView && viewItem =~ /^databricks.cluster.*$/",
-                    "group": "inline@1"
+                    "group": "inline@2"
                 },
                 {
                     "command": "databricks.connection.attachSyncDestination",
                     "when": "view == configurationView && viewItem == syncDetached",
-                    "group": "inline@1"
+                    "group": "inline@2"
                 },
                 {
                     "command": "databricks.connection.attachSyncDestination",
                     "when": "view == configurationView && viewItem == syncStopped || view == configurationView && viewItem == syncRunning",
-                    "group": "inline@1"
+                    "group": "inline@2"
                 },
                 {
                     "command": "databricks.sync.start",
@@ -313,11 +323,6 @@
                 {
                     "command": "databricks.cluster.start",
                     "when": "view == configurationView && viewItem == databricks.cluster.terminated",
-                    "group": "inline@0"
-                },
-                {
-                    "command": "databricks.utils.openExternal",
-                    "when": "viewItem =~ /^.*databricks-link.*$/ ",
                     "group": "inline@0"
                 },
                 {

--- a/packages/databricks-vscode/src/cluster/ClusterListDataProvider.test.ts
+++ b/packages/databricks-vscode/src/cluster/ClusterListDataProvider.test.ts
@@ -15,6 +15,8 @@ const mockListClustersResponse: cluster.ListClustersResponse = {
             cluster_name: "cluster-name-2",
             cluster_source: "UI",
             creator_user_name: "user-2",
+            driver_node_type_id: "Standard_DS3_v2",
+            node_type_id: "Standard_DS3_v2",
             spark_version: "10.4.x-scala2.12",
             state: "TERMINATED",
         },
@@ -23,6 +25,8 @@ const mockListClustersResponse: cluster.ListClustersResponse = {
             cluster_name: "cluster-name-1",
             cluster_source: "UI",
             creator_user_name: "user-1",
+            driver_node_type_id: "Standard_DS3_v2",
+            node_type_id: "Standard_DS3_v2",
             spark_version: "10.4.x-scala2.12",
             state: "RUNNING",
         },
@@ -100,7 +104,7 @@ describe(__filename, () => {
             provider.getChildren(cluster)
         );
         assert(children);
-        assert.equal(children.length, 5);
+        assert.equal(children.length, 6);
     });
 
     it("should get cluster tree node items", async () => {
@@ -115,25 +119,27 @@ describe(__filename, () => {
         assert.deepEqual(items, [
             {
                 description: "cluster-id-2",
-                label: "Cluster ID:",
+                label: "Cluster ID",
             },
             {
-                contextValue: "databricks-link",
-                description:
-                    "https://www.example.com/#setting/clusters/cluster-id-2/configuration",
-                label: "URL:",
+                description: "Standard_DS3_v2",
+                label: "Driver",
+            },
+            {
+                description: "None (single node cluster)",
+                label: "Worker",
             },
             {
                 description: "10.4.x",
-                label: "Databricks Runtime:",
+                label: "Databricks Runtime",
             },
             {
                 description: "TERMINATED",
-                label: "State:",
+                label: "State",
             },
             {
                 description: "user-2",
-                label: "Creator:",
+                label: "Creator",
             },
         ]);
     });
@@ -147,6 +153,7 @@ describe(__filename, () => {
         let item = ClusterListDataProvider.clusterNodeToTreeItem(cluster);
         assert.deepEqual(item, {
             collapsibleState: 1,
+            contextValue: "cluster",
             iconPath: {
                 color: undefined,
                 id: "debug-stop",
@@ -163,6 +170,7 @@ describe(__filename, () => {
         item = ClusterListDataProvider.clusterNodeToTreeItem(cluster);
         assert.deepEqual(item, {
             collapsibleState: 1,
+            contextValue: "cluster",
             iconPath: {
                 color: undefined,
                 id: "debug-start",

--- a/packages/databricks-vscode/src/cluster/ClusterListDataProvider.ts
+++ b/packages/databricks-vscode/src/cluster/ClusterListDataProvider.ts
@@ -100,6 +100,7 @@ export class ClusterListDataProvider
             label: element.name,
             iconPath: icon,
             id: element.id,
+            contextValue: "cluster",
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }
@@ -114,56 +115,52 @@ export class ClusterListDataProvider
     ): Promise<Array<TreeItem>> {
         const children: TreeItem[] = [
             {
-                label: "Cluster ID:",
+                label: "Cluster ID",
                 description: element.id,
             },
-            {
-                label: "URL:",
-                description: await element.url,
-                contextValue: "databricks-link",
-            },
         ];
-        if (element.cores) {
+
+        children.push({
+            label: "Driver",
+            description: element.details.driver_node_type_id,
+        });
+
+        if (element.details.autoscale) {
             children.push({
-                label: "Cores:",
-                description: element.cores + "",
+                label: "Worker",
+                description: `${element.details.node_type_id}, ${element.details.autoscale.min_workers}-${element.details.autoscale.max_workers} workers`,
+            });
+        } else if (element.details.num_workers || 0 > 0) {
+            children.push({
+                label: "Worker",
+                description: `${element.details.node_type_id}, ${element.details.num_workers} workers`,
+            });
+        } else {
+            children.push({
+                label: "Worker",
+                description: `None (single node cluster)`,
             });
         }
-        if (element.memoryMb) {
-            children.push({
-                label: "Memory:",
-                description: formatSize(element.memoryMb),
-            });
+
+        let stateDescription: string = element.state;
+        if (element.stateMessage && element.state !== "RUNNING") {
+            stateDescription = `${element.state} - ${element.stateMessage}`;
         }
+
         children.push(
             {
-                label: "Databricks Runtime:",
+                label: "Databricks Runtime",
                 description: element.dbrVersion.join("."),
             },
             {
-                label: "State:",
-                description: element.state,
+                label: "State",
+                description: stateDescription,
             },
             {
-                label: "Creator:",
+                label: "Creator",
                 description: element.creator,
             }
         );
-
-        if (element.stateMessage && element.state !== "RUNNING") {
-            children.push({
-                label: "State message:",
-                description: element.stateMessage,
-            });
-        }
-
-        function formatSize(sizeInMB: number): string {
-            if (sizeInMB > 1024) {
-                return Math.round(sizeInMB / 1024).toString() + " GB";
-            } else {
-                return `${sizeInMB} MB`;
-            }
-        }
 
         return children;
     }

--- a/packages/databricks-vscode/src/configuration/ConfigurationDataProvider.test.ts
+++ b/packages/databricks-vscode/src/configuration/ConfigurationDataProvider.test.ts
@@ -102,7 +102,11 @@ describe(__filename, () => {
     });
 
     it("should return cluster children", async () => {
-        const cluster = new Cluster(instance(mock(ApiClient)), {
+        const mockApiClient = mock(ApiClient);
+        when(mockApiClient.host).thenResolve(
+            new URL("https://www.example.com")
+        );
+        const cluster = new Cluster(instance(mockApiClient), {
             cluster_id: "cluster-id-2",
             cluster_name: "cluster-name-2",
             cluster_source: "UI",
@@ -129,6 +133,7 @@ describe(__filename, () => {
                 },
                 id: "WORKSPACE",
                 label: "Workspace",
+                url: undefined,
             },
             {
                 collapsibleState: 2,
@@ -139,6 +144,7 @@ describe(__filename, () => {
                 },
                 id: "CLUSTER",
                 label: "Cluster",
+                url: "https://www.example.com/#setting/clusters/cluster-id-2/configuration",
             },
             {
                 collapsibleState: 2,

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -287,7 +287,7 @@ export async function activate(
         NamedLogger.getOrCreate("Extension").error("Quick Start error", e);
     });
 
-    //utils
+    // Utils
     const utilCommands = new UtilsCommands.UtilsCommands();
     context.subscriptions.push(
         commands.registerCommand(

--- a/packages/databricks-vscode/src/test/e2e/configure.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/configure.e2e.ts
@@ -109,7 +109,13 @@ describe("Configure Databricks Extension", async function () {
         const buttons = await (
             clusterConfigItem as TreeItem
         ).getActionButtons();
-        await buttons[0].elem.click();
+
+        const configureButton = buttons.filter((b) => {
+            return b.getLabel() === "Configure cluster";
+        })[0];
+        assert(configureButton);
+
+        await configureButton.elem.click();
 
         const input = await new InputBox(workbench.locatorMap).wait();
         await sleep(200);
@@ -131,7 +137,7 @@ describe("Configure Databricks Extension", async function () {
             clusterProps[await i.getLabel()] = (await i.getDescription()) || "";
         }
 
-        const testClusterId = clusterProps["Cluster ID:"];
+        const testClusterId = clusterProps["Cluster ID"];
         assert.equal(testClusterId, clusterId);
     });
 

--- a/packages/databricks-vscode/src/test/e2e/utils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils.ts
@@ -128,7 +128,7 @@ export async function waitForSyncComplete() {
 
             let status: TreeItem | undefined = undefined;
             for (const i of await repoConfigItem.getChildren()) {
-                if ((await i.getLabel()).includes("State:")) {
+                if ((await i.getLabel()).includes("State")) {
                     status = i;
                     break;
                 }
@@ -165,7 +165,7 @@ export async function startSyncIfStopped() {
 
             let status: TreeItem | undefined = undefined;
             for (const i of await repoConfigItem.getChildren()) {
-                if ((await i.getLabel()).includes("State:")) {
+                if ((await i.getLabel()).includes("State")) {
                     status = i;
                     break;
                 }

--- a/packages/databricks-vscode/src/utils/UtilsCommands.ts
+++ b/packages/databricks-vscode/src/utils/UtilsCommands.ts
@@ -1,12 +1,25 @@
-import {Disposable, TreeItem} from "vscode";
+import {Cluster} from "@databricks/databricks-sdk";
+import {Disposable} from "vscode";
+import {ConfigurationTreeItem} from "../configuration/ConfigurationDataProvider";
 import {openExternal} from "./urlUtils";
 
 export class UtilsCommands implements Disposable {
     private disposables: Disposable[] = [];
 
     openExternalCommand() {
-        return async (value: TreeItem) => {
-            await openExternal(`${value.description}`);
+        return async (value: ConfigurationTreeItem | Cluster) => {
+            let url: string | undefined;
+
+            if (value instanceof Cluster) {
+                url = await value.url;
+            } else {
+                url = value.url;
+            }
+
+            if (!url) {
+                return;
+            }
+            await openExternal(url);
         };
     }
 


### PR DESCRIPTION
- Unify: drop colons between tree label and description
- Move "open in browser" to tope level groups
- Remove URL tree items from cluster and sync destination
- Replace "cores and CPUs" with information about node types for driver and worker
- collapse state and state description into one tree item

https://user-images.githubusercontent.com/40952/215496240-16c36857-5cf3-4df4-8439-6a774b3f9131.mov


