### PR TITLE
Hide existing repos

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -273,23 +273,6 @@ export class ConnectionCommands implements Disposable {
                             };
                         })
                 );
-                children.push(
-                    {
-                        label: "Repos",
-                        kind: QuickPickItemKind.Separator,
-                    },
-                    ...repos
-                        .filter((entity) => {
-                            return !entity.basename.endsWith(REPO_NAME_SUFFIX);
-                        })
-                        .map((entity) => {
-                            return {
-                                label: entity.basename,
-                                detail: entity.path,
-                                path: entity.path,
-                            };
-                        })
-                );
             }
             input.items = children;
             input.busy = false;


### PR DESCRIPTION
No longer offer existing Repos  as sync destination. This avoids the risk of users accidentally overwriting existing files and notebooks.

Before:
![Screenshot 2023-02-17 at 16 28 00](https://user-images.githubusercontent.com/40952/219696022-6c6c84d4-2a5a-4aa5-bf5b-e3510cc11f1c.png)

After: 
![Screenshot 2023-02-17 at 16 27 35](https://user-images.githubusercontent.com/40952/219696029-6d188ff9-f7d4-4faa-a986-7d8afee39f2e.png)
