### PR TITLE
Publish extension also to OpenVSIX

### DIFF
--- a/.github/workflows/publish-to-vscode.yml
+++ b/.github/workflows/publish-to-vscode.yml
@@ -52,3 +52,14 @@ jobs:
 
               env:
                   VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+
+            - name: Install ovsx
+              run: npm install -g ovsx
+
+            - name: Publish to Open VSIX
+              run: |
+                  ovsx verify-pat databricks
+                  ovsx publish --packagePath databricks-*.vsix
+
+              env:
+                  OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
This is required for VSCode distributions that are not published by Microsoft such as Gitpod, or VSCodium as they are not allowed to install extension from the MS Marketplace.

![Screenshot 2023-03-10 at 11 30 55](https://user-images.githubusercontent.com/40952/224293284-12ee3708-d4d2-43b3-b564-ed9ca56aa227.png)
