### PR TITLE
Use waiter to handle long running calls

### DIFF
--- a/packages/databricks-sdk-js/src/.codegen/api.ts.tmpl
+++ b/packages/databricks-sdk-js/src/.codegen/api.ts.tmpl
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types"
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context"
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 {{range $i, $s := .Services }}
 export class {{$s.PascalName}}RetriableError extends ApiRetriableError {
@@ -30,88 +31,102 @@ export class {{$s.PascalName}}Service {
 	constructor(readonly client: ApiClient){}
 
 	{{- range $s.Methods}}
+
+	@withLogContext(ExposedLoggers.SDK)
+    private async _{{.CamelName}}({{if .Request}}request:  model.{{.Request.PascalName}},{{end}}
+        @context context?: Context
+	): Promise<{{template "type_for_response" .}}> 
+	
+	{
+		const path = {{if .PathParts -}}
+			`{{range  .PathParts}}{{.Prefix}}{{if .Field}}${request.{{.Field.Name}}}{{ else if .IsAccountId }}${this.client.accountId}{{end}}{{ end }}`
+		{{- else}}"{{.Path}}"{{end}}
+		return (await this.client.request(
+			path,
+			"{{.Verb}}",
+			{{if .Request -}}request{{else}}undefined{{end}}, 
+			context
+		) as {{if .Response}}{{if .Response.ArrayValue}}Array<model.{{.Response.ArrayValue.PascalName}}>{{else}}model.{{.Response.PascalName}}{{end}}{{else}}model.EmptyResponse{{end}})
+	}	
+
+	{{if .Wait}}
+	/**
+    {{.Comment "    * " 80}}
+	*/
+	@withLogContext(ExposedLoggers.SDK)
+	async {{.CamelName}}({{if .Request}}{{.Request.CamelName}}: model.{{.Request.PascalName}}{{end}},
+		@context context?: Context	
+	): Promise<Waiter<{{template "type_for_response" .}}, {{template "type_for_poll_response" .}}>> {
+		let cancellationToken = context?.cancellationToken;
+
+		{{if .Response}}const {{.Response.CamelName}} = {{end}}await this._{{.CamelName}}({{if .Request}}{{.Request.CamelName}},{{end}} context);
+
+		return asWaiter({{ if .Response}}{{.Response.CamelName}}{{ else }}null{{end}}, async(options) => { 
+			options = options || {};
+			options.onProgress =
+				options.onProgress || (async (newPollResponse) => {});
+			let {timeout, onProgress} = options;
+
+			return await retry<{{template "type_for_poll_response" .}}>({
+				timeout,
+				fn: async () => {
+					const pollResponse = await this.{{.Wait.Poll.CamelName}}({
+						{{range .Wait.Binding}}{{.PollField.Name}}: {{.Bind.Of.CamelName}}.{{.Bind.Name}}!,{{end}}
+					}, context)
+					if(cancellationToken?.isCancellationRequested) {
+						context?.logger?.error("{{$s.PascalName}}.{{.CamelName}}AndWait: cancelled");
+						throw new {{$s.PascalName}}Error("{{.CamelName}}AndWait", "cancelled");
+					}
+					await onProgress(pollResponse);
+					const status = pollResponse{{range $i, $e := .Wait.StatusPath}}{{if $i}}!{{end}}.{{$e.SnakeName}}{{end}}
+					const statusMessage = pollResponse{{range $i, $e := .Wait.MessagePath}}{{if $i}}!{{end}}.{{$e.SnakeName}}{{end}}
+					switch(status) {
+						{{range $i, $e := .Wait.Success}}{{if $i}} {{end}}case '{{$e.Content}}':{{end}}{
+							return pollResponse
+						}
+						{{if .Wait.Failure}}{{range $i, $e := .Wait.Failure}}{{if $i}} {{end}}case '{{$e.Content}}':{{end}}{
+							const errorMessage = `failed to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state, got ${status}: ${statusMessage}`;
+							context?.logger?.error(`{{$s.PascalName}}.{{.CamelName}}AndWait: ${errorMessage}`);
+							throw new {{$s.PascalName}}Error("{{.CamelName}}AndWait", errorMessage);
+						}
+						{{end}}default:{
+							const errorMessage = `failed to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state, got ${status}: ${statusMessage}`;
+							context?.logger?.error(`{{$s.PascalName}}.{{.CamelName}}AndWait: retrying: ${errorMessage}`);
+							throw new {{$s.PascalName}}RetriableError("{{.CamelName}}AndWait", errorMessage);
+						}
+					}
+				}
+			});
+		});
+	}
+	{{ else }}
 	/**
     {{.Comment "    * " 80}}
 	*/
 	@withLogContext(ExposedLoggers.SDK)
     async {{.CamelName}}({{if .Request}}request:  model.{{.Request.PascalName}},{{end}}
         @context context?: Context
-	): Promise<{{if .Response}}
+	): Promise<{{template "type_for_response" .}}> 	
+	{
+		return await this._{{.CamelName}}({{if .Request}}request,{{end}} context);
+	}	
+	{{end}}
+	{{end}}
+}
+{{end}}
+
+{{- define "type_for_response" -}}
+	{{if .Response}}
         {{if .Response.ArrayValue}}
             Array<model.{{.Response.ArrayValue.PascalName}}>
         {{else}}
             model.{{.Response.PascalName}}
         {{end}}
 	{{else}}
-      model.EmptyResponse
-	{{end}}> 
-	
-	{
-            const path = {{if .PathParts -}}
-		        `{{range  .PathParts}}{{.Prefix}}{{if .Field}}${request.{{.Field.Name}}}{{ else if .IsAccountId }}${this.client.accountId}{{end}}{{ end }}`
-	        {{- else}}"{{.Path}}"{{end}}
-			return (await this.client.request(
-				path,
-				"{{.Verb}}",
-				{{if .Request -}}request{{else}}undefined{{end}}, 
-				context
-			) as {{if .Response}}{{if .Response.ArrayValue}}Array<model.{{.Response.ArrayValue.PascalName}}>{{else}}model.{{.Response.PascalName}}{{end}}{{else}}model.EmptyResponse{{end}})
-		}
-
-	{{if .Wait}}
-	/**
-	* {{.CamelName}} and wait to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state
-	* {{if .Wait.Failure}} or fail on reaching {{range $i, $e := .Wait.Failure}}{{if $i}} or {{end}}{{.Content}}{{end}} state{{end}}
-	*/
-	@withLogContext(ExposedLoggers.SDK)
-	async {{.CamelName}}AndWait({{if .Request}}{{.Request.CamelName}}: model.{{.Request.PascalName}}{{end}},
-		options?: {
-			timeout?: Time,
-			onProgress?: (newPollResponse: model.{{if .Wait.Poll.Response}}{{.Wait.Poll.Response.PascalName}}{{else}}{{.Wait.Poll.EmptyResponseName.PascalName}}{{end}}) => Promise<void>
-		},
-		@context context?: Context	
-	): Promise<model.{{if .Wait.Poll.Response}}{{.Wait.Poll.Response.PascalName}}{{else}}{{.Wait.Poll.EmptyResponseName.PascalName}}{{end}}> {
-
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-		let {timeout, onProgress} = options;
-		let cancellationToken = context?.cancellationToken;
-
-		{{if .Wait.ForceBindRequest}}{{else if .Response}}const {{.Response.CamelName}} = {{end}}await this.{{.CamelName}}({{if .Request}}{{.Request.CamelName}},{{end}} context);
-
-		return await retry<model.{{if .Wait.Poll.Response}}{{.Wait.Poll.Response.PascalName}}{{else}}{{.Wait.Poll.EmptyResponseName.PascalName}}{{end}}>({
-			timeout,
-			fn: async () => {
-				const pollResponse = await this.{{.Wait.Poll.CamelName}}({
-                    {{range .Wait.Binding}}{{.PollField.Name}}: {{.Bind.Of.CamelName}}.{{.Bind.Name}}!,{{end}}
-				}, context)
-				if(cancellationToken?.isCancellationRequested) {
-					context?.logger?.error("{{$s.PascalName}}.{{.CamelName}}AndWait: cancelled");
-					throw new {{$s.PascalName}}Error("{{.CamelName}}AndWait", "cancelled");
-				}
-				await onProgress(pollResponse);
-				const status = pollResponse{{range $i, $e := .Wait.StatusPath}}{{if $i}}!{{end}}.{{$e.SnakeName}}{{end}}
-				const statusMessage = pollResponse{{range $i, $e := .Wait.MessagePath}}{{if $i}}!{{end}}.{{$e.SnakeName}}{{end}}
-				switch(status) {
-					{{range $i, $e := .Wait.Success}}{{if $i}} {{end}}case '{{$e.Content}}':{{end}}{
-						return pollResponse
-					}
-					{{if .Wait.Failure}}{{range $i, $e := .Wait.Failure}}{{if $i}} {{end}}case '{{$e.Content}}':{{end}}{
-						const errorMessage = `failed to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state, got ${status}: ${statusMessage}`;
-						context?.logger?.error(`{{$s.PascalName}}.{{.CamelName}}AndWait: ${errorMessage}`);
-						throw new {{$s.PascalName}}Error("{{.CamelName}}AndWait", errorMessage);
-					}
-					{{end}}default:{
-						const errorMessage = `failed to reach {{range $i, $e := .Wait.Success}}{{if $i}} or {{end}}{{.Content}}{{end}} state, got ${status}: ${statusMessage}`;
-						context?.logger?.error(`{{$s.PascalName}}.{{.CamelName}}AndWait: retrying: ${errorMessage}`);
-						throw new {{$s.PascalName}}RetriableError("{{.CamelName}}AndWait", errorMessage);
-					}
-				}
-			}
-		});
-	}
+        model.EmptyResponse
 	{{end}}
-	{{end}}
-}
-{{end}}
+{{- end -}}
+
+{{- define "type_for_poll_response" -}}
+model.{{if .Wait.Poll.Response}}{{.Wait.Poll.Response.PascalName}}{{else}}{{.Wait.Poll.EmptyResponseName.PascalName}}{{end}}
+{{- end -}}

--- a/packages/databricks-sdk-js/src/apis/clusterpolicies/api.ts
+++ b/packages/databricks-sdk-js/src/apis/clusterpolicies/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class ClusterPoliciesRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -50,13 +51,9 @@ export class ClusterPoliciesError extends ApiError {
  */
 export class ClusterPoliciesService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new policy.
-     *
-     * Creates a new policy with prescribed settings.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreatePolicy,
         @context context?: Context
     ): Promise<model.CreatePolicyResponse> {
@@ -70,6 +67,33 @@ export class ClusterPoliciesService {
     }
 
     /**
+     * Create a new policy.
+     *
+     * Creates a new policy with prescribed settings.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async create(
+        request: model.CreatePolicy,
+        @context context?: Context
+    ): Promise<model.CreatePolicyResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeletePolicy,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/policies/clusters/delete";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Delete a cluster policy.
      *
      * Delete a policy for a cluster. Clusters governed by this policy can still
@@ -80,7 +104,15 @@ export class ClusterPoliciesService {
         request: model.DeletePolicy,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/policies/clusters/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _edit(
+        request: model.EditPolicy,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/policies/clusters/edit";
         return (await this.client.request(
             path,
             "POST",
@@ -100,23 +132,11 @@ export class ClusterPoliciesService {
         request: model.EditPolicy,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/policies/clusters/edit";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._edit(request, context);
     }
 
-    /**
-     * Get entity.
-     *
-     * Get a cluster policy entity. Creation and editing is available to admins
-     * only.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.Policy> {
@@ -130,12 +150,21 @@ export class ClusterPoliciesService {
     }
 
     /**
-     * Get a cluster policy.
+     * Get entity.
      *
-     * Returns a list of policies accessible by the requesting user.
+     * Get a cluster policy entity. Creation and editing is available to admins
+     * only.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.Policy> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.List,
         @context context?: Context
     ): Promise<model.ListPoliciesResponse> {
@@ -146,6 +175,19 @@ export class ClusterPoliciesService {
             request,
             context
         )) as model.ListPoliciesResponse;
+    }
+
+    /**
+     * Get a cluster policy.
+     *
+     * Returns a list of policies accessible by the requesting user.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.List,
+        @context context?: Context
+    ): Promise<model.ListPoliciesResponse> {
+        return await this._list(request, context);
     }
 }
 
@@ -173,11 +215,9 @@ export class PolicyFamiliesError extends ApiError {
  */
 export class PolicyFamiliesService {
     constructor(readonly client: ApiClient) {}
-    /**
-    
-	*/
+
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetPolicyFamilyRequest,
         @context context?: Context
     ): Promise<model.PolicyFamily> {
@@ -194,7 +234,15 @@ export class PolicyFamiliesService {
     
 	*/
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetPolicyFamilyRequest,
+        @context context?: Context
+    ): Promise<model.PolicyFamily> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListPolicyFamiliesRequest,
         @context context?: Context
     ): Promise<model.ListPolicyFamiliesResponse> {
@@ -205,5 +253,16 @@ export class PolicyFamiliesService {
             request,
             context
         )) as model.ListPolicyFamiliesResponse;
+    }
+
+    /**
+    
+	*/
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListPolicyFamiliesRequest,
+        @context context?: Context
+    ): Promise<model.ListPolicyFamiliesResponse> {
+        return await this._list(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/commands/commands.integ.ts
+++ b/packages/databricks-sdk-js/src/apis/commands/commands.integ.ts
@@ -16,18 +16,22 @@ describe(__filename, function () {
     it("should execute python with low level API", async () => {
         const commandsApi = integSetup.client.commands;
 
-        const context = await commandsApi.createAndWait({
-            clusterId: integSetup.cluster.id,
-            language: "python",
-        });
+        const context = await (
+            await commandsApi.create({
+                clusterId: integSetup.cluster.id,
+                language: "python",
+            })
+        ).wait();
         //console.log("Execution context", context);
 
-        const status = await commandsApi.executeAndWait({
-            clusterId: integSetup.cluster.id,
-            contextId: context.id,
-            language: "python",
-            command: "print('juhu')",
-        });
+        const status = await (
+            await commandsApi.execute({
+                clusterId: integSetup.cluster.id,
+                contextId: context.id,
+                language: "python",
+                command: "print('juhu')",
+            })
+        ).wait();
 
         // console.log("Status", status);
 

--- a/packages/databricks-sdk-js/src/apis/dbfs/api.ts
+++ b/packages/databricks-sdk-js/src/apis/dbfs/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class DbfsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -28,6 +29,21 @@ export class DbfsError extends ApiError {
  */
 export class DbfsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _addBlock(
+        request: model.AddBlock,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/add-block";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
     /**
      * Append data block.
      *
@@ -43,7 +59,15 @@ export class DbfsService {
         request: model.AddBlock,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/add-block";
+        return await this._addBlock(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _close(
+        request: model.Close,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/close";
         return (await this.client.request(
             path,
             "POST",
@@ -63,13 +87,21 @@ export class DbfsService {
         request: model.Close,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/close";
+        return await this._close(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.Create,
+        @context context?: Context
+    ): Promise<model.CreateResponse> {
+        const path = "/api/2.0/dbfs/create";
         return (await this.client.request(
             path,
             "POST",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.CreateResponse;
     }
 
     /**
@@ -91,13 +123,21 @@ export class DbfsService {
         request: model.Create,
         @context context?: Context
     ): Promise<model.CreateResponse> {
-        const path = "/api/2.0/dbfs/create";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/delete";
         return (await this.client.request(
             path,
             "POST",
             request,
             context
-        )) as model.CreateResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -127,13 +167,21 @@ export class DbfsService {
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getStatus(
+        request: model.GetStatus,
+        @context context?: Context
+    ): Promise<model.FileInfo> {
+        const path = "/api/2.0/dbfs/get-status";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.FileInfo;
     }
 
     /**
@@ -148,13 +196,21 @@ export class DbfsService {
         request: model.GetStatus,
         @context context?: Context
     ): Promise<model.FileInfo> {
-        const path = "/api/2.0/dbfs/get-status";
+        return await this._getStatus(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.List,
+        @context context?: Context
+    ): Promise<model.ListStatusResponse> {
+        const path = "/api/2.0/dbfs/list";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.FileInfo;
+        )) as model.ListStatusResponse;
     }
 
     /**
@@ -178,13 +234,21 @@ export class DbfsService {
         request: model.List,
         @context context?: Context
     ): Promise<model.ListStatusResponse> {
-        const path = "/api/2.0/dbfs/list";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _mkdirs(
+        request: model.MkDirs,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/mkdirs";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListStatusResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -201,7 +265,15 @@ export class DbfsService {
         request: model.MkDirs,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/mkdirs";
+        return await this._mkdirs(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _move(
+        request: model.Move,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/move";
         return (await this.client.request(
             path,
             "POST",
@@ -225,7 +297,15 @@ export class DbfsService {
         request: model.Move,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/move";
+        return await this._move(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _put(
+        request: model.Put,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/dbfs/put";
         return (await this.client.request(
             path,
             "POST",
@@ -255,13 +335,21 @@ export class DbfsService {
         request: model.Put,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/dbfs/put";
+        return await this._put(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _read(
+        request: model.Read,
+        @context context?: Context
+    ): Promise<model.ReadResponse> {
+        const path = "/api/2.0/dbfs/read";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.ReadResponse;
     }
 
     /**
@@ -282,12 +370,6 @@ export class DbfsService {
         request: model.Read,
         @context context?: Context
     ): Promise<model.ReadResponse> {
-        const path = "/api/2.0/dbfs/read";
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.ReadResponse;
+        return await this._read(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/deployment/api.ts
+++ b/packages/databricks-sdk-js/src/apis/deployment/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class CredentialsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -31,6 +32,21 @@ export class CredentialsError extends ApiError {
  */
 export class CredentialsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateCredentialRequest,
+        @context context?: Context
+    ): Promise<model.Credential> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/credentials`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Credential;
+    }
+
     /**
      * Create credential configuration.
      *
@@ -54,13 +70,21 @@ export class CredentialsService {
         request: model.CreateCredentialRequest,
         @context context?: Context
     ): Promise<model.Credential> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/credentials`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteCredentialRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/credentials/${request.credentials_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.Credential;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -75,23 +99,11 @@ export class CredentialsService {
         request: model.DeleteCredentialRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/credentials/${request.credentials_id}`;
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._delete(request, context);
     }
 
-    /**
-     * Get credential configuration.
-     *
-     * Gets a Databricks credential configuration object for an account, both
-     * specified by ID.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetCredentialRequest,
         @context context?: Context
     ): Promise<model.Credential> {
@@ -105,13 +117,23 @@ export class CredentialsService {
     }
 
     /**
-     * Get all credential configurations.
+     * Get credential configuration.
      *
-     * Gets all Databricks credential configurations associated with an account
+     * Gets a Databricks credential configuration object for an account, both
      * specified by ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(@context context?: Context): Promise<Array<model.Credential>> {
+    async get(
+        request: model.GetCredentialRequest,
+        @context context?: Context
+    ): Promise<model.Credential> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.Credential>> {
         const path = `/api/2.0/accounts/${this.client.accountId}/credentials`;
         return (await this.client.request(
             path,
@@ -119,6 +141,17 @@ export class CredentialsService {
             undefined,
             context
         )) as Array<model.Credential>;
+    }
+
+    /**
+     * Get all credential configurations.
+     *
+     * Gets all Databricks credential configurations associated with an account
+     * specified by ID.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(@context context?: Context): Promise<Array<model.Credential>> {
+        return await this._list(context);
     }
 }
 
@@ -153,6 +186,21 @@ export class EncryptionKeysError extends ApiError {
  */
 export class EncryptionKeysService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateCustomerManagedKeyRequest,
+        @context context?: Context
+    ): Promise<model.CustomerManagedKey> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CustomerManagedKey;
+    }
+
     /**
      * Create encryption key configuration.
      *
@@ -178,13 +226,21 @@ export class EncryptionKeysService {
         request: model.CreateCustomerManagedKeyRequest,
         @context context?: Context
     ): Promise<model.CustomerManagedKey> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteEncryptionKeyRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys/${request.customer_managed_key_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.CustomerManagedKey;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -198,13 +254,21 @@ export class EncryptionKeysService {
         request: model.DeleteEncryptionKeyRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetEncryptionKeyRequest,
+        @context context?: Context
+    ): Promise<model.CustomerManagedKey> {
         const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys/${request.customer_managed_key_id}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.CustomerManagedKey;
     }
 
     /**
@@ -231,13 +295,20 @@ export class EncryptionKeysService {
         request: model.GetEncryptionKeyRequest,
         @context context?: Context
     ): Promise<model.CustomerManagedKey> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys/${request.customer_managed_key_id}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.CustomerManagedKey>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys`;
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.CustomerManagedKey;
+        )) as Array<model.CustomerManagedKey>;
     }
 
     /**
@@ -261,13 +332,7 @@ export class EncryptionKeysService {
     async list(
         @context context?: Context
     ): Promise<Array<model.CustomerManagedKey>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/customer-managed-keys`;
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as Array<model.CustomerManagedKey>;
+        return await this._list(context);
     }
 }
 
@@ -288,6 +353,21 @@ export class NetworksError extends ApiError {
  */
 export class NetworksService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateNetworkRequest,
+        @context context?: Context
+    ): Promise<model.Network> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/networks`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Network;
+    }
+
     /**
      * Create network configuration.
      *
@@ -300,13 +380,21 @@ export class NetworksService {
         request: model.CreateNetworkRequest,
         @context context?: Context
     ): Promise<model.Network> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/networks`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteNetworkRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/networks/${request.network_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.Network;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -324,23 +412,11 @@ export class NetworksService {
         request: model.DeleteNetworkRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/networks/${request.network_id}`;
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._delete(request, context);
     }
 
-    /**
-     * Get a network configuration.
-     *
-     * Gets a Databricks network configuration, which represents a cloud VPC and
-     * its resources.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetNetworkRequest,
         @context context?: Context
     ): Promise<model.Network> {
@@ -354,6 +430,33 @@ export class NetworksService {
     }
 
     /**
+     * Get a network configuration.
+     *
+     * Gets a Databricks network configuration, which represents a cloud VPC and
+     * its resources.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async get(
+        request: model.GetNetworkRequest,
+        @context context?: Context
+    ): Promise<model.Network> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.Network>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/networks`;
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as Array<model.Network>;
+    }
+
+    /**
      * Get all network configurations.
      *
      * Gets a list of all Databricks network configurations for an account,
@@ -364,13 +467,7 @@ export class NetworksService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<Array<model.Network>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/networks`;
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as Array<model.Network>;
+        return await this._list(context);
     }
 }
 
@@ -398,6 +495,21 @@ export class PrivateAccessError extends ApiError {
  */
 export class PrivateAccessService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.UpsertPrivateAccessSettingsRequest,
+        @context context?: Context
+    ): Promise<model.PrivateAccessSettings> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.PrivateAccessSettings;
+    }
+
     /**
      * Create private access settings.
      *
@@ -422,13 +534,21 @@ export class PrivateAccessService {
         request: model.UpsertPrivateAccessSettingsRequest,
         @context context?: Context
     ): Promise<model.PrivateAccessSettings> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeletePrivateAccesRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings/${request.private_access_settings_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.PrivateAccessSettings;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -448,13 +568,21 @@ export class PrivateAccessService {
         request: model.DeletePrivateAccesRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetPrivateAccesRequest,
+        @context context?: Context
+    ): Promise<model.PrivateAccessSettings> {
         const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings/${request.private_access_settings_id}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.PrivateAccessSettings;
     }
 
     /**
@@ -474,13 +602,20 @@ export class PrivateAccessService {
         request: model.GetPrivateAccesRequest,
         @context context?: Context
     ): Promise<model.PrivateAccessSettings> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings/${request.private_access_settings_id}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.PrivateAccessSettings>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings`;
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.PrivateAccessSettings;
+        )) as Array<model.PrivateAccessSettings>;
     }
 
     /**
@@ -493,13 +628,21 @@ export class PrivateAccessService {
     async list(
         @context context?: Context
     ): Promise<Array<model.PrivateAccessSettings>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings`;
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _replace(
+        request: model.UpsertPrivateAccessSettingsRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings/${request.private_access_settings_id}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PUT",
+            request,
             context
-        )) as Array<model.PrivateAccessSettings>;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -533,13 +676,7 @@ export class PrivateAccessService {
         request: model.UpsertPrivateAccessSettingsRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/private-access-settings/${request.private_access_settings_id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._replace(request, context);
     }
 }
 
@@ -564,6 +701,21 @@ export class StorageError extends ApiError {
  */
 export class StorageService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateStorageConfigurationRequest,
+        @context context?: Context
+    ): Promise<model.StorageConfiguration> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/storage-configurations`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.StorageConfiguration;
+    }
+
     /**
      * Create new storage configuration.
      *
@@ -583,23 +735,11 @@ export class StorageService {
         request: model.CreateStorageConfigurationRequest,
         @context context?: Context
     ): Promise<model.StorageConfiguration> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/storage-configurations`;
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.StorageConfiguration;
+        return await this._create(request, context);
     }
 
-    /**
-     * Delete storage configuration.
-     *
-     * Deletes a Databricks storage configuration. You cannot delete a storage
-     * configuration that is associated with any workspace.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    private async _delete(
         request: model.DeleteStorageRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -613,13 +753,21 @@ export class StorageService {
     }
 
     /**
-     * Get storage configuration.
+     * Delete storage configuration.
      *
-     * Gets a Databricks storage configuration for an account, both specified by
-     * ID.
+     * Deletes a Databricks storage configuration. You cannot delete a storage
+     * configuration that is associated with any workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteStorageRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetStorageRequest,
         @context context?: Context
     ): Promise<model.StorageConfiguration> {
@@ -633,13 +781,21 @@ export class StorageService {
     }
 
     /**
-     * Get all storage configurations.
+     * Get storage configuration.
      *
-     * Gets a list of all Databricks storage configurations for your account,
-     * specified by ID.
+     * Gets a Databricks storage configuration for an account, both specified by
+     * ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetStorageRequest,
+        @context context?: Context
+    ): Promise<model.StorageConfiguration> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         @context context?: Context
     ): Promise<Array<model.StorageConfiguration>> {
         const path = `/api/2.0/accounts/${this.client.accountId}/storage-configurations`;
@@ -649,6 +805,19 @@ export class StorageService {
             undefined,
             context
         )) as Array<model.StorageConfiguration>;
+    }
+
+    /**
+     * Get all storage configurations.
+     *
+     * Gets a list of all Databricks storage configurations for your account,
+     * specified by ID.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        @context context?: Context
+    ): Promise<Array<model.StorageConfiguration>> {
+        return await this._list(context);
     }
 }
 
@@ -677,6 +846,21 @@ export class VpcEndpointsError extends ApiError {
  */
 export class VpcEndpointsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateVpcEndpointRequest,
+        @context context?: Context
+    ): Promise<model.VpcEndpoint> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.VpcEndpoint;
+    }
+
     /**
      * Create VPC endpoint configuration.
      *
@@ -700,13 +884,21 @@ export class VpcEndpointsService {
         request: model.CreateVpcEndpointRequest,
         @context context?: Context
     ): Promise<model.VpcEndpoint> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteVpcEndpointRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints/${request.vpc_endpoint_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.VpcEndpoint;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -732,13 +924,21 @@ export class VpcEndpointsService {
         request: model.DeleteVpcEndpointRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetVpcEndpointRequest,
+        @context context?: Context
+    ): Promise<model.VpcEndpoint> {
         const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints/${request.vpc_endpoint_id}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.VpcEndpoint;
     }
 
     /**
@@ -756,13 +956,20 @@ export class VpcEndpointsService {
         request: model.GetVpcEndpointRequest,
         @context context?: Context
     ): Promise<model.VpcEndpoint> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints/${request.vpc_endpoint_id}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.VpcEndpoint>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints`;
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.VpcEndpoint;
+        )) as Array<model.VpcEndpoint>;
     }
 
     /**
@@ -777,13 +984,7 @@ export class VpcEndpointsService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<Array<model.VpcEndpoint>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/vpc-endpoints`;
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as Array<model.VpcEndpoint>;
+        return await this._list(context);
     }
 }
 
@@ -810,6 +1011,21 @@ export class WorkspacesError extends ApiError {
  */
 export class WorkspacesService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateWorkspaceRequest,
+        @context context?: Context
+    ): Promise<model.Workspace> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Workspace;
+    }
+
     /**
      * Create a new workspace.
      *
@@ -825,85 +1041,80 @@ export class WorkspacesService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async create(
-        request: model.CreateWorkspaceRequest,
-        @context context?: Context
-    ): Promise<model.Workspace> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces`;
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.Workspace;
-    }
-
-    /**
-     * create and wait to reach RUNNING state
-     *  or fail on reaching BANNED or FAILED state
-     */
-    @withLogContext(ExposedLoggers.SDK)
-    async createAndWait(
         createWorkspaceRequest: model.CreateWorkspaceRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (newPollResponse: model.Workspace) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.Workspace> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.Workspace, model.Workspace>> {
         const cancellationToken = context?.cancellationToken;
 
-        const workspace = await this.create(createWorkspaceRequest, context);
+        const workspace = await this._create(createWorkspaceRequest, context);
 
-        return await retry<model.Workspace>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        workspace_id: workspace.workspace_id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "Workspaces.createAndWait: cancelled"
+        return asWaiter(workspace, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.Workspace>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            workspace_id: workspace.workspace_id!,
+                        },
+                        context
                     );
-                    throw new WorkspacesError("createAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.workspace_status;
-                const statusMessage = pollResponse.workspace_status_message;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "BANNED":
-                    case "FAILED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Workspaces.createAndWait: ${errorMessage}`
+                            "Workspaces.createAndWait: cancelled"
                         );
-                        throw new WorkspacesError(
-                            "createAndWait",
-                            errorMessage
-                        );
+                        throw new WorkspacesError("createAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Workspaces.createAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WorkspacesRetriableError(
-                            "createAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.workspace_status;
+                    const statusMessage = pollResponse.workspace_status_message;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "BANNED":
+                        case "FAILED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Workspaces.createAndWait: ${errorMessage}`
+                            );
+                            throw new WorkspacesError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Workspaces.createAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WorkspacesRetriableError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteWorkspaceRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}`;
+        return (await this.client.request(
+            path,
+            "DELETE",
+            request,
+            context
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -923,13 +1134,21 @@ export class WorkspacesService {
         request: model.DeleteWorkspaceRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetWorkspaceRequest,
+        @context context?: Context
+    ): Promise<model.Workspace> {
         const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.Workspace;
     }
 
     /**
@@ -956,13 +1175,20 @@ export class WorkspacesService {
         request: model.GetWorkspaceRequest,
         @context context?: Context
     ): Promise<model.Workspace> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.Workspace>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces`;
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.Workspace;
+        )) as Array<model.Workspace>;
     }
 
     /**
@@ -976,13 +1202,21 @@ export class WorkspacesService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<Array<model.Workspace>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces`;
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateWorkspaceRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PATCH",
+            request,
             context
-        )) as Array<model.Workspace>;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1106,84 +1340,65 @@ export class WorkspacesService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async update(
-        request: model.UpdateWorkspaceRequest,
-        @context context?: Context
-    ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
-    }
-
-    /**
-     * update and wait to reach RUNNING state
-     *  or fail on reaching BANNED or FAILED state
-     */
-    @withLogContext(ExposedLoggers.SDK)
-    async updateAndWait(
         updateWorkspaceRequest: model.UpdateWorkspaceRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (newPollResponse: model.Workspace) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.Workspace> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.EmptyResponse, model.Workspace>> {
         const cancellationToken = context?.cancellationToken;
 
-        await this.update(updateWorkspaceRequest, context);
+        await this._update(updateWorkspaceRequest, context);
 
-        return await retry<model.Workspace>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        workspace_id: updateWorkspaceRequest.workspace_id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "Workspaces.updateAndWait: cancelled"
+        return asWaiter(null, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.Workspace>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            workspace_id: updateWorkspaceRequest.workspace_id!,
+                        },
+                        context
                     );
-                    throw new WorkspacesError("updateAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.workspace_status;
-                const statusMessage = pollResponse.workspace_status_message;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "BANNED":
-                    case "FAILED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Workspaces.updateAndWait: ${errorMessage}`
+                            "Workspaces.updateAndWait: cancelled"
                         );
-                        throw new WorkspacesError(
-                            "updateAndWait",
-                            errorMessage
-                        );
+                        throw new WorkspacesError("updateAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Workspaces.updateAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WorkspacesRetriableError(
-                            "updateAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.workspace_status;
+                    const statusMessage = pollResponse.workspace_status_message;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "BANNED":
+                        case "FAILED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Workspaces.updateAndWait: ${errorMessage}`
+                            );
+                            throw new WorkspacesError(
+                                "updateAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Workspaces.updateAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WorkspacesRetriableError(
+                                "updateAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 }

--- a/packages/databricks-sdk-js/src/apis/endpoints/api.ts
+++ b/packages/databricks-sdk-js/src/apis/endpoints/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class ServingEndpointsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -39,14 +40,9 @@ export class ServingEndpointsError extends ApiError {
  */
 export class ServingEndpointsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Retrieve the logs associated with building the model's environment for a
-     * given serving endpoint's served model.
-     *
-     * Retrieves the build logs associated with the provided served model.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async buildLogs(
+    private async _buildLogs(
         request: model.BuildLogsRequest,
         @context context?: Context
     ): Promise<model.BuildLogsResponse> {
@@ -60,10 +56,21 @@ export class ServingEndpointsService {
     }
 
     /**
-     * Create a new serving endpoint.
+     * Retrieve the logs associated with building the model's environment for a
+     * given serving endpoint's served model.
+     *
+     * Retrieves the build logs associated with the provided served model.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    async buildLogs(
+        request: model.BuildLogsRequest,
+        @context context?: Context
+    ): Promise<model.BuildLogsResponse> {
+        return await this._buildLogs(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
         request: model.CreateServingEndpoint,
         @context context?: Context
     ): Promise<model.ServingEndpointDetailed> {
@@ -77,79 +84,91 @@ export class ServingEndpointsService {
     }
 
     /**
-     * create and wait to reach NOT_UPDATING state
-     *  or fail on reaching UPDATE_FAILED state
+     * Create a new serving endpoint.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async createAndWait(
+    async create(
         createServingEndpoint: model.CreateServingEndpoint,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.ServingEndpointDetailed
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.ServingEndpointDetailed> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<
+        Waiter<model.ServingEndpointDetailed, model.ServingEndpointDetailed>
+    > {
         const cancellationToken = context?.cancellationToken;
 
-        const servingEndpointDetailed = await this.create(
+        const servingEndpointDetailed = await this._create(
             createServingEndpoint,
             context
         );
 
-        return await retry<model.ServingEndpointDetailed>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        name: servingEndpointDetailed.name!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "ServingEndpoints.createAndWait: cancelled"
+        return asWaiter(servingEndpointDetailed, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.ServingEndpointDetailed>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            name: servingEndpointDetailed.name!,
+                        },
+                        context
                     );
-                    throw new ServingEndpointsError(
-                        "createAndWait",
-                        "cancelled"
-                    );
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state!.config_update;
-                const statusMessage = pollResponse;
-                switch (status) {
-                    case "NOT_UPDATING": {
-                        return pollResponse;
-                    }
-                    case "UPDATE_FAILED": {
-                        const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `ServingEndpoints.createAndWait: ${errorMessage}`
+                            "ServingEndpoints.createAndWait: cancelled"
                         );
                         throw new ServingEndpointsError(
                             "createAndWait",
-                            errorMessage
+                            "cancelled"
                         );
                     }
-                    default: {
-                        const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `ServingEndpoints.createAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new ServingEndpointsRetriableError(
-                            "createAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state!.config_update;
+                    const statusMessage = pollResponse;
+                    switch (status) {
+                        case "NOT_UPDATING": {
+                            return pollResponse;
+                        }
+                        case "UPDATE_FAILED": {
+                            const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `ServingEndpoints.createAndWait: ${errorMessage}`
+                            );
+                            throw new ServingEndpointsError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `ServingEndpoints.createAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new ServingEndpointsRetriableError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteServingEndpointRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/serving-endpoints/${request.name}`;
+        return (await this.client.request(
+            path,
+            "DELETE",
+            request,
+            context
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -160,10 +179,18 @@ export class ServingEndpointsService {
         request: model.DeleteServingEndpointRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/serving-endpoints/${request.name}`;
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _exportMetrics(
+        request: model.ExportMetricsRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/serving-endpoints/${request.name}/metrics`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
         )) as model.EmptyResponse;
@@ -181,22 +208,11 @@ export class ServingEndpointsService {
         request: model.ExportMetricsRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/serving-endpoints/${request.name}/metrics`;
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._exportMetrics(request, context);
     }
 
-    /**
-     * Get a single serving endpoint.
-     *
-     * Retrieves the details for a single serving endpoint.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetServingEndpointRequest,
         @context context?: Context
     ): Promise<model.ServingEndpointDetailed> {
@@ -210,10 +226,20 @@ export class ServingEndpointsService {
     }
 
     /**
-     * Retrieve all serving endpoints.
+     * Get a single serving endpoint.
+     *
+     * Retrieves the details for a single serving endpoint.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetServingEndpointRequest,
+        @context context?: Context
+    ): Promise<model.ServingEndpointDetailed> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         @context context?: Context
     ): Promise<model.ListEndpointsResponse> {
         const path = "/api/2.0/serving-endpoints";
@@ -226,13 +252,17 @@ export class ServingEndpointsService {
     }
 
     /**
-     * Retrieve the most recent log lines associated with a given serving
-     * endpoint's served model.
-     *
-     * Retrieves the service logs associated with the provided served model.
+     * Retrieve all serving endpoints.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async logs(
+    async list(
+        @context context?: Context
+    ): Promise<model.ListEndpointsResponse> {
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _logs(
         request: model.LogsRequest,
         @context context?: Context
     ): Promise<model.ServerLogsResponse> {
@@ -246,10 +276,21 @@ export class ServingEndpointsService {
     }
 
     /**
-     * Query a serving endpoint with provided model input.
+     * Retrieve the most recent log lines associated with a given serving
+     * endpoint's served model.
+     *
+     * Retrieves the service logs associated with the provided served model.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async query(
+    async logs(
+        request: model.LogsRequest,
+        @context context?: Context
+    ): Promise<model.ServerLogsResponse> {
+        return await this._logs(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _query(
         request: model.QueryRequest,
         @context context?: Context
     ): Promise<model.QueryEndpointResponse> {
@@ -263,15 +304,18 @@ export class ServingEndpointsService {
     }
 
     /**
-     * Update a serving endpoint with a new config.
-     *
-     * Updates any combination of the serving endpoint's served models, the
-     * compute configuration of those served models, and the endpoint's traffic
-     * config. An endpoint that already has an update in progress can not be
-     * updated until the current update completes or fails.
+     * Query a serving endpoint with provided model input.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async updateConfig(
+    async query(
+        request: model.QueryRequest,
+        @context context?: Context
+    ): Promise<model.QueryEndpointResponse> {
+        return await this._query(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _updateConfig(
         request: model.EndpointCoreConfigInput,
         @context context?: Context
     ): Promise<model.ServingEndpointDetailed> {
@@ -285,78 +329,81 @@ export class ServingEndpointsService {
     }
 
     /**
-     * updateConfig and wait to reach NOT_UPDATING state
-     *  or fail on reaching UPDATE_FAILED state
+     * Update a serving endpoint with a new config.
+     *
+     * Updates any combination of the serving endpoint's served models, the
+     * compute configuration of those served models, and the endpoint's traffic
+     * config. An endpoint that already has an update in progress can not be
+     * updated until the current update completes or fails.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async updateConfigAndWait(
+    async updateConfig(
         endpointCoreConfigInput: model.EndpointCoreConfigInput,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.ServingEndpointDetailed
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.ServingEndpointDetailed> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<
+        Waiter<model.ServingEndpointDetailed, model.ServingEndpointDetailed>
+    > {
         const cancellationToken = context?.cancellationToken;
 
-        const servingEndpointDetailed = await this.updateConfig(
+        const servingEndpointDetailed = await this._updateConfig(
             endpointCoreConfigInput,
             context
         );
 
-        return await retry<model.ServingEndpointDetailed>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        name: servingEndpointDetailed.name!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "ServingEndpoints.updateConfigAndWait: cancelled"
+        return asWaiter(servingEndpointDetailed, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.ServingEndpointDetailed>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            name: servingEndpointDetailed.name!,
+                        },
+                        context
                     );
-                    throw new ServingEndpointsError(
-                        "updateConfigAndWait",
-                        "cancelled"
-                    );
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state!.config_update;
-                const statusMessage = pollResponse;
-                switch (status) {
-                    case "NOT_UPDATING": {
-                        return pollResponse;
-                    }
-                    case "UPDATE_FAILED": {
-                        const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `ServingEndpoints.updateConfigAndWait: ${errorMessage}`
+                            "ServingEndpoints.updateConfigAndWait: cancelled"
                         );
                         throw new ServingEndpointsError(
                             "updateConfigAndWait",
-                            errorMessage
+                            "cancelled"
                         );
                     }
-                    default: {
-                        const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `ServingEndpoints.updateConfigAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new ServingEndpointsRetriableError(
-                            "updateConfigAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state!.config_update;
+                    const statusMessage = pollResponse;
+                    switch (status) {
+                        case "NOT_UPDATING": {
+                            return pollResponse;
+                        }
+                        case "UPDATE_FAILED": {
+                            const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `ServingEndpoints.updateConfigAndWait: ${errorMessage}`
+                            );
+                            throw new ServingEndpointsError(
+                                "updateConfigAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach NOT_UPDATING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `ServingEndpoints.updateConfigAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new ServingEndpointsRetriableError(
+                                "updateConfigAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 }

--- a/packages/databricks-sdk-js/src/apis/gitcredentials/api.ts
+++ b/packages/databricks-sdk-js/src/apis/gitcredentials/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class GitCredentialsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -32,16 +33,9 @@ export class GitCredentialsError extends ApiError {
  */
 export class GitCredentialsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a credential entry.
-     *
-     * Creates a Git credential entry for the user. Only one Git credential per
-     * user is supported, so any attempts to create credentials if an entry
-     * already exists will fail. Use the PATCH endpoint to update existing
-     * credentials, or the DELETE endpoint to delete existing credentials.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateCredentials,
         @context context?: Context
     ): Promise<model.CreateCredentialsResponse> {
@@ -55,12 +49,23 @@ export class GitCredentialsService {
     }
 
     /**
-     * Delete a credential.
+     * Create a credential entry.
      *
-     * Deletes the specified Git credential.
+     * Creates a Git credential entry for the user. Only one Git credential per
+     * user is supported, so any attempts to create credentials if an entry
+     * already exists will fail. Use the PATCH endpoint to update existing
+     * credentials, or the DELETE endpoint to delete existing credentials.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateCredentials,
+        @context context?: Context
+    ): Promise<model.CreateCredentialsResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -74,12 +79,20 @@ export class GitCredentialsService {
     }
 
     /**
-     * Get a credential entry.
+     * Delete a credential.
      *
-     * Gets the Git credential with the specified credential ID.
+     * Deletes the specified Git credential.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.CredentialInfo> {
@@ -93,13 +106,20 @@ export class GitCredentialsService {
     }
 
     /**
-     * Get Git credentials.
+     * Get a credential entry.
      *
-     * Lists the calling user's Git credentials. One credential per user is
-     * supported.
+     * Gets the Git credential with the specified credential ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.CredentialInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         @context context?: Context
     ): Promise<model.GetCredentialsResponse> {
         const path = "/api/2.0/git-credentials";
@@ -112,12 +132,20 @@ export class GitCredentialsService {
     }
 
     /**
-     * Update a credential.
+     * Get Git credentials.
      *
-     * Updates the specified Git credential.
+     * Lists the calling user's Git credentials. One credential per user is
+     * supported.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async list(
+        @context context?: Context
+    ): Promise<model.GetCredentialsResponse> {
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateCredentials,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -128,5 +156,18 @@ export class GitCredentialsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Update a credential.
+     *
+     * Updates the specified Git credential.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateCredentials,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/globalinitscripts/api.ts
+++ b/packages/databricks-sdk-js/src/apis/globalinitscripts/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class GlobalInitScriptsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -35,13 +36,9 @@ export class GlobalInitScriptsError extends ApiError {
  */
 export class GlobalInitScriptsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create init script.
-     *
-     * Creates a new global init script in this workspace.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.GlobalInitScriptCreateRequest,
         @context context?: Context
     ): Promise<model.CreateResponse> {
@@ -55,12 +52,20 @@ export class GlobalInitScriptsService {
     }
 
     /**
-     * Delete init script.
+     * Create init script.
      *
-     * Deletes a global init script.
+     * Creates a new global init script in this workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.GlobalInitScriptCreateRequest,
+        @context context?: Context
+    ): Promise<model.CreateResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -74,12 +79,20 @@ export class GlobalInitScriptsService {
     }
 
     /**
-     * Get an init script.
+     * Delete init script.
      *
-     * Gets all the details of a script, including its Base64-encoded contents.
+     * Deletes a global init script.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.GlobalInitScriptDetailsWithContent> {
@@ -90,6 +103,32 @@ export class GlobalInitScriptsService {
             request,
             context
         )) as model.GlobalInitScriptDetailsWithContent;
+    }
+
+    /**
+     * Get an init script.
+     *
+     * Gets all the details of a script, including its Base64-encoded contents.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.GlobalInitScriptDetailsWithContent> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListGlobalInitScriptsResponse> {
+        const path = "/api/2.0/global-init-scripts";
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as model.ListGlobalInitScriptsResponse;
     }
 
     /**
@@ -104,13 +143,21 @@ export class GlobalInitScriptsService {
     async list(
         @context context?: Context
     ): Promise<model.ListGlobalInitScriptsResponse> {
-        const path = "/api/2.0/global-init-scripts";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.GlobalInitScriptUpdateRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/global-init-scripts/${request.script_id}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PATCH",
+            request,
             context
-        )) as model.ListGlobalInitScriptsResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -124,12 +171,6 @@ export class GlobalInitScriptsService {
         request: model.GlobalInitScriptUpdateRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/global-init-scripts/${request.script_id}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/instancepools/api.ts
+++ b/packages/databricks-sdk-js/src/apis/instancepools/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class InstancePoolsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -44,13 +45,9 @@ export class InstancePoolsError extends ApiError {
  */
 export class InstancePoolsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new instance pool.
-     *
-     * Creates a new instance pool using idle and ready-to-use cloud instances.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateInstancePool,
         @context context?: Context
     ): Promise<model.CreateInstancePoolResponse> {
@@ -64,6 +61,33 @@ export class InstancePoolsService {
     }
 
     /**
+     * Create a new instance pool.
+     *
+     * Creates a new instance pool using idle and ready-to-use cloud instances.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async create(
+        request: model.CreateInstancePool,
+        @context context?: Context
+    ): Promise<model.CreateInstancePoolResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteInstancePool,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/instance-pools/delete";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Delete an instance pool.
      *
      * Deletes the instance pool permanently. The idle instances in the pool are
@@ -74,7 +98,15 @@ export class InstancePoolsService {
         request: model.DeleteInstancePool,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/instance-pools/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _edit(
+        request: model.EditInstancePool,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/instance-pools/edit";
         return (await this.client.request(
             path,
             "POST",
@@ -93,22 +125,11 @@ export class InstancePoolsService {
         request: model.EditInstancePool,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/instance-pools/edit";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._edit(request, context);
     }
 
-    /**
-     * Get instance pool information.
-     *
-     * Retrieve the information for an instance pool based on its identifier.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.GetInstancePool> {
@@ -122,12 +143,22 @@ export class InstancePoolsService {
     }
 
     /**
-     * List instance pool info.
+     * Get instance pool information.
      *
-     * Gets a list of instance pools with their statistics.
+     * Retrieve the information for an instance pool based on its identifier.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(@context context?: Context): Promise<model.ListInstancePools> {
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.GetInstancePool> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListInstancePools> {
         const path = "/api/2.0/instance-pools/list";
         return (await this.client.request(
             path,
@@ -135,5 +166,15 @@ export class InstancePoolsService {
             undefined,
             context
         )) as model.ListInstancePools;
+    }
+
+    /**
+     * List instance pool info.
+     *
+     * Gets a list of instance pools with their statistics.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(@context context?: Context): Promise<model.ListInstancePools> {
+        return await this._list(context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/ipaccesslists/api.ts
+++ b/packages/databricks-sdk-js/src/apis/ipaccesslists/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class IpAccessListsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -47,6 +48,21 @@ export class IpAccessListsError extends ApiError {
  */
 export class IpAccessListsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateIpAccessList,
+        @context context?: Context
+    ): Promise<model.CreateIpAccessListResponse> {
+        const path = "/api/2.0/ip-access-lists";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CreateIpAccessListResponse;
+    }
+
     /**
      * Create access list.
      *
@@ -73,22 +89,11 @@ export class IpAccessListsService {
         request: model.CreateIpAccessList,
         @context context?: Context
     ): Promise<model.CreateIpAccessListResponse> {
-        const path = "/api/2.0/ip-access-lists";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.CreateIpAccessListResponse;
+        return await this._create(request, context);
     }
 
-    /**
-     * Delete access list.
-     *
-     * Deletes an IP access list, specified by its list ID.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    private async _delete(
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -102,12 +107,20 @@ export class IpAccessListsService {
     }
 
     /**
-     * Get access list.
+     * Delete access list.
      *
-     * Gets an IP access list, specified by its list ID.
+     * Deletes an IP access list, specified by its list ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.FetchIpAccessListResponse> {
@@ -121,12 +134,20 @@ export class IpAccessListsService {
     }
 
     /**
-     * Get access lists.
+     * Get access list.
      *
-     * Gets all IP access lists for the specified workspace.
+     * Gets an IP access list, specified by its list ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.FetchIpAccessListResponse> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         @context context?: Context
     ): Promise<model.GetIpAccessListResponse> {
         const path = "/api/2.0/ip-access-lists";
@@ -136,6 +157,32 @@ export class IpAccessListsService {
             undefined,
             context
         )) as model.GetIpAccessListResponse;
+    }
+
+    /**
+     * Get access lists.
+     *
+     * Gets all IP access lists for the specified workspace.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        @context context?: Context
+    ): Promise<model.GetIpAccessListResponse> {
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _replace(
+        request: model.ReplaceIpAccessList,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/ip-access-lists/${request.ip_access_list_id}`;
+        return (await this.client.request(
+            path,
+            "PUT",
+            request,
+            context
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -160,10 +207,18 @@ export class IpAccessListsService {
         request: model.ReplaceIpAccessList,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._replace(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateIpAccessList,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/ip-access-lists/${request.ip_access_list_id}`;
         return (await this.client.request(
             path,
-            "PUT",
+            "PATCH",
             request,
             context
         )) as model.EmptyResponse;
@@ -195,12 +250,6 @@ export class IpAccessListsService {
         request: model.UpdateIpAccessList,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/ip-access-lists/${request.ip_access_list_id}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/libraries/api.ts
+++ b/packages/databricks-sdk-js/src/apis/libraries/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class LibrariesRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -46,6 +47,20 @@ export class LibrariesError extends ApiError {
  */
 export class LibrariesService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _allClusterStatuses(
+        @context context?: Context
+    ): Promise<model.ListAllClusterLibraryStatusesResponse> {
+        const path = "/api/2.0/libraries/all-cluster-statuses";
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as model.ListAllClusterLibraryStatusesResponse;
+    }
+
     /**
      * Get all statuses.
      *
@@ -58,13 +73,21 @@ export class LibrariesService {
     async allClusterStatuses(
         @context context?: Context
     ): Promise<model.ListAllClusterLibraryStatusesResponse> {
-        const path = "/api/2.0/libraries/all-cluster-statuses";
+        return await this._allClusterStatuses(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _clusterStatus(
+        request: model.ClusterStatus,
+        @context context?: Context
+    ): Promise<model.ClusterLibraryStatuses> {
+        const path = "/api/2.0/libraries/cluster-status";
         return (await this.client.request(
             path,
             "GET",
-            undefined,
+            request,
             context
-        )) as model.ListAllClusterLibraryStatusesResponse;
+        )) as model.ClusterLibraryStatuses;
     }
 
     /**
@@ -91,13 +114,21 @@ export class LibrariesService {
         request: model.ClusterStatus,
         @context context?: Context
     ): Promise<model.ClusterLibraryStatuses> {
-        const path = "/api/2.0/libraries/cluster-status";
+        return await this._clusterStatus(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _install(
+        request: model.InstallLibraries,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/libraries/install";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ClusterLibraryStatuses;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -116,7 +147,15 @@ export class LibrariesService {
         request: model.InstallLibraries,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/libraries/install";
+        return await this._install(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _uninstall(
+        request: model.UninstallLibraries,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/libraries/uninstall";
         return (await this.client.request(
             path,
             "POST",
@@ -137,12 +176,6 @@ export class LibrariesService {
         request: model.UninstallLibraries,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/libraries/uninstall";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._uninstall(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/mlflow/api.ts
+++ b/packages/databricks-sdk-js/src/apis/mlflow/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class ExperimentsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -27,6 +28,21 @@ export class ExperimentsError extends ApiError {
 */
 export class ExperimentsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateExperiment,
+        @context context?: Context
+    ): Promise<model.CreateExperimentResponse> {
+        const path = "/api/2.0/mlflow/experiments/create";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CreateExperimentResponse;
+    }
+
     /**
      * Create experiment.
      *
@@ -43,13 +59,21 @@ export class ExperimentsService {
         request: model.CreateExperiment,
         @context context?: Context
     ): Promise<model.CreateExperimentResponse> {
-        const path = "/api/2.0/mlflow/experiments/create";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteExperiment,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/experiments/delete";
         return (await this.client.request(
             path,
             "POST",
             request,
             context
-        )) as model.CreateExperimentResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -64,13 +88,21 @@ export class ExperimentsService {
         request: model.DeleteExperiment,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/experiments/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetExperimentRequest,
+        @context context?: Context
+    ): Promise<model.Experiment> {
+        const path = "/api/2.0/mlflow/experiments/get";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.Experiment;
     }
 
     /**
@@ -83,13 +115,21 @@ export class ExperimentsService {
         request: model.GetExperimentRequest,
         @context context?: Context
     ): Promise<model.Experiment> {
-        const path = "/api/2.0/mlflow/experiments/get";
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getByName(
+        request: model.GetByNameRequest,
+        @context context?: Context
+    ): Promise<model.GetExperimentByNameResponse> {
+        const path = "/api/2.0/mlflow/experiments/get-by-name";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.Experiment;
+        )) as model.GetExperimentByNameResponse;
     }
 
     /**
@@ -110,13 +150,21 @@ export class ExperimentsService {
         request: model.GetByNameRequest,
         @context context?: Context
     ): Promise<model.GetExperimentByNameResponse> {
-        const path = "/api/2.0/mlflow/experiments/get-by-name";
+        return await this._getByName(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListExperimentsRequest,
+        @context context?: Context
+    ): Promise<model.ListExperimentsResponse> {
+        const path = "/api/2.0/mlflow/experiments/list";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.GetExperimentByNameResponse;
+        )) as model.ListExperimentsResponse;
     }
 
     /**
@@ -129,13 +177,21 @@ export class ExperimentsService {
         request: model.ListExperimentsRequest,
         @context context?: Context
     ): Promise<model.ListExperimentsResponse> {
-        const path = "/api/2.0/mlflow/experiments/list";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _restore(
+        request: model.RestoreExperiment,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/experiments/restore";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListExperimentsResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -153,22 +209,11 @@ export class ExperimentsService {
         request: model.RestoreExperiment,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/experiments/restore";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._restore(request, context);
     }
 
-    /**
-     * Search experiments.
-     *
-     * Searches for experiments that satisfy specified search criteria.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async search(
+    private async _search(
         request: model.SearchExperiments,
         @context context?: Context
     ): Promise<model.SearchExperimentsResponse> {
@@ -182,6 +227,33 @@ export class ExperimentsService {
     }
 
     /**
+     * Search experiments.
+     *
+     * Searches for experiments that satisfy specified search criteria.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async search(
+        request: model.SearchExperiments,
+        @context context?: Context
+    ): Promise<model.SearchExperimentsResponse> {
+        return await this._search(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _setExperimentTag(
+        request: model.SetExperimentTag,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/experiments/set-experiment-tag";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Set a tag.
      *
      * Sets a tag on an experiment. Experiment tags are metadata that can be
@@ -192,7 +264,15 @@ export class ExperimentsService {
         request: model.SetExperimentTag,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/experiments/set-experiment-tag";
+        return await this._setExperimentTag(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateExperiment,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/experiments/update";
         return (await this.client.request(
             path,
             "POST",
@@ -211,13 +291,7 @@ export class ExperimentsService {
         request: model.UpdateExperiment,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/experiments/update";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -237,6 +311,21 @@ export class MLflowArtifactsError extends ApiError {
 */
 export class MLflowArtifactsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListArtifactsRequest,
+        @context context?: Context
+    ): Promise<model.ListArtifactsResponse> {
+        const path = "/api/2.0/mlflow/artifacts/list";
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.ListArtifactsResponse;
+    }
+
     /**
      * Get all artifacts.
      *
@@ -249,13 +338,7 @@ export class MLflowArtifactsService {
         request: model.ListArtifactsRequest,
         @context context?: Context
     ): Promise<model.ListArtifactsResponse> {
-        const path = "/api/2.0/mlflow/artifacts/list";
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.ListArtifactsResponse;
+        return await this._list(request, context);
     }
 }
 
@@ -276,6 +359,21 @@ export class MLflowDatabricksError extends ApiError {
  */
 export class MLflowDatabricksService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetMLflowDatabrickRequest,
+        @context context?: Context
+    ): Promise<model.GetResponse> {
+        const path = "/api/2.0/mlflow/databricks/registered-models/get";
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.GetResponse;
+    }
+
     /**
      * Get model.
      *
@@ -290,13 +388,22 @@ export class MLflowDatabricksService {
         request: model.GetMLflowDatabrickRequest,
         @context context?: Context
     ): Promise<model.GetResponse> {
-        const path = "/api/2.0/mlflow/databricks/registered-models/get";
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _transitionStage(
+        request: model.TransitionModelVersionStageDatabricks,
+        @context context?: Context
+    ): Promise<model.TransitionStageResponse> {
+        const path =
+            "/api/2.0/mlflow/databricks/model-versions/transition-stage";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.GetResponse;
+        )) as model.TransitionStageResponse;
     }
 
     /**
@@ -313,14 +420,7 @@ export class MLflowDatabricksService {
         request: model.TransitionModelVersionStageDatabricks,
         @context context?: Context
     ): Promise<model.TransitionStageResponse> {
-        const path =
-            "/api/2.0/mlflow/databricks/model-versions/transition-stage";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.TransitionStageResponse;
+        return await this._transitionStage(request, context);
     }
 }
 
@@ -340,13 +440,9 @@ export class MLflowMetricsError extends ApiError {
 */
 export class MLflowMetricsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get history of a given metric within a run.
-     *
-     * Gets a list of all values for the specified metric for a given run.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async getHistory(
+    private async _getHistory(
         request: model.GetHistoryRequest,
         @context context?: Context
     ): Promise<model.GetMetricHistoryResponse> {
@@ -357,6 +453,19 @@ export class MLflowMetricsService {
             request,
             context
         )) as model.GetMetricHistoryResponse;
+    }
+
+    /**
+     * Get history of a given metric within a run.
+     *
+     * Gets a list of all values for the specified metric for a given run.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async getHistory(
+        request: model.GetHistoryRequest,
+        @context context?: Context
+    ): Promise<model.GetMetricHistoryResponse> {
+        return await this._getHistory(request, context);
     }
 }
 
@@ -376,16 +485,9 @@ export class MLflowRunsError extends ApiError {
 */
 export class MLflowRunsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a run.
-     *
-     * Creates a new run within an experiment. A run is usually a single
-     * execution of a machine learning or data ETL pipeline. MLflow uses runs to
-     * track the `mlflowParam`, `mlflowMetric` and `mlflowRunTag` associated with
-     * a single execution.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateRun,
         @context context?: Context
     ): Promise<model.CreateRunResponse> {
@@ -399,6 +501,36 @@ export class MLflowRunsService {
     }
 
     /**
+     * Create a run.
+     *
+     * Creates a new run within an experiment. A run is usually a single
+     * execution of a machine learning or data ETL pipeline. MLflow uses runs to
+     * track the `mlflowParam`, `mlflowMetric` and `mlflowRunTag` associated with
+     * a single execution.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async create(
+        request: model.CreateRun,
+        @context context?: Context
+    ): Promise<model.CreateRunResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteRun,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/delete";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Delete a run.
      *
      * Marks a run for deletion.
@@ -408,7 +540,15 @@ export class MLflowRunsService {
         request: model.DeleteRun,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteTag(
+        request: model.DeleteTag,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/delete-tag";
         return (await this.client.request(
             path,
             "POST",
@@ -428,13 +568,21 @@ export class MLflowRunsService {
         request: model.DeleteTag,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/delete-tag";
+        return await this._deleteTag(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetRunRequest,
+        @context context?: Context
+    ): Promise<model.GetRunResponse> {
+        const path = "/api/2.0/mlflow/runs/get";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.GetRunResponse;
     }
 
     /**
@@ -452,13 +600,21 @@ export class MLflowRunsService {
         request: model.GetRunRequest,
         @context context?: Context
     ): Promise<model.GetRunResponse> {
-        const path = "/api/2.0/mlflow/runs/get";
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _logBatch(
+        request: model.LogBatch,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/log-batch";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.GetRunResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -509,7 +665,15 @@ export class MLflowRunsService {
         request: model.LogBatch,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/log-batch";
+        return await this._logBatch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _logMetric(
+        request: model.LogMetric,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/log-metric";
         return (await this.client.request(
             path,
             "POST",
@@ -530,7 +694,15 @@ export class MLflowRunsService {
         request: model.LogMetric,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/log-metric";
+        return await this._logMetric(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _logModel(
+        request: model.LogModel,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/log-model";
         return (await this.client.request(
             path,
             "POST",
@@ -550,7 +722,15 @@ export class MLflowRunsService {
         request: model.LogModel,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/log-model";
+        return await this._logModel(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _logParameter(
+        request: model.LogParam,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/log-parameter";
         return (await this.client.request(
             path,
             "POST",
@@ -572,7 +752,15 @@ export class MLflowRunsService {
         request: model.LogParam,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/log-parameter";
+        return await this._logParameter(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _restore(
+        request: model.RestoreRun,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/runs/restore";
         return (await this.client.request(
             path,
             "POST",
@@ -591,13 +779,21 @@ export class MLflowRunsService {
         request: model.RestoreRun,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/runs/restore";
+        return await this._restore(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _search(
+        request: model.SearchRuns,
+        @context context?: Context
+    ): Promise<model.SearchRunsResponse> {
+        const path = "/api/2.0/mlflow/runs/search";
         return (await this.client.request(
             path,
             "POST",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.SearchRunsResponse;
     }
 
     /**
@@ -612,23 +808,11 @@ export class MLflowRunsService {
         request: model.SearchRuns,
         @context context?: Context
     ): Promise<model.SearchRunsResponse> {
-        const path = "/api/2.0/mlflow/runs/search";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.SearchRunsResponse;
+        return await this._search(request, context);
     }
 
-    /**
-     * Set a tag.
-     *
-     * Sets a tag on a run. Tags are run metadata that can be updated during a
-     * run and after a run completes.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async setTag(
+    private async _setTag(
         request: model.SetTag,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -642,12 +826,21 @@ export class MLflowRunsService {
     }
 
     /**
-     * Update a run.
+     * Set a tag.
      *
-     * Updates run metadata.
+     * Sets a tag on a run. Tags are run metadata that can be updated during a
+     * run and after a run completes.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async setTag(
+        request: model.SetTag,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._setTag(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateRun,
         @context context?: Context
     ): Promise<model.UpdateRunResponse> {
@@ -658,6 +851,19 @@ export class MLflowRunsService {
             request,
             context
         )) as model.UpdateRunResponse;
+    }
+
+    /**
+     * Update a run.
+     *
+     * Updates run metadata.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateRun,
+        @context context?: Context
+    ): Promise<model.UpdateRunResponse> {
+        return await this._update(request, context);
     }
 }
 
@@ -677,15 +883,9 @@ export class ModelVersionCommentsError extends ApiError {
 */
 export class ModelVersionCommentsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Post a comment.
-     *
-     * Posts a comment on a model version. A comment can be submitted either by a
-     * user or programmatically to display relevant information about the model.
-     * For example, test results or deployment errors.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateComment,
         @context context?: Context
     ): Promise<model.CreateResponse> {
@@ -699,12 +899,22 @@ export class ModelVersionCommentsService {
     }
 
     /**
-     * Delete a comment.
+     * Post a comment.
      *
-     * Deletes a comment on a model version.
+     * Posts a comment on a model version. A comment can be submitted either by a
+     * user or programmatically to display relevant information about the model.
+     * For example, test results or deployment errors.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateComment,
+        @context context?: Context
+    ): Promise<model.CreateResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteModelVersionCommentRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -718,12 +928,20 @@ export class ModelVersionCommentsService {
     }
 
     /**
-     * Update a comment.
+     * Delete a comment.
      *
-     * Post an edit to a comment on a model version.
+     * Deletes a comment on a model version.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async delete(
+        request: model.DeleteModelVersionCommentRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateComment,
         @context context?: Context
     ): Promise<model.UpdateResponse> {
@@ -734,6 +952,19 @@ export class ModelVersionCommentsService {
             request,
             context
         )) as model.UpdateResponse;
+    }
+
+    /**
+     * Update a comment.
+     *
+     * Post an edit to a comment on a model version.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateComment,
+        @context context?: Context
+    ): Promise<model.UpdateResponse> {
+        return await this._update(request, context);
     }
 }
 
@@ -753,13 +984,9 @@ export class ModelVersionsError extends ApiError {
 */
 export class ModelVersionsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a model version.
-     *
-     * Creates a model version.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateModelVersionRequest,
         @context context?: Context
     ): Promise<model.CreateModelVersionResponse> {
@@ -773,6 +1000,33 @@ export class ModelVersionsService {
     }
 
     /**
+     * Create a model version.
+     *
+     * Creates a model version.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async create(
+        request: model.CreateModelVersionRequest,
+        @context context?: Context
+    ): Promise<model.CreateModelVersionResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteModelVersionRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/model-versions/delete";
+        return (await this.client.request(
+            path,
+            "DELETE",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Delete a model version.
      *
      * Deletes a model version.
@@ -782,7 +1036,15 @@ export class ModelVersionsService {
         request: model.DeleteModelVersionRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/model-versions/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteTag(
+        request: model.DeleteModelVersionTagRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/model-versions/delete-tag";
         return (await this.client.request(
             path,
             "DELETE",
@@ -801,22 +1063,11 @@ export class ModelVersionsService {
         request: model.DeleteModelVersionTagRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/model-versions/delete-tag";
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._deleteTag(request, context);
     }
 
-    /**
-     * Get a model version.
-     *
-     * Get a model version.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetModelVersionRequest,
         @context context?: Context
     ): Promise<model.GetModelVersionResponse> {
@@ -830,12 +1081,20 @@ export class ModelVersionsService {
     }
 
     /**
-     * Get a model version URI.
+     * Get a model version.
      *
-     * Gets a URI to download the model version.
+     * Get a model version.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async getDownloadUri(
+    async get(
+        request: model.GetModelVersionRequest,
+        @context context?: Context
+    ): Promise<model.GetModelVersionResponse> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getDownloadUri(
         request: model.GetModelVersionDownloadUriRequest,
         @context context?: Context
     ): Promise<model.GetModelVersionDownloadUriResponse> {
@@ -849,12 +1108,20 @@ export class ModelVersionsService {
     }
 
     /**
-     * Searches model versions.
+     * Get a model version URI.
      *
-     * Searches for specific model versions based on the supplied __filter__.
+     * Gets a URI to download the model version.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async search(
+    async getDownloadUri(
+        request: model.GetModelVersionDownloadUriRequest,
+        @context context?: Context
+    ): Promise<model.GetModelVersionDownloadUriResponse> {
+        return await this._getDownloadUri(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _search(
         request: model.SearchModelVersionsRequest,
         @context context?: Context
     ): Promise<model.SearchModelVersionsResponse> {
@@ -868,12 +1135,20 @@ export class ModelVersionsService {
     }
 
     /**
-     * Set a version tag.
+     * Searches model versions.
      *
-     * Sets a model version tag.
+     * Searches for specific model versions based on the supplied __filter__.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async setTag(
+    async search(
+        request: model.SearchModelVersionsRequest,
+        @context context?: Context
+    ): Promise<model.SearchModelVersionsResponse> {
+        return await this._search(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _setTag(
         request: model.SetModelVersionTagRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -887,12 +1162,20 @@ export class ModelVersionsService {
     }
 
     /**
-     * Transition a stage.
+     * Set a version tag.
      *
-     * Transition to the next model stage.
+     * Sets a model version tag.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async transitionStage(
+    async setTag(
+        request: model.SetModelVersionTagRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._setTag(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _transitionStage(
         request: model.TransitionModelVersionStage,
         @context context?: Context
     ): Promise<model.TransitionModelVersionStageResponse> {
@@ -906,12 +1189,20 @@ export class ModelVersionsService {
     }
 
     /**
-     * Update model version.
+     * Transition a stage.
      *
-     * Updates the model version.
+     * Transition to the next model stage.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async transitionStage(
+        request: model.TransitionModelVersionStage,
+        @context context?: Context
+    ): Promise<model.TransitionModelVersionStageResponse> {
+        return await this._transitionStage(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateModelVersionRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -922,6 +1213,19 @@ export class ModelVersionsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Update model version.
+     *
+     * Updates the model version.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateModelVersionRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }
 
@@ -941,6 +1245,21 @@ export class RegisteredModelsError extends ApiError {
 */
 export class RegisteredModelsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateRegisteredModelRequest,
+        @context context?: Context
+    ): Promise<model.CreateRegisteredModelResponse> {
+        const path = "/api/2.0/mlflow/registered-models/create";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CreateRegisteredModelResponse;
+    }
+
     /**
      * Create a model.
      *
@@ -955,13 +1274,21 @@ export class RegisteredModelsService {
         request: model.CreateRegisteredModelRequest,
         @context context?: Context
     ): Promise<model.CreateRegisteredModelResponse> {
-        const path = "/api/2.0/mlflow/registered-models/create";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteRegisteredModelRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registered-models/delete";
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.CreateRegisteredModelResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -974,7 +1301,15 @@ export class RegisteredModelsService {
         request: model.DeleteRegisteredModelRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registered-models/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteTag(
+        request: model.DeleteRegisteredModelTagRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registered-models/delete-tag";
         return (await this.client.request(
             path,
             "DELETE",
@@ -993,22 +1328,11 @@ export class RegisteredModelsService {
         request: model.DeleteRegisteredModelTagRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registered-models/delete-tag";
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._deleteTag(request, context);
     }
 
-    /**
-     * Get a model.
-     *
-     * Gets the registered model that matches the specified ID.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetRegisteredModelRequest,
         @context context?: Context
     ): Promise<model.GetRegisteredModelResponse> {
@@ -1022,12 +1346,20 @@ export class RegisteredModelsService {
     }
 
     /**
-     * Get the latest version.
+     * Get a model.
      *
-     * Gets the latest version of a registered model.
+     * Gets the registered model that matches the specified ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async getLatestVersions(
+    async get(
+        request: model.GetRegisteredModelRequest,
+        @context context?: Context
+    ): Promise<model.GetRegisteredModelResponse> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getLatestVersions(
         request: model.GetLatestVersionsRequest,
         @context context?: Context
     ): Promise<model.GetLatestVersionsResponse> {
@@ -1041,13 +1373,20 @@ export class RegisteredModelsService {
     }
 
     /**
-     * List models.
+     * Get the latest version.
      *
-     * Lists all available registered models, up to the limit specified in
-     * __max_results__.
+     * Gets the latest version of a registered model.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async getLatestVersions(
+        request: model.GetLatestVersionsRequest,
+        @context context?: Context
+    ): Promise<model.GetLatestVersionsResponse> {
+        return await this._getLatestVersions(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListRegisteredModelsRequest,
         @context context?: Context
     ): Promise<model.ListRegisteredModelsResponse> {
@@ -1061,12 +1400,21 @@ export class RegisteredModelsService {
     }
 
     /**
-     * Rename a model.
+     * List models.
      *
-     * Renames a registered model.
+     * Lists all available registered models, up to the limit specified in
+     * __max_results__.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async rename(
+    async list(
+        request: model.ListRegisteredModelsRequest,
+        @context context?: Context
+    ): Promise<model.ListRegisteredModelsResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _rename(
         request: model.RenameRegisteredModelRequest,
         @context context?: Context
     ): Promise<model.RenameRegisteredModelResponse> {
@@ -1080,12 +1428,20 @@ export class RegisteredModelsService {
     }
 
     /**
-     * Search models.
+     * Rename a model.
      *
-     * Search for registered models based on the specified __filter__.
+     * Renames a registered model.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async search(
+    async rename(
+        request: model.RenameRegisteredModelRequest,
+        @context context?: Context
+    ): Promise<model.RenameRegisteredModelResponse> {
+        return await this._rename(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _search(
         request: model.SearchRegisteredModelsRequest,
         @context context?: Context
     ): Promise<model.SearchRegisteredModelsResponse> {
@@ -1099,6 +1455,33 @@ export class RegisteredModelsService {
     }
 
     /**
+     * Search models.
+     *
+     * Search for registered models based on the specified __filter__.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async search(
+        request: model.SearchRegisteredModelsRequest,
+        @context context?: Context
+    ): Promise<model.SearchRegisteredModelsResponse> {
+        return await this._search(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _setTag(
+        request: model.SetRegisteredModelTagRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registered-models/set-tag";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Set a tag.
      *
      * Sets a tag on a registered model.
@@ -1108,10 +1491,18 @@ export class RegisteredModelsService {
         request: model.SetRegisteredModelTagRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registered-models/set-tag";
+        return await this._setTag(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateRegisteredModelRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registered-models/update";
         return (await this.client.request(
             path,
-            "POST",
+            "PATCH",
             request,
             context
         )) as model.EmptyResponse;
@@ -1127,13 +1518,7 @@ export class RegisteredModelsService {
         request: model.UpdateRegisteredModelRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registered-models/update";
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -1153,6 +1538,21 @@ export class RegistryWebhooksError extends ApiError {
 */
 export class RegistryWebhooksService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateRegistryWebhook,
+        @context context?: Context
+    ): Promise<model.CreateResponse> {
+        const path = "/api/2.0/mlflow/registry-webhooks/create";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CreateResponse;
+    }
+
     /**
      * Create a webhook.
      *
@@ -1165,13 +1565,21 @@ export class RegistryWebhooksService {
         request: model.CreateRegistryWebhook,
         @context context?: Context
     ): Promise<model.CreateResponse> {
-        const path = "/api/2.0/mlflow/registry-webhooks/create";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteRegistryWebhookRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registry-webhooks/delete";
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.CreateResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1186,13 +1594,21 @@ export class RegistryWebhooksService {
         request: model.DeleteRegistryWebhookRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registry-webhooks/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListRegistryWebhooksRequest,
+        @context context?: Context
+    ): Promise<model.ListRegistryWebhooks> {
+        const path = "/api/2.0/mlflow/registry-webhooks/list";
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.ListRegistryWebhooks;
     }
 
     /**
@@ -1207,13 +1623,21 @@ export class RegistryWebhooksService {
         request: model.ListRegistryWebhooksRequest,
         @context context?: Context
     ): Promise<model.ListRegistryWebhooks> {
-        const path = "/api/2.0/mlflow/registry-webhooks/list";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _test(
+        request: model.TestRegistryWebhookRequest,
+        @context context?: Context
+    ): Promise<model.TestRegistryWebhookResponse> {
+        const path = "/api/2.0/mlflow/registry-webhooks/test";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListRegistryWebhooks;
+        )) as model.TestRegistryWebhookResponse;
     }
 
     /**
@@ -1228,13 +1652,21 @@ export class RegistryWebhooksService {
         request: model.TestRegistryWebhookRequest,
         @context context?: Context
     ): Promise<model.TestRegistryWebhookResponse> {
-        const path = "/api/2.0/mlflow/registry-webhooks/test";
+        return await this._test(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateRegistryWebhook,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/mlflow/registry-webhooks/update";
         return (await this.client.request(
             path,
-            "POST",
+            "PATCH",
             request,
             context
-        )) as model.TestRegistryWebhookResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1249,13 +1681,7 @@ export class RegistryWebhooksService {
         request: model.UpdateRegistryWebhook,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/mlflow/registry-webhooks/update";
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -1275,13 +1701,9 @@ export class TransitionRequestsError extends ApiError {
 */
 export class TransitionRequestsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Approve transition requests.
-     *
-     * Approves a model version stage transition request.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async approve(
+    private async _approve(
         request: model.ApproveTransitionRequest,
         @context context?: Context
     ): Promise<model.ApproveResponse> {
@@ -1295,12 +1717,20 @@ export class TransitionRequestsService {
     }
 
     /**
-     * Make a transition request.
+     * Approve transition requests.
      *
-     * Creates a model version stage transition request.
+     * Approves a model version stage transition request.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    async approve(
+        request: model.ApproveTransitionRequest,
+        @context context?: Context
+    ): Promise<model.ApproveResponse> {
+        return await this._approve(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
         request: model.CreateTransitionRequest,
         @context context?: Context
     ): Promise<model.CreateResponse> {
@@ -1314,12 +1744,20 @@ export class TransitionRequestsService {
     }
 
     /**
-     * Delete a ransition request.
+     * Make a transition request.
      *
-     * Cancels a model version stage transition request.
+     * Creates a model version stage transition request.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateTransitionRequest,
+        @context context?: Context
+    ): Promise<model.CreateResponse> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteTransitionRequestRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1333,12 +1771,20 @@ export class TransitionRequestsService {
     }
 
     /**
-     * List transition requests.
+     * Delete a ransition request.
      *
-     * Gets a list of all open stage transition requests for the model version.
+     * Cancels a model version stage transition request.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async delete(
+        request: model.DeleteTransitionRequestRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListTransitionRequestsRequest,
         @context context?: Context
     ): Promise<model.ListResponse> {
@@ -1352,12 +1798,20 @@ export class TransitionRequestsService {
     }
 
     /**
-     * Reject a transition request.
+     * List transition requests.
      *
-     * Rejects a model version stage transition request.
+     * Gets a list of all open stage transition requests for the model version.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async reject(
+    async list(
+        request: model.ListTransitionRequestsRequest,
+        @context context?: Context
+    ): Promise<model.ListResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _reject(
         request: model.RejectTransitionRequest,
         @context context?: Context
     ): Promise<model.RejectResponse> {
@@ -1368,5 +1822,18 @@ export class TransitionRequestsService {
             request,
             context
         )) as model.RejectResponse;
+    }
+
+    /**
+     * Reject a transition request.
+     *
+     * Rejects a model version stage transition request.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async reject(
+        request: model.RejectTransitionRequest,
+        @context context?: Context
+    ): Promise<model.RejectResponse> {
+        return await this._reject(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/oauth2/api.ts
+++ b/packages/databricks-sdk-js/src/apis/oauth2/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class CustomAppIntegrationRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -33,15 +34,9 @@ export class CustomAppIntegrationError extends ApiError {
  */
 export class CustomAppIntegrationService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create Custom OAuth App Integration.
-     *
-     * Create Custom OAuth App Integration.
-     *
-     * You can retrieve the custom oauth app integration via :method:get.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateCustomAppIntegration,
         @context context?: Context
     ): Promise<model.CreateCustomAppIntegrationOutput> {
@@ -55,13 +50,22 @@ export class CustomAppIntegrationService {
     }
 
     /**
-     * Delete Custom OAuth App Integration.
+     * Create Custom OAuth App Integration.
      *
-     * Delete an existing Custom OAuth App Integration. You can retrieve the
-     * custom oauth app integration via :method:get.
+     * Create Custom OAuth App Integration.
+     *
+     * You can retrieve the custom oauth app integration via :method:get.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateCustomAppIntegration,
+        @context context?: Context
+    ): Promise<model.CreateCustomAppIntegrationOutput> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteCustomAppIntegrationRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -75,12 +79,21 @@ export class CustomAppIntegrationService {
     }
 
     /**
-     * Get OAuth Custom App Integration.
+     * Delete Custom OAuth App Integration.
      *
-     * Gets the Custom OAuth App Integration for the given integration id.
+     * Delete an existing Custom OAuth App Integration. You can retrieve the
+     * custom oauth app integration via :method:get.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteCustomAppIntegrationRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetCustomAppIntegrationRequest,
         @context context?: Context
     ): Promise<model.GetCustomAppIntegrationOutput> {
@@ -94,13 +107,20 @@ export class CustomAppIntegrationService {
     }
 
     /**
-     * Updates Custom OAuth App Integration.
+     * Get OAuth Custom App Integration.
      *
-     * Updates an existing custom OAuth App Integration. You can retrieve the
-     * custom oauth app integration via :method:get.
+     * Gets the Custom OAuth App Integration for the given integration id.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async get(
+        request: model.GetCustomAppIntegrationRequest,
+        @context context?: Context
+    ): Promise<model.GetCustomAppIntegrationOutput> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateCustomAppIntegration,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -111,6 +131,20 @@ export class CustomAppIntegrationService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Updates Custom OAuth App Integration.
+     *
+     * Updates an existing custom OAuth App Integration. You can retrieve the
+     * custom oauth app integration via :method:get.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateCustomAppIntegration,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }
 
@@ -136,15 +170,9 @@ export class PublishedAppIntegrationError extends ApiError {
  */
 export class PublishedAppIntegrationService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create Published OAuth App Integration.
-     *
-     * Create Published OAuth App Integration.
-     *
-     * You can retrieve the published oauth app integration via :method:get.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreatePublishedAppIntegration,
         @context context?: Context
     ): Promise<model.CreatePublishedAppIntegrationOutput> {
@@ -158,13 +186,22 @@ export class PublishedAppIntegrationService {
     }
 
     /**
-     * Delete Published OAuth App Integration.
+     * Create Published OAuth App Integration.
      *
-     * Delete an existing Published OAuth App Integration. You can retrieve the
-     * published oauth app integration via :method:get.
+     * Create Published OAuth App Integration.
+     *
+     * You can retrieve the published oauth app integration via :method:get.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreatePublishedAppIntegration,
+        @context context?: Context
+    ): Promise<model.CreatePublishedAppIntegrationOutput> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeletePublishedAppIntegrationRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -178,12 +215,21 @@ export class PublishedAppIntegrationService {
     }
 
     /**
-     * Get OAuth Published App Integration.
+     * Delete Published OAuth App Integration.
      *
-     * Gets the Published OAuth App Integration for the given integration id.
+     * Delete an existing Published OAuth App Integration. You can retrieve the
+     * published oauth app integration via :method:get.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeletePublishedAppIntegrationRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetPublishedAppIntegrationRequest,
         @context context?: Context
     ): Promise<model.GetPublishedAppIntegrationOutput> {
@@ -197,13 +243,20 @@ export class PublishedAppIntegrationService {
     }
 
     /**
-     * Updates Published OAuth App Integration.
+     * Get OAuth Published App Integration.
      *
-     * Updates an existing published OAuth App Integration. You can retrieve the
-     * published oauth app integration via :method:get.
+     * Gets the Published OAuth App Integration for the given integration id.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async get(
+        request: model.GetPublishedAppIntegrationRequest,
+        @context context?: Context
+    ): Promise<model.GetPublishedAppIntegrationOutput> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdatePublishedAppIntegration,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -214,5 +267,19 @@ export class PublishedAppIntegrationService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Updates Published OAuth App Integration.
+     *
+     * Updates an existing published OAuth App Integration. You can retrieve the
+     * published oauth app integration via :method:get.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdatePublishedAppIntegration,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/permissions/api.ts
+++ b/packages/databricks-sdk-js/src/apis/permissions/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class PermissionsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -28,14 +29,9 @@ export class PermissionsError extends ApiError {
  */
 export class PermissionsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get object permissions.
-     *
-     * Gets the permission of an object. Objects can inherit permissions from
-     * their parent objects or root objects.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.ObjectPermissions> {
@@ -49,12 +45,21 @@ export class PermissionsService {
     }
 
     /**
-     * Get permission levels.
+     * Get object permissions.
      *
-     * Gets the permission levels that a user can have on an object.
+     * Gets the permission of an object. Objects can inherit permissions from
+     * their parent objects or root objects.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async getPermissionLevels(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.ObjectPermissions> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getPermissionLevels(
         request: model.GetPermissionLevels,
         @context context?: Context
     ): Promise<model.GetPermissionLevelsResponse> {
@@ -68,6 +73,33 @@ export class PermissionsService {
     }
 
     /**
+     * Get permission levels.
+     *
+     * Gets the permission levels that a user can have on an object.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async getPermissionLevels(
+        request: model.GetPermissionLevels,
+        @context context?: Context
+    ): Promise<model.GetPermissionLevelsResponse> {
+        return await this._getPermissionLevels(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _set(
+        request: model.PermissionsRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/permissions/${request.request_object_type}/${request.request_object_id}`;
+        return (await this.client.request(
+            path,
+            "PUT",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Set permissions.
      *
      * Sets permissions on object. Objects can inherit permissions from their
@@ -78,10 +110,18 @@ export class PermissionsService {
         request: model.PermissionsRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._set(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.PermissionsRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/permissions/${request.request_object_type}/${request.request_object_id}`;
         return (await this.client.request(
             path,
-            "PUT",
+            "PATCH",
             request,
             context
         )) as model.EmptyResponse;
@@ -97,13 +137,7 @@ export class PermissionsService {
         request: model.PermissionsRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/permissions/${request.request_object_type}/${request.request_object_id}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -124,14 +158,9 @@ export class WorkspaceAssignmentError extends ApiError {
  */
 export class WorkspaceAssignmentService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Delete permissions assignment.
-     *
-     * Deletes the workspace permissions assignment in a given account and
-     * workspace for the specified principal.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    private async _delete(
         request: model.DeleteWorkspaceAssignmentRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -145,13 +174,21 @@ export class WorkspaceAssignmentService {
     }
 
     /**
-     * List workspace permissions.
+     * Delete permissions assignment.
      *
-     * Get an array of workspace permissions for the specified account and
-     * workspace.
+     * Deletes the workspace permissions assignment in a given account and
+     * workspace for the specified principal.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteWorkspaceAssignmentRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetWorkspaceAssignmentRequest,
         @context context?: Context
     ): Promise<model.WorkspacePermissions> {
@@ -165,13 +202,21 @@ export class WorkspaceAssignmentService {
     }
 
     /**
-     * Get permission assignments.
+     * List workspace permissions.
      *
-     * Get the permission assignments for the specified Databricks Account and
-     * Databricks Workspace.
+     * Get an array of workspace permissions for the specified account and
+     * workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetWorkspaceAssignmentRequest,
+        @context context?: Context
+    ): Promise<model.WorkspacePermissions> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListWorkspaceAssignmentRequest,
         @context context?: Context
     ): Promise<model.PermissionAssignments> {
@@ -185,13 +230,21 @@ export class WorkspaceAssignmentService {
     }
 
     /**
-     * Create or update permissions assignment.
+     * Get permission assignments.
      *
-     * Creates or updates the workspace permissions assignment in a given account
-     * and workspace for the specified principal.
+     * Get the permission assignments for the specified Databricks Account and
+     * Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async list(
+        request: model.ListWorkspaceAssignmentRequest,
+        @context context?: Context
+    ): Promise<model.PermissionAssignments> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateWorkspaceAssignments,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -202,5 +255,19 @@ export class WorkspaceAssignmentService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Create or update permissions assignment.
+     *
+     * Creates or updates the workspace permissions assignment in a given account
+     * and workspace for the specified principal.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateWorkspaceAssignments,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/repos/api.ts
+++ b/packages/databricks-sdk-js/src/apis/repos/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class ReposRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -36,15 +37,9 @@ export class ReposError extends ApiError {
  */
 export class ReposService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a repo.
-     *
-     * Creates a repo in the workspace and links it to the remote Git repo
-     * specified. Note that repos created programmatically must be linked to a
-     * remote Git repo, unlike repos created in the browser.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateRepo,
         @context context?: Context
     ): Promise<model.RepoInfo> {
@@ -58,12 +53,22 @@ export class ReposService {
     }
 
     /**
-     * Delete a repo.
+     * Create a repo.
      *
-     * Deletes the specified repo.
+     * Creates a repo in the workspace and links it to the remote Git repo
+     * specified. Note that repos created programmatically must be linked to a
+     * remote Git repo, unlike repos created in the browser.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateRepo,
+        @context context?: Context
+    ): Promise<model.RepoInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -77,12 +82,20 @@ export class ReposService {
     }
 
     /**
-     * Get a repo.
+     * Delete a repo.
      *
-     * Returns the repo with the given repo ID.
+     * Deletes the specified repo.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.RepoInfo> {
@@ -96,13 +109,20 @@ export class ReposService {
     }
 
     /**
-     * Get repos.
+     * Get a repo.
      *
-     * Returns repos that the calling user has Manage permissions on. Results are
-     * paginated with each page containing twenty repos.
+     * Returns the repo with the given repo ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.RepoInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.List,
         @context context?: Context
     ): Promise<model.ListReposResponse> {
@@ -116,13 +136,21 @@ export class ReposService {
     }
 
     /**
-     * Update a repo.
+     * Get repos.
      *
-     * Updates the repo to a different branch or tag, or updates the repo to the
-     * latest commit on the same branch.
+     * Returns repos that the calling user has Manage permissions on. Results are
+     * paginated with each page containing twenty repos.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async list(
+        request: model.List,
+        @context context?: Context
+    ): Promise<model.ListReposResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateRepo,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -133,5 +161,19 @@ export class ReposService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Update a repo.
+     *
+     * Updates the repo to a different branch or tag, or updates the repo to the
+     * latest commit on the same branch.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateRepo,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/scim/api.ts
+++ b/packages/databricks-sdk-js/src/apis/scim/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class AccountGroupsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -33,14 +34,9 @@ export class AccountGroupsError extends ApiError {
  */
 export class AccountGroupsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new group.
-     *
-     * Creates a group in the Databricks Account with a unique name, using the
-     * supplied group details.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.Group,
         @context context?: Context
     ): Promise<model.Group> {
@@ -54,12 +50,21 @@ export class AccountGroupsService {
     }
 
     /**
-     * Delete a group.
+     * Create a new group.
      *
-     * Deletes a group from the Databricks Account.
+     * Creates a group in the Databricks Account with a unique name, using the
+     * supplied group details.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.Group,
+        @context context?: Context
+    ): Promise<model.Group> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteGroupRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -73,12 +78,20 @@ export class AccountGroupsService {
     }
 
     /**
-     * Get group details.
+     * Delete a group.
      *
-     * Gets the information for a specific group in the Databricks Account.
+     * Deletes a group from the Databricks Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteGroupRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetGroupRequest,
         @context context?: Context
     ): Promise<model.Group> {
@@ -92,12 +105,20 @@ export class AccountGroupsService {
     }
 
     /**
-     * List group details.
+     * Get group details.
      *
-     * Gets all details of the groups associated with the Databricks Account.
+     * Gets the information for a specific group in the Databricks Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetGroupRequest,
+        @context context?: Context
+    ): Promise<model.Group> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListGroupsRequest,
         @context context?: Context
     ): Promise<model.ListGroupsResponse> {
@@ -111,6 +132,33 @@ export class AccountGroupsService {
     }
 
     /**
+     * List group details.
+     *
+     * Gets all details of the groups associated with the Databricks Account.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListGroupsRequest,
+        @context context?: Context
+    ): Promise<model.ListGroupsResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Groups/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update group details.
      *
      * Partially updates the details of a group.
@@ -120,10 +168,18 @@ export class AccountGroupsService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.Group,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Groups/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -139,13 +195,7 @@ export class AccountGroupsService {
         request: model.Group,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Groups/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -170,13 +220,9 @@ export class AccountServicePrincipalsError extends ApiError {
  */
 export class AccountServicePrincipalsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a service principal.
-     *
-     * Creates a new service principal in the Databricks Account.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.ServicePrincipal,
         @context context?: Context
     ): Promise<model.ServicePrincipal> {
@@ -190,12 +236,20 @@ export class AccountServicePrincipalsService {
     }
 
     /**
-     * Delete a service principal.
+     * Create a service principal.
      *
-     * Delete a single service principal in the Databricks Account.
+     * Creates a new service principal in the Databricks Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.ServicePrincipal,
+        @context context?: Context
+    ): Promise<model.ServicePrincipal> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteServicePrincipalRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -209,13 +263,20 @@ export class AccountServicePrincipalsService {
     }
 
     /**
-     * Get service principal details.
+     * Delete a service principal.
      *
-     * Gets the details for a single service principal define in the Databricks
-     * Account.
+     * Delete a single service principal in the Databricks Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteServicePrincipalRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetServicePrincipalRequest,
         @context context?: Context
     ): Promise<model.ServicePrincipal> {
@@ -229,12 +290,21 @@ export class AccountServicePrincipalsService {
     }
 
     /**
-     * List service principals.
+     * Get service principal details.
      *
-     * Gets the set of service principals associated with a Databricks Account.
+     * Gets the details for a single service principal define in the Databricks
+     * Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetServicePrincipalRequest,
+        @context context?: Context
+    ): Promise<model.ServicePrincipal> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListServicePrincipalsRequest,
         @context context?: Context
     ): Promise<model.ListServicePrincipalResponse> {
@@ -248,6 +318,33 @@ export class AccountServicePrincipalsService {
     }
 
     /**
+     * List service principals.
+     *
+     * Gets the set of service principals associated with a Databricks Account.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListServicePrincipalsRequest,
+        @context context?: Context
+    ): Promise<model.ListServicePrincipalResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/ServicePrincipals/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update service principal details.
      *
      * Partially updates the details of a single service principal in the
@@ -258,10 +355,18 @@ export class AccountServicePrincipalsService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.ServicePrincipal,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/ServicePrincipals/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -279,13 +384,7 @@ export class AccountServicePrincipalsService {
         request: model.ServicePrincipal,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/ServicePrincipals/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -315,14 +414,9 @@ export class AccountUsersError extends ApiError {
  */
 export class AccountUsersService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new user.
-     *
-     * Creates a new user in the Databricks Account. This new user will also be
-     * added to the Databricks account.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.User,
         @context context?: Context
     ): Promise<model.User> {
@@ -336,13 +430,21 @@ export class AccountUsersService {
     }
 
     /**
-     * Delete a user.
+     * Create a new user.
      *
-     * Deletes a user. Deleting a user from a Databricks Account also removes
-     * objects associated with the user.
+     * Creates a new user in the Databricks Account. This new user will also be
+     * added to the Databricks account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.User,
+        @context context?: Context
+    ): Promise<model.User> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteUserRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -356,12 +458,21 @@ export class AccountUsersService {
     }
 
     /**
-     * Get user details.
+     * Delete a user.
      *
-     * Gets information for a specific user in Databricks Account.
+     * Deletes a user. Deleting a user from a Databricks Account also removes
+     * objects associated with the user.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteUserRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetUserRequest,
         @context context?: Context
     ): Promise<model.User> {
@@ -375,12 +486,20 @@ export class AccountUsersService {
     }
 
     /**
-     * List users.
+     * Get user details.
      *
-     * Gets details for all the users associated with a Databricks Account.
+     * Gets information for a specific user in Databricks Account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetUserRequest,
+        @context context?: Context
+    ): Promise<model.User> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListUsersRequest,
         @context context?: Context
     ): Promise<model.ListUsersResponse> {
@@ -394,6 +513,33 @@ export class AccountUsersService {
     }
 
     /**
+     * List users.
+     *
+     * Gets details for all the users associated with a Databricks Account.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListUsersRequest,
+        @context context?: Context
+    ): Promise<model.ListUsersResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Users/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update user details.
      *
      * Partially updates a user resource by applying the supplied operations on
@@ -404,10 +550,18 @@ export class AccountUsersService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.User,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Users/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -423,13 +577,7 @@ export class AccountUsersService {
         request: model.User,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/scim/v2/Users/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -450,13 +598,9 @@ export class CurrentUserError extends ApiError {
  */
 export class CurrentUserService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get current user info.
-     *
-     * Get details about the current method caller's identity.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async me(@context context?: Context): Promise<model.User> {
+    private async _me(@context context?: Context): Promise<model.User> {
         const path = "/api/2.0/preview/scim/v2/Me";
         return (await this.client.request(
             path,
@@ -464,6 +608,16 @@ export class CurrentUserService {
             undefined,
             context
         )) as model.User;
+    }
+
+    /**
+     * Get current user info.
+     *
+     * Get details about the current method caller's identity.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async me(@context context?: Context): Promise<model.User> {
+        return await this._me(context);
     }
 }
 
@@ -489,14 +643,9 @@ export class GroupsError extends ApiError {
  */
 export class GroupsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new group.
-     *
-     * Creates a group in the Databricks Workspace with a unique name, using the
-     * supplied group details.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.Group,
         @context context?: Context
     ): Promise<model.Group> {
@@ -510,12 +659,21 @@ export class GroupsService {
     }
 
     /**
-     * Delete a group.
+     * Create a new group.
      *
-     * Deletes a group from the Databricks Workspace.
+     * Creates a group in the Databricks Workspace with a unique name, using the
+     * supplied group details.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.Group,
+        @context context?: Context
+    ): Promise<model.Group> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteGroupRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -529,12 +687,20 @@ export class GroupsService {
     }
 
     /**
-     * Get group details.
+     * Delete a group.
      *
-     * Gets the information for a specific group in the Databricks Workspace.
+     * Deletes a group from the Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteGroupRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetGroupRequest,
         @context context?: Context
     ): Promise<model.Group> {
@@ -548,12 +714,20 @@ export class GroupsService {
     }
 
     /**
-     * List group details.
+     * Get group details.
      *
-     * Gets all details of the groups associated with the Databricks Workspace.
+     * Gets the information for a specific group in the Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetGroupRequest,
+        @context context?: Context
+    ): Promise<model.Group> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListGroupsRequest,
         @context context?: Context
     ): Promise<model.ListGroupsResponse> {
@@ -567,6 +741,33 @@ export class GroupsService {
     }
 
     /**
+     * List group details.
+     *
+     * Gets all details of the groups associated with the Databricks Workspace.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListGroupsRequest,
+        @context context?: Context
+    ): Promise<model.ListGroupsResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/scim/v2/Groups/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update group details.
      *
      * Partially updates the details of a group.
@@ -576,10 +777,18 @@ export class GroupsService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.Group,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/preview/scim/v2/Groups/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -595,13 +804,7 @@ export class GroupsService {
         request: model.Group,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/scim/v2/Groups/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -626,13 +829,9 @@ export class ServicePrincipalsError extends ApiError {
  */
 export class ServicePrincipalsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a service principal.
-     *
-     * Creates a new service principal in the Databricks Workspace.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.ServicePrincipal,
         @context context?: Context
     ): Promise<model.ServicePrincipal> {
@@ -646,12 +845,20 @@ export class ServicePrincipalsService {
     }
 
     /**
-     * Delete a service principal.
+     * Create a service principal.
      *
-     * Delete a single service principal in the Databricks Workspace.
+     * Creates a new service principal in the Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.ServicePrincipal,
+        @context context?: Context
+    ): Promise<model.ServicePrincipal> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteServicePrincipalRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -665,13 +872,20 @@ export class ServicePrincipalsService {
     }
 
     /**
-     * Get service principal details.
+     * Delete a service principal.
      *
-     * Gets the details for a single service principal define in the Databricks
-     * Workspace.
+     * Delete a single service principal in the Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteServicePrincipalRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetServicePrincipalRequest,
         @context context?: Context
     ): Promise<model.ServicePrincipal> {
@@ -685,12 +899,21 @@ export class ServicePrincipalsService {
     }
 
     /**
-     * List service principals.
+     * Get service principal details.
      *
-     * Gets the set of service principals associated with a Databricks Workspace.
+     * Gets the details for a single service principal define in the Databricks
+     * Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetServicePrincipalRequest,
+        @context context?: Context
+    ): Promise<model.ServicePrincipal> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListServicePrincipalsRequest,
         @context context?: Context
     ): Promise<model.ListServicePrincipalResponse> {
@@ -704,6 +927,33 @@ export class ServicePrincipalsService {
     }
 
     /**
+     * List service principals.
+     *
+     * Gets the set of service principals associated with a Databricks Workspace.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListServicePrincipalsRequest,
+        @context context?: Context
+    ): Promise<model.ListServicePrincipalResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/scim/v2/ServicePrincipals/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update service principal details.
      *
      * Partially updates the details of a single service principal in the
@@ -714,10 +964,18 @@ export class ServicePrincipalsService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.ServicePrincipal,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/preview/scim/v2/ServicePrincipals/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -735,13 +993,7 @@ export class ServicePrincipalsService {
         request: model.ServicePrincipal,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/scim/v2/ServicePrincipals/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -771,14 +1023,9 @@ export class UsersError extends ApiError {
  */
 export class UsersService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a new user.
-     *
-     * Creates a new user in the Databricks Workspace. This new user will also be
-     * added to the Databricks account.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.User,
         @context context?: Context
     ): Promise<model.User> {
@@ -792,13 +1039,21 @@ export class UsersService {
     }
 
     /**
-     * Delete a user.
+     * Create a new user.
      *
-     * Deletes a user. Deleting a user from a Databricks Workspace also removes
-     * objects associated with the user.
+     * Creates a new user in the Databricks Workspace. This new user will also be
+     * added to the Databricks account.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.User,
+        @context context?: Context
+    ): Promise<model.User> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteUserRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -812,12 +1067,21 @@ export class UsersService {
     }
 
     /**
-     * Get user details.
+     * Delete a user.
      *
-     * Gets information for a specific user in Databricks Workspace.
+     * Deletes a user. Deleting a user from a Databricks Workspace also removes
+     * objects associated with the user.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteUserRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetUserRequest,
         @context context?: Context
     ): Promise<model.User> {
@@ -831,12 +1095,20 @@ export class UsersService {
     }
 
     /**
-     * List users.
+     * Get user details.
      *
-     * Gets details for all the users associated with a Databricks Workspace.
+     * Gets information for a specific user in Databricks Workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetUserRequest,
+        @context context?: Context
+    ): Promise<model.User> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListUsersRequest,
         @context context?: Context
     ): Promise<model.ListUsersResponse> {
@@ -850,6 +1122,33 @@ export class UsersService {
     }
 
     /**
+     * List users.
+     *
+     * Gets details for all the users associated with a Databricks Workspace.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.ListUsersRequest,
+        @context context?: Context
+    ): Promise<model.ListUsersResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _patch(
+        request: model.PartialUpdate,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/scim/v2/Users/${request.id}`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
+    /**
      * Update user details.
      *
      * Partially updates a user resource by applying the supplied operations on
@@ -860,10 +1159,18 @@ export class UsersService {
         request: model.PartialUpdate,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._patch(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.User,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
         const path = `/api/2.0/preview/scim/v2/Users/${request.id}`;
         return (await this.client.request(
             path,
-            "PATCH",
+            "PUT",
             request,
             context
         )) as model.EmptyResponse;
@@ -879,12 +1186,6 @@ export class UsersService {
         request: model.User,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/scim/v2/Users/${request.id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/secrets/api.ts
+++ b/packages/databricks-sdk-js/src/apis/secrets/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class SecretsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -38,6 +39,21 @@ export class SecretsError extends ApiError {
  */
 export class SecretsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _createScope(
+        request: model.CreateScope,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/scopes/create";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
     /**
      * Create a new secret scope.
      *
@@ -50,7 +66,15 @@ export class SecretsService {
         request: model.CreateScope,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/scopes/create";
+        return await this._createScope(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteAcl(
+        request: model.DeleteAcl,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/acls/delete";
         return (await this.client.request(
             path,
             "POST",
@@ -74,7 +98,15 @@ export class SecretsService {
         request: model.DeleteAcl,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/acls/delete";
+        return await this._deleteAcl(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteScope(
+        request: model.DeleteScope,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/scopes/delete";
         return (await this.client.request(
             path,
             "POST",
@@ -97,7 +129,15 @@ export class SecretsService {
         request: model.DeleteScope,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/scopes/delete";
+        return await this._deleteScope(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _deleteSecret(
+        request: model.DeleteSecret,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/delete";
         return (await this.client.request(
             path,
             "POST",
@@ -121,13 +161,21 @@ export class SecretsService {
         request: model.DeleteSecret,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/delete";
+        return await this._deleteSecret(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getAcl(
+        request: model.GetAcl,
+        @context context?: Context
+    ): Promise<model.AclItem> {
+        const path = "/api/2.0/secrets/acls/get";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.AclItem;
     }
 
     /**
@@ -145,13 +193,21 @@ export class SecretsService {
         request: model.GetAcl,
         @context context?: Context
     ): Promise<model.AclItem> {
-        const path = "/api/2.0/secrets/acls/get";
+        return await this._getAcl(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _listAcls(
+        request: model.ListAcls,
+        @context context?: Context
+    ): Promise<model.ListAclsResponse> {
+        const path = "/api/2.0/secrets/acls/list";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.AclItem;
+        )) as model.ListAclsResponse;
     }
 
     /**
@@ -169,13 +225,20 @@ export class SecretsService {
         request: model.ListAcls,
         @context context?: Context
     ): Promise<model.ListAclsResponse> {
-        const path = "/api/2.0/secrets/acls/list";
+        return await this._listAcls(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _listScopes(
+        @context context?: Context
+    ): Promise<model.ListScopesResponse> {
+        const path = "/api/2.0/secrets/scopes/list";
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.ListAclsResponse;
+        )) as model.ListScopesResponse;
     }
 
     /**
@@ -190,13 +253,21 @@ export class SecretsService {
     async listScopes(
         @context context?: Context
     ): Promise<model.ListScopesResponse> {
-        const path = "/api/2.0/secrets/scopes/list";
+        return await this._listScopes(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _listSecrets(
+        request: model.ListSecrets,
+        @context context?: Context
+    ): Promise<model.ListSecretsResponse> {
+        const path = "/api/2.0/secrets/list";
         return (await this.client.request(
             path,
             "GET",
-            undefined,
+            request,
             context
-        )) as model.ListScopesResponse;
+        )) as model.ListSecretsResponse;
     }
 
     /**
@@ -216,13 +287,21 @@ export class SecretsService {
         request: model.ListSecrets,
         @context context?: Context
     ): Promise<model.ListSecretsResponse> {
-        const path = "/api/2.0/secrets/list";
+        return await this._listSecrets(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _putAcl(
+        request: model.PutAcl,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/acls/put";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListSecretsResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -261,7 +340,15 @@ export class SecretsService {
         request: model.PutAcl,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/acls/put";
+        return await this._putAcl(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _putSecret(
+        request: model.PutSecret,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/secrets/put";
         return (await this.client.request(
             path,
             "POST",
@@ -299,12 +386,6 @@ export class SecretsService {
         request: model.PutSecret,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/secrets/put";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._putSecret(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/sql/api.ts
+++ b/packages/databricks-sdk-js/src/apis/sql/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class AlertsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -30,6 +31,21 @@ export class AlertsError extends ApiError {
  */
 export class AlertsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateAlert,
+        @context context?: Context
+    ): Promise<model.Alert> {
+        const path = "/api/2.0/preview/sql/alerts";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Alert;
+    }
+
     /**
      * Create an alert.
      *
@@ -42,13 +58,21 @@ export class AlertsService {
         request: model.CreateAlert,
         @context context?: Context
     ): Promise<model.Alert> {
-        const path = "/api/2.0/preview/sql/alerts";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteAlertRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/sql/alerts/${request.alert_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.Alert;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -63,22 +87,11 @@ export class AlertsService {
         request: model.DeleteAlertRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/sql/alerts/${request.alert_id}`;
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._delete(request, context);
     }
 
-    /**
-     * Get an alert.
-     *
-     * Gets an alert.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetAlertRequest,
         @context context?: Context
     ): Promise<model.Alert> {
@@ -92,12 +105,22 @@ export class AlertsService {
     }
 
     /**
-     * Get alerts.
+     * Get an alert.
      *
-     * Gets a list of alerts.
+     * Gets an alert.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(@context context?: Context): Promise<Array<model.Alert>> {
+    async get(
+        request: model.GetAlertRequest,
+        @context context?: Context
+    ): Promise<model.Alert> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.Alert>> {
         const path = "/api/2.0/preview/sql/alerts";
         return (await this.client.request(
             path,
@@ -105,6 +128,30 @@ export class AlertsService {
             undefined,
             context
         )) as Array<model.Alert>;
+    }
+
+    /**
+     * Get alerts.
+     *
+     * Gets a list of alerts.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(@context context?: Context): Promise<Array<model.Alert>> {
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.EditAlert,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/sql/alerts/${request.alert_id}`;
+        return (await this.client.request(
+            path,
+            "PUT",
+            request,
+            context
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -117,13 +164,7 @@ export class AlertsService {
         request: model.EditAlert,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/sql/alerts/${request.alert_id}`;
-        return (await this.client.request(
-            path,
-            "PUT",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -147,11 +188,9 @@ export class DashboardsError extends ApiError {
  */
 export class DashboardsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a dashboard object.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateDashboardRequest,
         @context context?: Context
     ): Promise<model.Dashboard> {
@@ -165,13 +204,18 @@ export class DashboardsService {
     }
 
     /**
-     * Remove a dashboard.
-     *
-     * Moves a dashboard to the trash. Trashed dashboards do not appear in list
-     * views or searches, and cannot be shared.
+     * Create a dashboard object.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateDashboardRequest,
+        @context context?: Context
+    ): Promise<model.Dashboard> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteDashboardRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -185,13 +229,21 @@ export class DashboardsService {
     }
 
     /**
-     * Retrieve a definition.
+     * Remove a dashboard.
      *
-     * Returns a JSON representation of a dashboard object, including its
-     * visualization and query objects.
+     * Moves a dashboard to the trash. Trashed dashboards do not appear in list
+     * views or searches, and cannot be shared.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteDashboardRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetDashboardRequest,
         @context context?: Context
     ): Promise<model.Dashboard> {
@@ -205,12 +257,21 @@ export class DashboardsService {
     }
 
     /**
-     * Get dashboard objects.
+     * Retrieve a definition.
      *
-     * Fetch a paginated list of dashboard objects.
+     * Returns a JSON representation of a dashboard object, including its
+     * visualization and query objects.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetDashboardRequest,
+        @context context?: Context
+    ): Promise<model.Dashboard> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListDashboardsRequest,
         @context context?: Context
     ): Promise<model.ListResponse> {
@@ -224,12 +285,20 @@ export class DashboardsService {
     }
 
     /**
-     * Restore a dashboard.
+     * Get dashboard objects.
      *
-     * A restored dashboard appears in list views and searches and can be shared.
+     * Fetch a paginated list of dashboard objects.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async restore(
+    async list(
+        request: model.ListDashboardsRequest,
+        @context context?: Context
+    ): Promise<model.ListResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _restore(
         request: model.RestoreDashboardRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -240,6 +309,19 @@ export class DashboardsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Restore a dashboard.
+     *
+     * A restored dashboard appears in list views and searches and can be shared.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async restore(
+        request: model.RestoreDashboardRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._restore(request, context);
     }
 }
 
@@ -268,6 +350,20 @@ export class DataSourcesError extends ApiError {
  */
 export class DataSourcesService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.DataSource>> {
+        const path = "/api/2.0/preview/sql/data_sources";
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as Array<model.DataSource>;
+    }
+
     /**
      * Get a list of SQL warehouses.
      *
@@ -278,13 +374,7 @@ export class DataSourcesService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<Array<model.DataSource>> {
-        const path = "/api/2.0/preview/sql/data_sources";
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as Array<model.DataSource>;
+        return await this._list(context);
     }
 }
 
@@ -316,14 +406,9 @@ export class DbsqlPermissionsError extends ApiError {
  */
 export class DbsqlPermissionsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get object ACL.
-     *
-     * Gets a JSON representation of the access control list (ACL) for a
-     * specified object.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetDbsqlPermissionRequest,
         @context context?: Context
     ): Promise<model.GetResponse> {
@@ -337,13 +422,21 @@ export class DbsqlPermissionsService {
     }
 
     /**
-     * Set object ACL.
+     * Get object ACL.
      *
-     * Sets the access control list (ACL) for a specified object. This operation
-     * will complete rewrite the ACL.
+     * Gets a JSON representation of the access control list (ACL) for a
+     * specified object.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async set(
+    async get(
+        request: model.GetDbsqlPermissionRequest,
+        @context context?: Context
+    ): Promise<model.GetResponse> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _set(
         request: model.SetRequest,
         @context context?: Context
     ): Promise<model.SetResponse> {
@@ -357,13 +450,21 @@ export class DbsqlPermissionsService {
     }
 
     /**
-     * Transfer object ownership.
+     * Set object ACL.
      *
-     * Transfers ownership of a dashboard, query, or alert to an active user.
-     * Requires an admin API key.
+     * Sets the access control list (ACL) for a specified object. This operation
+     * will complete rewrite the ACL.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async transferOwnership(
+    async set(
+        request: model.SetRequest,
+        @context context?: Context
+    ): Promise<model.SetResponse> {
+        return await this._set(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _transferOwnership(
         request: model.TransferOwnershipRequest,
         @context context?: Context
     ): Promise<model.Success> {
@@ -374,6 +475,20 @@ export class DbsqlPermissionsService {
             request,
             context
         )) as model.Success;
+    }
+
+    /**
+     * Transfer object ownership.
+     *
+     * Transfers ownership of a dashboard, query, or alert to an active user.
+     * Requires an admin API key.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async transferOwnership(
+        request: model.TransferOwnershipRequest,
+        @context context?: Context
+    ): Promise<model.Success> {
+        return await this._transferOwnership(request, context);
     }
 }
 
@@ -395,6 +510,21 @@ export class QueriesError extends ApiError {
  */
 export class QueriesService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.QueryPostContent,
+        @context context?: Context
+    ): Promise<model.Query> {
+        const path = "/api/2.0/preview/sql/queries";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Query;
+    }
+
     /**
      * Create a new query definition.
      *
@@ -413,13 +543,21 @@ export class QueriesService {
         request: model.QueryPostContent,
         @context context?: Context
     ): Promise<model.Query> {
-        const path = "/api/2.0/preview/sql/queries";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteQueryRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.0/preview/sql/queries/${request.query_id}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.Query;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -434,23 +572,11 @@ export class QueriesService {
         request: model.DeleteQueryRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.0/preview/sql/queries/${request.query_id}`;
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._delete(request, context);
     }
 
-    /**
-     * Get a query definition.
-     *
-     * Retrieve a query object definition along with contextual permissions
-     * information about the currently authenticated user.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetQueryRequest,
         @context context?: Context
     ): Promise<model.Query> {
@@ -464,13 +590,21 @@ export class QueriesService {
     }
 
     /**
-     * Get a list of queries.
+     * Get a query definition.
      *
-     * Gets a list of queries. Optionally, this list can be filtered by a search
-     * term.
+     * Retrieve a query object definition along with contextual permissions
+     * information about the currently authenticated user.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetQueryRequest,
+        @context context?: Context
+    ): Promise<model.Query> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListQueriesRequest,
         @context context?: Context
     ): Promise<model.QueryList> {
@@ -484,13 +618,21 @@ export class QueriesService {
     }
 
     /**
-     * Restore a query.
+     * Get a list of queries.
      *
-     * Restore a query that has been moved to the trash. A restored query appears
-     * in list views and searches. You can use restored queries for alerts.
+     * Gets a list of queries. Optionally, this list can be filtered by a search
+     * term.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async restore(
+    async list(
+        request: model.ListQueriesRequest,
+        @context context?: Context
+    ): Promise<model.QueryList> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _restore(
         request: model.RestoreQueryRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -501,6 +643,34 @@ export class QueriesService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Restore a query.
+     *
+     * Restore a query that has been moved to the trash. A restored query appears
+     * in list views and searches. You can use restored queries for alerts.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async restore(
+        request: model.RestoreQueryRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._restore(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.QueryEditContent,
+        @context context?: Context
+    ): Promise<model.Query> {
+        const path = `/api/2.0/preview/sql/queries/${request.query_id}`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.Query;
     }
 
     /**
@@ -515,13 +685,7 @@ export class QueriesService {
         request: model.QueryEditContent,
         @context context?: Context
     ): Promise<model.Query> {
-        const path = `/api/2.0/preview/sql/queries/${request.query_id}`;
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.Query;
+        return await this._update(request, context);
     }
 }
 
@@ -541,6 +705,21 @@ export class QueryHistoryError extends ApiError {
  */
 export class QueryHistoryService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListQueryHistoryRequest,
+        @context context?: Context
+    ): Promise<model.ListQueriesResponse> {
+        const path = "/api/2.0/sql/history/queries";
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.ListQueriesResponse;
+    }
+
     /**
      * List Queries.
      *
@@ -553,13 +732,7 @@ export class QueryHistoryService {
         request: model.ListQueryHistoryRequest,
         @context context?: Context
     ): Promise<model.ListQueriesResponse> {
-        const path = "/api/2.0/sql/history/queries";
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.ListQueriesResponse;
+        return await this._list(request, context);
     }
 }
 
@@ -759,14 +932,9 @@ export class StatementExecutionError extends ApiError {
  */
 export class StatementExecutionService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Cancel statement execution.
-     *
-     * Requests that an executing statement be canceled. Callers must poll for
-     * status to see the terminal state.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async cancelExecution(
+    private async _cancelExecution(
         request: model.CancelExecutionRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -780,13 +948,21 @@ export class StatementExecutionService {
     }
 
     /**
-     * Execute a SQL statement.
+     * Cancel statement execution.
      *
-     * Execute a SQL statement, and if flagged as such, await its result for a
-     * specified time.
+     * Requests that an executing statement be canceled. Callers must poll for
+     * status to see the terminal state.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async executeStatement(
+    async cancelExecution(
+        request: model.CancelExecutionRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._cancelExecution(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _executeStatement(
         request: model.ExecuteStatementRequest,
         @context context?: Context
     ): Promise<model.ExecuteStatementResponse> {
@@ -797,6 +973,34 @@ export class StatementExecutionService {
             request,
             context
         )) as model.ExecuteStatementResponse;
+    }
+
+    /**
+     * Execute a SQL statement.
+     *
+     * Execute a SQL statement, and if flagged as such, await its result for a
+     * specified time.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async executeStatement(
+        request: model.ExecuteStatementRequest,
+        @context context?: Context
+    ): Promise<model.ExecuteStatementResponse> {
+        return await this._executeStatement(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getStatement(
+        request: model.GetStatementRequest,
+        @context context?: Context
+    ): Promise<model.GetStatementResponse> {
+        const path = `/api/2.0/sql/statements/${request.statement_id}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.GetStatementResponse;
     }
 
     /**
@@ -813,13 +1017,21 @@ export class StatementExecutionService {
         request: model.GetStatementRequest,
         @context context?: Context
     ): Promise<model.GetStatementResponse> {
-        const path = `/api/2.0/sql/statements/${request.statement_id}`;
+        return await this._getStatement(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getStatementResultChunkN(
+        request: model.GetStatementResultChunkNRequest,
+        @context context?: Context
+    ): Promise<model.ResultData> {
+        const path = `/api/2.0/sql/statements/${request.statement_id}/result/chunks/${request.chunk_index}`;
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.GetStatementResponse;
+        )) as model.ResultData;
     }
 
     /**
@@ -839,13 +1051,7 @@ export class StatementExecutionService {
         request: model.GetStatementResultChunkNRequest,
         @context context?: Context
     ): Promise<model.ResultData> {
-        const path = `/api/2.0/sql/statements/${request.statement_id}/result/chunks/${request.chunk_index}`;
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.ResultData;
+        return await this._getStatementResultChunkN(request, context);
     }
 }
 
@@ -867,13 +1073,9 @@ export class WarehousesError extends ApiError {
  */
 export class WarehousesService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a warehouse.
-     *
-     * Creates a new SQL warehouse.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateWarehouseRequest,
         @context context?: Context
     ): Promise<model.CreateWarehouseResponse> {
@@ -887,86 +1089,81 @@ export class WarehousesService {
     }
 
     /**
-     * create and wait to reach RUNNING state
-     *  or fail on reaching STOPPED or DELETED state
+     * Create a warehouse.
+     *
+     * Creates a new SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async createAndWait(
+    async create(
         createWarehouseRequest: model.CreateWarehouseRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<
+        Waiter<model.CreateWarehouseResponse, model.GetWarehouseResponse>
+    > {
         const cancellationToken = context?.cancellationToken;
 
-        const createWarehouseResponse = await this.create(
+        const createWarehouseResponse = await this._create(
             createWarehouseRequest,
             context
         );
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: createWarehouseResponse.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "Warehouses.createAndWait: cancelled"
+        return asWaiter(createWarehouseResponse, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: createWarehouseResponse.id!,
+                        },
+                        context
                     );
-                    throw new WarehousesError("createAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "STOPPED":
-                    case "DELETED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.createAndWait: ${errorMessage}`
+                            "Warehouses.createAndWait: cancelled"
                         );
-                        throw new WarehousesError(
-                            "createAndWait",
-                            errorMessage
-                        );
+                        throw new WarehousesError("createAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Warehouses.createAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WarehousesRetriableError(
-                            "createAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "STOPPED":
+                        case "DELETED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.createAndWait: ${errorMessage}`
+                            );
+                            throw new WarehousesError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.createAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "createAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 
-    /**
-     * Delete a warehouse.
-     *
-     * Deletes a SQL warehouse.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    private async _delete(
         request: model.DeleteWarehouseRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -980,72 +1177,65 @@ export class WarehousesService {
     }
 
     /**
-     * delete and wait to reach DELETED state
+     * Delete a warehouse.
      *
+     * Deletes a SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async deleteAndWait(
+    async delete(
         deleteWarehouseRequest: model.DeleteWarehouseRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.EmptyResponse, model.GetWarehouseResponse>> {
         const cancellationToken = context?.cancellationToken;
 
-        await this.delete(deleteWarehouseRequest, context);
+        await this._delete(deleteWarehouseRequest, context);
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: deleteWarehouseRequest.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "Warehouses.deleteAndWait: cancelled"
+        return asWaiter(null, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: deleteWarehouseRequest.id!,
+                        },
+                        context
                     );
-                    throw new WarehousesError("deleteAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "DELETED": {
-                        return pollResponse;
-                    }
-                    default: {
-                        const errorMessage = `failed to reach DELETED state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.deleteAndWait: retrying: ${errorMessage}`
+                            "Warehouses.deleteAndWait: cancelled"
                         );
-                        throw new WarehousesRetriableError(
-                            "deleteAndWait",
-                            errorMessage
-                        );
+                        throw new WarehousesError("deleteAndWait", "cancelled");
                     }
-                }
-            },
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "DELETED": {
+                            return pollResponse;
+                        }
+                        default: {
+                            const errorMessage = `failed to reach DELETED state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.deleteAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "deleteAndWait",
+                                errorMessage
+                            );
+                        }
+                    }
+                },
+            });
         });
     }
 
-    /**
-     * Update a warehouse.
-     *
-     * Updates the configuration for a SQL warehouse.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async edit(
+    private async _edit(
         request: model.EditWarehouseRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1059,78 +1249,76 @@ export class WarehousesService {
     }
 
     /**
-     * edit and wait to reach RUNNING state
-     *  or fail on reaching STOPPED or DELETED state
+     * Update a warehouse.
+     *
+     * Updates the configuration for a SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async editAndWait(
+    async edit(
         editWarehouseRequest: model.EditWarehouseRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.EmptyResponse, model.GetWarehouseResponse>> {
         const cancellationToken = context?.cancellationToken;
 
-        await this.edit(editWarehouseRequest, context);
+        await this._edit(editWarehouseRequest, context);
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: editWarehouseRequest.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error("Warehouses.editAndWait: cancelled");
-                    throw new WarehousesError("editAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "STOPPED":
-                    case "DELETED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+        return asWaiter(null, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: editWarehouseRequest.id!,
+                        },
+                        context
+                    );
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.editAndWait: ${errorMessage}`
+                            "Warehouses.editAndWait: cancelled"
                         );
-                        throw new WarehousesError("editAndWait", errorMessage);
+                        throw new WarehousesError("editAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Warehouses.editAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WarehousesRetriableError(
-                            "editAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "STOPPED":
+                        case "DELETED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.editAndWait: ${errorMessage}`
+                            );
+                            throw new WarehousesError(
+                                "editAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.editAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "editAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 
-    /**
-     * Get warehouse info.
-     *
-     * Gets the information for a single SQL warehouse.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetWarehouseRequest,
         @context context?: Context
     ): Promise<model.GetWarehouseResponse> {
@@ -1144,82 +1332,79 @@ export class WarehousesService {
     }
 
     /**
-     * get and wait to reach RUNNING state
-     *  or fail on reaching STOPPED or DELETED state
+     * Get warehouse info.
+     *
+     * Gets the information for a single SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async getAndWait(
+    async get(
         getWarehouseRequest: model.GetWarehouseRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.GetWarehouseResponse, model.GetWarehouseResponse>> {
         const cancellationToken = context?.cancellationToken;
 
-        const getWarehouseResponse = await this.get(
+        const getWarehouseResponse = await this._get(
             getWarehouseRequest,
             context
         );
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: getWarehouseResponse.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error("Warehouses.getAndWait: cancelled");
-                    throw new WarehousesError("getAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "STOPPED":
-                    case "DELETED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+        return asWaiter(getWarehouseResponse, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: getWarehouseResponse.id!,
+                        },
+                        context
+                    );
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.getAndWait: ${errorMessage}`
+                            "Warehouses.getAndWait: cancelled"
                         );
-                        throw new WarehousesError("getAndWait", errorMessage);
+                        throw new WarehousesError("getAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Warehouses.getAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WarehousesRetriableError(
-                            "getAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "STOPPED":
+                        case "DELETED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.getAndWait: ${errorMessage}`
+                            );
+                            throw new WarehousesError(
+                                "getAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.getAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "getAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 
-    /**
-     * Get the workspace configuration.
-     *
-     * Gets the workspace level configuration that is shared by all SQL
-     * warehouses in a workspace.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async getWorkspaceWarehouseConfig(
+    private async _getWorkspaceWarehouseConfig(
         @context context?: Context
     ): Promise<model.GetWorkspaceWarehouseConfigResponse> {
         const path = "/api/2.0/sql/config/warehouses";
@@ -1232,12 +1417,20 @@ export class WarehousesService {
     }
 
     /**
-     * List warehouses.
+     * Get the workspace configuration.
      *
-     * Lists all SQL warehouses that a user has manager permissions on.
+     * Gets the workspace level configuration that is shared by all SQL
+     * warehouses in a workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async getWorkspaceWarehouseConfig(
+        @context context?: Context
+    ): Promise<model.GetWorkspaceWarehouseConfigResponse> {
+        return await this._getWorkspaceWarehouseConfig(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.ListWarehousesRequest,
         @context context?: Context
     ): Promise<model.ListWarehousesResponse> {
@@ -1251,13 +1444,20 @@ export class WarehousesService {
     }
 
     /**
-     * Set the workspace configuration.
+     * List warehouses.
      *
-     * Sets the workspace level configuration that is shared by all SQL
-     * warehouses in a workspace.
+     * Lists all SQL warehouses that a user has manager permissions on.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async setWorkspaceWarehouseConfig(
+    async list(
+        request: model.ListWarehousesRequest,
+        @context context?: Context
+    ): Promise<model.ListWarehousesResponse> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _setWorkspaceWarehouseConfig(
         request: model.SetWorkspaceWarehouseConfigRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1271,12 +1471,21 @@ export class WarehousesService {
     }
 
     /**
-     * Start a warehouse.
+     * Set the workspace configuration.
      *
-     * Starts a SQL warehouse.
+     * Sets the workspace level configuration that is shared by all SQL
+     * warehouses in a workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async start(
+    async setWorkspaceWarehouseConfig(
+        request: model.SetWorkspaceWarehouseConfigRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._setWorkspaceWarehouseConfig(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _start(
         request: model.StartRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1290,80 +1499,76 @@ export class WarehousesService {
     }
 
     /**
-     * start and wait to reach RUNNING state
-     *  or fail on reaching STOPPED or DELETED state
+     * Start a warehouse.
+     *
+     * Starts a SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async startAndWait(
+    async start(
         startRequest: model.StartRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.EmptyResponse, model.GetWarehouseResponse>> {
         const cancellationToken = context?.cancellationToken;
 
-        await this.start(startRequest, context);
+        await this._start(startRequest, context);
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: startRequest.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error(
-                        "Warehouses.startAndWait: cancelled"
+        return asWaiter(null, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: startRequest.id!,
+                        },
+                        context
                     );
-                    throw new WarehousesError("startAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "RUNNING": {
-                        return pollResponse;
-                    }
-                    case "STOPPED":
-                    case "DELETED": {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.startAndWait: ${errorMessage}`
+                            "Warehouses.startAndWait: cancelled"
                         );
-                        throw new WarehousesError("startAndWait", errorMessage);
+                        throw new WarehousesError("startAndWait", "cancelled");
                     }
-                    default: {
-                        const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
-                        context?.logger?.error(
-                            `Warehouses.startAndWait: retrying: ${errorMessage}`
-                        );
-                        throw new WarehousesRetriableError(
-                            "startAndWait",
-                            errorMessage
-                        );
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "RUNNING": {
+                            return pollResponse;
+                        }
+                        case "STOPPED":
+                        case "DELETED": {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.startAndWait: ${errorMessage}`
+                            );
+                            throw new WarehousesError(
+                                "startAndWait",
+                                errorMessage
+                            );
+                        }
+                        default: {
+                            const errorMessage = `failed to reach RUNNING state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.startAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "startAndWait",
+                                errorMessage
+                            );
+                        }
                     }
-                }
-            },
+                },
+            });
         });
     }
 
-    /**
-     * Stop a warehouse.
-     *
-     * Stops a SQL warehouse.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async stop(
+    private async _stop(
         request: model.StopRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1377,60 +1582,60 @@ export class WarehousesService {
     }
 
     /**
-     * stop and wait to reach STOPPED state
+     * Stop a warehouse.
      *
+     * Stops a SQL warehouse.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async stopAndWait(
+    async stop(
         stopRequest: model.StopRequest,
-        options?: {
-            timeout?: Time;
-            onProgress?: (
-                newPollResponse: model.GetWarehouseResponse
-            ) => Promise<void>;
-        },
         @context context?: Context
-    ): Promise<model.GetWarehouseResponse> {
-        options = options || {};
-        options.onProgress =
-            options.onProgress || (async (newPollResponse) => {});
-        const {timeout, onProgress} = options;
+    ): Promise<Waiter<model.EmptyResponse, model.GetWarehouseResponse>> {
         const cancellationToken = context?.cancellationToken;
 
-        await this.stop(stopRequest, context);
+        await this._stop(stopRequest, context);
 
-        return await retry<model.GetWarehouseResponse>({
-            timeout,
-            fn: async () => {
-                const pollResponse = await this.get(
-                    {
-                        id: stopRequest.id!,
-                    },
-                    context
-                );
-                if (cancellationToken?.isCancellationRequested) {
-                    context?.logger?.error("Warehouses.stopAndWait: cancelled");
-                    throw new WarehousesError("stopAndWait", "cancelled");
-                }
-                await onProgress(pollResponse);
-                const status = pollResponse.state;
-                const statusMessage = pollResponse.health!.summary;
-                switch (status) {
-                    case "STOPPED": {
-                        return pollResponse;
-                    }
-                    default: {
-                        const errorMessage = `failed to reach STOPPED state, got ${status}: ${statusMessage}`;
+        return asWaiter(null, async (options) => {
+            options = options || {};
+            options.onProgress =
+                options.onProgress || (async (newPollResponse) => {});
+            const {timeout, onProgress} = options;
+
+            return await retry<model.GetWarehouseResponse>({
+                timeout,
+                fn: async () => {
+                    const pollResponse = await this.get(
+                        {
+                            id: stopRequest.id!,
+                        },
+                        context
+                    );
+                    if (cancellationToken?.isCancellationRequested) {
                         context?.logger?.error(
-                            `Warehouses.stopAndWait: retrying: ${errorMessage}`
+                            "Warehouses.stopAndWait: cancelled"
                         );
-                        throw new WarehousesRetriableError(
-                            "stopAndWait",
-                            errorMessage
-                        );
+                        throw new WarehousesError("stopAndWait", "cancelled");
                     }
-                }
-            },
+                    await onProgress(pollResponse);
+                    const status = pollResponse.state;
+                    const statusMessage = pollResponse.health!.summary;
+                    switch (status) {
+                        case "STOPPED": {
+                            return pollResponse;
+                        }
+                        default: {
+                            const errorMessage = `failed to reach STOPPED state, got ${status}: ${statusMessage}`;
+                            context?.logger?.error(
+                                `Warehouses.stopAndWait: retrying: ${errorMessage}`
+                            );
+                            throw new WarehousesRetriableError(
+                                "stopAndWait",
+                                errorMessage
+                            );
+                        }
+                    }
+                },
+            });
         });
     }
 }

--- a/packages/databricks-sdk-js/src/apis/sql/model.ts
+++ b/packages/databricks-sdk-js/src/apis/sql/model.ts
@@ -129,9 +129,6 @@ export interface ChannelInfo {
     name?: ChannelName;
 }
 
-/**
- * Name of the channel
- */
 export type ChannelName =
     | "CHANNEL_NAME_CURRENT"
     | "CHANNEL_NAME_CUSTOM"

--- a/packages/databricks-sdk-js/src/apis/tokenmanagement/api.ts
+++ b/packages/databricks-sdk-js/src/apis/tokenmanagement/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class TokenManagementRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -29,13 +30,9 @@ export class TokenManagementError extends ApiError {
  */
 export class TokenManagementService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create on-behalf token.
-     *
-     * Creates a token on behalf of a service principal.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async createOboToken(
+    private async _createOboToken(
         request: model.CreateOboTokenRequest,
         @context context?: Context
     ): Promise<model.CreateOboTokenResponse> {
@@ -49,12 +46,20 @@ export class TokenManagementService {
     }
 
     /**
-     * Delete a token.
+     * Create on-behalf token.
      *
-     * Deletes a token, specified by its ID.
+     * Creates a token on behalf of a service principal.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async createOboToken(
+        request: model.CreateOboTokenRequest,
+        @context context?: Context
+    ): Promise<model.CreateOboTokenResponse> {
+        return await this._createOboToken(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -68,12 +73,20 @@ export class TokenManagementService {
     }
 
     /**
-     * Get token info.
+     * Delete a token.
      *
-     * Gets information about a token, specified by its ID.
+     * Deletes a token, specified by its ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.Get,
         @context context?: Context
     ): Promise<model.TokenInfo> {
@@ -87,12 +100,20 @@ export class TokenManagementService {
     }
 
     /**
-     * List all tokens.
+     * Get token info.
      *
-     * Lists all tokens associated with the specified workspace or user.
+     * Gets information about a token, specified by its ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.Get,
+        @context context?: Context
+    ): Promise<model.TokenInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         request: model.List,
         @context context?: Context
     ): Promise<model.ListTokensResponse> {
@@ -103,5 +124,18 @@ export class TokenManagementService {
             request,
             context
         )) as model.ListTokensResponse;
+    }
+
+    /**
+     * List all tokens.
+     *
+     * Lists all tokens associated with the specified workspace or user.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async list(
+        request: model.List,
+        @context context?: Context
+    ): Promise<model.ListTokensResponse> {
+        return await this._list(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/tokens/api.ts
+++ b/packages/databricks-sdk-js/src/apis/tokens/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class TokensRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -28,6 +29,21 @@ export class TokensError extends ApiError {
  */
 export class TokensService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateTokenRequest,
+        @context context?: Context
+    ): Promise<model.CreateTokenResponse> {
+        const path = "/api/2.0/token/create";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.CreateTokenResponse;
+    }
+
     /**
      * Create a user token.
      *
@@ -41,13 +57,21 @@ export class TokensService {
         request: model.CreateTokenRequest,
         @context context?: Context
     ): Promise<model.CreateTokenResponse> {
-        const path = "/api/2.0/token/create";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.RevokeTokenRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/token/delete";
         return (await this.client.request(
             path,
             "POST",
             request,
             context
-        )) as model.CreateTokenResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -63,13 +87,20 @@ export class TokensService {
         request: model.RevokeTokenRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/token/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListTokensResponse> {
+        const path = "/api/2.0/token/list";
         return (await this.client.request(
             path,
-            "POST",
-            request,
+            "GET",
+            undefined,
             context
-        )) as model.EmptyResponse;
+        )) as model.ListTokensResponse;
     }
 
     /**
@@ -79,12 +110,6 @@ export class TokensService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<model.ListTokensResponse> {
-        const path = "/api/2.0/token/list";
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as model.ListTokensResponse;
+        return await this._list(context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/unitycatalog/api.ts
+++ b/packages/databricks-sdk-js/src/apis/unitycatalog/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class AccountMetastoreAssignmentsRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -27,13 +28,9 @@ export class AccountMetastoreAssignmentsError extends ApiError {
  */
 export class AccountMetastoreAssignmentsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Assigns a workspace to a metastore.
-     *
-     * Creates an assignment to a metastore for a workspace
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateMetastoreAssignment,
         @context context?: Context
     ): Promise<model.MetastoreAssignment> {
@@ -47,13 +44,20 @@ export class AccountMetastoreAssignmentsService {
     }
 
     /**
-     * Delete a metastore assignment.
+     * Assigns a workspace to a metastore.
      *
-     * Deletes a metastore assignment to a workspace, leaving the workspace with
-     * no metastore.
+     * Creates an assignment to a metastore for a workspace
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateMetastoreAssignment,
+        @context context?: Context
+    ): Promise<model.MetastoreAssignment> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteAccountMetastoreAssignmentRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -64,6 +68,34 @@ export class AccountMetastoreAssignmentsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete a metastore assignment.
+     *
+     * Deletes a metastore assignment to a workspace, leaving the workspace with
+     * no metastore.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteAccountMetastoreAssignmentRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetAccountMetastoreAssignmentRequest,
+        @context context?: Context
+    ): Promise<model.MetastoreAssignment> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}/metastore`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.MetastoreAssignment;
     }
 
     /**
@@ -79,23 +111,11 @@ export class AccountMetastoreAssignmentsService {
         request: model.GetAccountMetastoreAssignmentRequest,
         @context context?: Context
     ): Promise<model.MetastoreAssignment> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/workspaces/${request.workspace_id}/metastore`;
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.MetastoreAssignment;
+        return await this._get(request, context);
     }
 
-    /**
-     * Get all workspaces assigned to a metastore.
-     *
-     * Gets a list of all Databricks workspace IDs that have been assigned to
-     * given metastore.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    private async _list(
         request: model.ListAccountMetastoreAssignmentsRequest,
         @context context?: Context
     ): Promise<Array<model.MetastoreAssignment>> {
@@ -109,13 +129,21 @@ export class AccountMetastoreAssignmentsService {
     }
 
     /**
-     * Updates a metastore assignment to a workspaces.
+     * Get all workspaces assigned to a metastore.
      *
-     * Updates an assignment to a metastore for a workspace. Currently, only the
-     * default catalog may be updated
+     * Gets a list of all Databricks workspace IDs that have been assigned to
+     * given metastore.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async list(
+        request: model.ListAccountMetastoreAssignmentsRequest,
+        @context context?: Context
+    ): Promise<Array<model.MetastoreAssignment>> {
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateMetastoreAssignment,
         @context context?: Context
     ): Promise<model.MetastoreAssignment> {
@@ -126,6 +154,20 @@ export class AccountMetastoreAssignmentsService {
             request,
             context
         )) as model.MetastoreAssignment;
+    }
+
+    /**
+     * Updates a metastore assignment to a workspaces.
+     *
+     * Updates an assignment to a metastore for a workspace. Currently, only the
+     * default catalog may be updated
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateMetastoreAssignment,
+        @context context?: Context
+    ): Promise<model.MetastoreAssignment> {
+        return await this._update(request, context);
     }
 }
 
@@ -146,13 +188,9 @@ export class AccountMetastoresError extends ApiError {
  */
 export class AccountMetastoresService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create metastore.
-     *
-     * Creates a Unity Catalog metastore.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateMetastore,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -166,13 +204,20 @@ export class AccountMetastoresService {
     }
 
     /**
-     * Delete a metastore.
+     * Create metastore.
      *
-     * Deletes a Databricks Unity Catalog metastore for an account, both
-     * specified by ID.
+     * Creates a Unity Catalog metastore.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateMetastore,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteAccountMetastoreRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -186,13 +231,21 @@ export class AccountMetastoresService {
     }
 
     /**
-     * Get a metastore.
+     * Delete a metastore.
      *
-     * Gets a Databricks Unity Catalog metastore from an account, both specified
-     * by ID.
+     * Deletes a Databricks Unity Catalog metastore for an account, both
+     * specified by ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteAccountMetastoreRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetAccountMetastoreRequest,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -206,13 +259,21 @@ export class AccountMetastoresService {
     }
 
     /**
-     * Get all metastores associated with an account.
+     * Get a metastore.
      *
-     * Gets all Unity Catalog metastores associated with an account specified by
-     * ID.
+     * Gets a Databricks Unity Catalog metastore from an account, both specified
+     * by ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async list(
+    async get(
+        request: model.GetAccountMetastoreRequest,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
         @context context?: Context
     ): Promise<model.ListMetastoresResponse> {
         const path = `/api/2.0/accounts/${this.client.accountId}/metastores`;
@@ -225,12 +286,20 @@ export class AccountMetastoresService {
     }
 
     /**
-     * Update a metastore.
+     * Get all metastores associated with an account.
      *
-     * Updates an existing Unity Catalog metastore.
+     * Gets all Unity Catalog metastores associated with an account specified by
+     * ID.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async list(
+        @context context?: Context
+    ): Promise<model.ListMetastoresResponse> {
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateMetastore,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -241,6 +310,19 @@ export class AccountMetastoresService {
             request,
             context
         )) as model.MetastoreInfo;
+    }
+
+    /**
+     * Update a metastore.
+     *
+     * Updates an existing Unity Catalog metastore.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateMetastore,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._update(request, context);
     }
 }
 
@@ -260,6 +342,21 @@ export class AccountStorageCredentialsError extends ApiError {
  */
 export class AccountStorageCredentialsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateStorageCredential,
+        @context context?: Context
+    ): Promise<model.StorageCredentialInfo> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials`;
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.StorageCredentialInfo;
+    }
+
     /**
      * Create a storage credential.
      *
@@ -277,10 +374,18 @@ export class AccountStorageCredentialsService {
         request: model.CreateStorageCredential,
         @context context?: Context
     ): Promise<model.StorageCredentialInfo> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials`;
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetAccountStorageCredentialRequest,
+        @context context?: Context
+    ): Promise<model.StorageCredentialInfo> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials/`;
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
         )) as model.StorageCredentialInfo;
@@ -298,13 +403,21 @@ export class AccountStorageCredentialsService {
         request: model.GetAccountStorageCredentialRequest,
         @context context?: Context
     ): Promise<model.StorageCredentialInfo> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials/`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListAccountStorageCredentialsRequest,
+        @context context?: Context
+    ): Promise<Array<model.StorageCredentialInfo>> {
+        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials`;
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.StorageCredentialInfo;
+        )) as Array<model.StorageCredentialInfo>;
     }
 
     /**
@@ -318,13 +431,7 @@ export class AccountStorageCredentialsService {
         request: model.ListAccountStorageCredentialsRequest,
         @context context?: Context
     ): Promise<Array<model.StorageCredentialInfo>> {
-        const path = `/api/2.0/accounts/${this.client.accountId}/metastores/${request.metastore_id}/storage-credentials`;
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as Array<model.StorageCredentialInfo>;
+        return await this._list(request, context);
     }
 }
 
@@ -351,14 +458,9 @@ export class CatalogsError extends ApiError {
  */
 export class CatalogsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a catalog.
-     *
-     * Creates a new catalog instance in the parent metastore if the caller is a
-     * metastore admin or has the **CREATE_CATALOG** privilege.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateCatalog,
         @context context?: Context
     ): Promise<model.CatalogInfo> {
@@ -372,13 +474,21 @@ export class CatalogsService {
     }
 
     /**
-     * Delete a catalog.
+     * Create a catalog.
      *
-     * Deletes the catalog that matches the supplied name. The caller must be a
-     * metastore admin or the owner of the catalog.
+     * Creates a new catalog instance in the parent metastore if the caller is a
+     * metastore admin or has the **CREATE_CATALOG** privilege.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateCatalog,
+        @context context?: Context
+    ): Promise<model.CatalogInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteCatalogRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -389,6 +499,34 @@ export class CatalogsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete a catalog.
+     *
+     * Deletes the catalog that matches the supplied name. The caller must be a
+     * metastore admin or the owner of the catalog.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteCatalogRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetCatalogRequest,
+        @context context?: Context
+    ): Promise<model.CatalogInfo> {
+        const path = `/api/2.1/unity-catalog/catalogs/${request.name}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.CatalogInfo;
     }
 
     /**
@@ -403,13 +541,20 @@ export class CatalogsService {
         request: model.GetCatalogRequest,
         @context context?: Context
     ): Promise<model.CatalogInfo> {
-        const path = `/api/2.1/unity-catalog/catalogs/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListCatalogsResponse> {
+        const path = "/api/2.1/unity-catalog/catalogs";
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.CatalogInfo;
+        )) as model.ListCatalogsResponse;
     }
 
     /**
@@ -425,13 +570,21 @@ export class CatalogsService {
     async list(
         @context context?: Context
     ): Promise<model.ListCatalogsResponse> {
-        const path = "/api/2.1/unity-catalog/catalogs";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateCatalog,
+        @context context?: Context
+    ): Promise<model.CatalogInfo> {
+        const path = `/api/2.1/unity-catalog/catalogs/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PATCH",
+            request,
             context
-        )) as model.ListCatalogsResponse;
+        )) as model.CatalogInfo;
     }
 
     /**
@@ -446,13 +599,7 @@ export class CatalogsService {
         request: model.UpdateCatalog,
         @context context?: Context
     ): Promise<model.CatalogInfo> {
-        const path = `/api/2.1/unity-catalog/catalogs/${request.name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.CatalogInfo;
+        return await this._update(request, context);
     }
 }
 
@@ -484,15 +631,9 @@ export class ExternalLocationsError extends ApiError {
  */
 export class ExternalLocationsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create an external location.
-     *
-     * Creates a new external location entry in the metastore. The caller must be
-     * a metastore admin or have the **CREATE_EXTERNAL_LOCATION** privilege on
-     * both the metastore and the associated storage credential.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateExternalLocation,
         @context context?: Context
     ): Promise<model.ExternalLocationInfo> {
@@ -506,13 +647,22 @@ export class ExternalLocationsService {
     }
 
     /**
-     * Delete an external location.
+     * Create an external location.
      *
-     * Deletes the specified external location from the metastore. The caller
-     * must be the owner of the external location.
+     * Creates a new external location entry in the metastore. The caller must be
+     * a metastore admin or have the **CREATE_EXTERNAL_LOCATION** privilege on
+     * both the metastore and the associated storage credential.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateExternalLocation,
+        @context context?: Context
+    ): Promise<model.ExternalLocationInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteExternalLocationRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -523,6 +673,34 @@ export class ExternalLocationsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete an external location.
+     *
+     * Deletes the specified external location from the metastore. The caller
+     * must be the owner of the external location.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteExternalLocationRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetExternalLocationRequest,
+        @context context?: Context
+    ): Promise<model.ExternalLocationInfo> {
+        const path = `/api/2.1/unity-catalog/external-locations/${request.name}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.ExternalLocationInfo;
     }
 
     /**
@@ -537,13 +715,20 @@ export class ExternalLocationsService {
         request: model.GetExternalLocationRequest,
         @context context?: Context
     ): Promise<model.ExternalLocationInfo> {
-        const path = `/api/2.1/unity-catalog/external-locations/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListExternalLocationsResponse> {
+        const path = "/api/2.1/unity-catalog/external-locations";
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.ExternalLocationInfo;
+        )) as model.ListExternalLocationsResponse;
     }
 
     /**
@@ -559,13 +744,21 @@ export class ExternalLocationsService {
     async list(
         @context context?: Context
     ): Promise<model.ListExternalLocationsResponse> {
-        const path = "/api/2.1/unity-catalog/external-locations";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateExternalLocation,
+        @context context?: Context
+    ): Promise<model.ExternalLocationInfo> {
+        const path = `/api/2.1/unity-catalog/external-locations/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PATCH",
+            request,
             context
-        )) as model.ListExternalLocationsResponse;
+        )) as model.ExternalLocationInfo;
     }
 
     /**
@@ -580,13 +773,7 @@ export class ExternalLocationsService {
         request: model.UpdateExternalLocation,
         @context context?: Context
     ): Promise<model.ExternalLocationInfo> {
-        const path = `/api/2.1/unity-catalog/external-locations/${request.name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.ExternalLocationInfo;
+        return await this._update(request, context);
     }
 }
 
@@ -611,6 +798,21 @@ export class FunctionsError extends ApiError {
  */
 export class FunctionsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateFunction,
+        @context context?: Context
+    ): Promise<model.FunctionInfo> {
+        const path = "/api/2.1/unity-catalog/functions";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.FunctionInfo;
+    }
+
     /**
      * Create a function.
      *
@@ -625,13 +827,21 @@ export class FunctionsService {
         request: model.CreateFunction,
         @context context?: Context
     ): Promise<model.FunctionInfo> {
-        const path = "/api/2.1/unity-catalog/functions";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteFunctionRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/functions/${request.name}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.FunctionInfo;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -650,13 +860,21 @@ export class FunctionsService {
         request: model.DeleteFunctionRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetFunctionRequest,
+        @context context?: Context
+    ): Promise<model.FunctionInfo> {
         const path = `/api/2.1/unity-catalog/functions/${request.name}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.FunctionInfo;
     }
 
     /**
@@ -675,13 +893,21 @@ export class FunctionsService {
         request: model.GetFunctionRequest,
         @context context?: Context
     ): Promise<model.FunctionInfo> {
-        const path = `/api/2.1/unity-catalog/functions/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListFunctionsRequest,
+        @context context?: Context
+    ): Promise<model.ListFunctionsResponse> {
+        const path = "/api/2.1/unity-catalog/functions";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.FunctionInfo;
+        )) as model.ListFunctionsResponse;
     }
 
     /**
@@ -700,13 +926,21 @@ export class FunctionsService {
         request: model.ListFunctionsRequest,
         @context context?: Context
     ): Promise<model.ListFunctionsResponse> {
-        const path = "/api/2.1/unity-catalog/functions";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateFunction,
+        @context context?: Context
+    ): Promise<model.FunctionInfo> {
+        const path = `/api/2.1/unity-catalog/functions/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
+            "PATCH",
             request,
             context
-        )) as model.ListFunctionsResponse;
+        )) as model.FunctionInfo;
     }
 
     /**
@@ -726,13 +960,7 @@ export class FunctionsService {
         request: model.UpdateFunction,
         @context context?: Context
     ): Promise<model.FunctionInfo> {
-        const path = `/api/2.1/unity-catalog/functions/${request.name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.FunctionInfo;
+        return await this._update(request, context);
     }
 }
 
@@ -762,13 +990,9 @@ export class GrantsError extends ApiError {
  */
 export class GrantsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get permissions.
-     *
-     * Gets the permissions for a securable.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    private async _get(
         request: model.GetGrantRequest,
         @context context?: Context
     ): Promise<model.PermissionsList> {
@@ -782,12 +1006,20 @@ export class GrantsService {
     }
 
     /**
-     * Get effective permissions.
+     * Get permissions.
      *
-     * Gets the effective permissions for a securable.
+     * Gets the permissions for a securable.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async getEffective(
+    async get(
+        request: model.GetGrantRequest,
+        @context context?: Context
+    ): Promise<model.PermissionsList> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getEffective(
         request: model.GetEffectiveRequest,
         @context context?: Context
     ): Promise<model.EffectivePermissionsList> {
@@ -801,12 +1033,20 @@ export class GrantsService {
     }
 
     /**
-     * Update permissions.
+     * Get effective permissions.
      *
-     * Updates the permissions for a securable.
+     * Gets the effective permissions for a securable.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async getEffective(
+        request: model.GetEffectiveRequest,
+        @context context?: Context
+    ): Promise<model.EffectivePermissionsList> {
+        return await this._getEffective(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdatePermissions,
         @context context?: Context
     ): Promise<model.PermissionsList> {
@@ -817,6 +1057,19 @@ export class GrantsService {
             request,
             context
         )) as model.PermissionsList;
+    }
+
+    /**
+     * Update permissions.
+     *
+     * Updates the permissions for a securable.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdatePermissions,
+        @context context?: Context
+    ): Promise<model.PermissionsList> {
+        return await this._update(request, context);
     }
 }
 
@@ -848,16 +1101,9 @@ export class MetastoresError extends ApiError {
  */
 export class MetastoresService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create an assignment.
-     *
-     * Creates a new metastore assignment. If an assignment for the same
-     * __workspace_id__ exists, it will be overwritten by the new
-     * __metastore_id__ and __default_catalog_name__. The caller must be an
-     * account admin.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async assign(
+    private async _assign(
         request: model.CreateMetastoreAssignment,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -871,12 +1117,23 @@ export class MetastoresService {
     }
 
     /**
-     * Create a metastore.
+     * Create an assignment.
      *
-     * Creates a new metastore based on a provided name and storage root path.
+     * Creates a new metastore assignment. If an assignment for the same
+     * __workspace_id__ exists, it will be overwritten by the new
+     * __metastore_id__ and __default_catalog_name__. The caller must be an
+     * account admin.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    async assign(
+        request: model.CreateMetastoreAssignment,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._assign(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
         request: model.CreateMetastore,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -890,12 +1147,20 @@ export class MetastoresService {
     }
 
     /**
-     * Get metastore assignment for workspace.
+     * Create a metastore.
      *
-     * Gets the metastore assignment for the workspace being accessed.
+     * Creates a new metastore based on a provided name and storage root path.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async current(
+    async create(
+        request: model.CreateMetastore,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _current(
         @context context?: Context
     ): Promise<model.MetastoreAssignment> {
         const path = "/api/2.1/unity-catalog/current-metastore-assignment";
@@ -908,12 +1173,19 @@ export class MetastoresService {
     }
 
     /**
-     * Delete a metastore.
+     * Get metastore assignment for workspace.
      *
-     * Deletes a metastore. The caller must be a metastore admin.
+     * Gets the metastore assignment for the workspace being accessed.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async current(
+        @context context?: Context
+    ): Promise<model.MetastoreAssignment> {
+        return await this._current(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteMetastoreRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -927,13 +1199,20 @@ export class MetastoresService {
     }
 
     /**
-     * Get a metastore.
+     * Delete a metastore.
      *
-     * Gets a metastore that matches the supplied ID. The caller must be a
-     * metastore admin to retrieve this info.
+     * Deletes a metastore. The caller must be a metastore admin.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteMetastoreRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetMetastoreRequest,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -947,6 +1226,33 @@ export class MetastoresService {
     }
 
     /**
+     * Get a metastore.
+     *
+     * Gets a metastore that matches the supplied ID. The caller must be a
+     * metastore admin to retrieve this info.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async get(
+        request: model.GetMetastoreRequest,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListMetastoresResponse> {
+        const path = "/api/2.1/unity-catalog/metastores";
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as model.ListMetastoresResponse;
+    }
+
+    /**
      * List metastores.
      *
      * Gets an array of the available metastores (as __MetastoreInfo__ objects).
@@ -957,13 +1263,20 @@ export class MetastoresService {
     async list(
         @context context?: Context
     ): Promise<model.ListMetastoresResponse> {
-        const path = "/api/2.1/unity-catalog/metastores";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _summary(
+        @context context?: Context
+    ): Promise<model.GetMetastoreSummaryResponse> {
+        const path = "/api/2.1/unity-catalog/metastore_summary";
         return (await this.client.request(
             path,
             "GET",
             undefined,
             context
-        )) as model.ListMetastoresResponse;
+        )) as model.GetMetastoreSummaryResponse;
     }
 
     /**
@@ -977,23 +1290,11 @@ export class MetastoresService {
     async summary(
         @context context?: Context
     ): Promise<model.GetMetastoreSummaryResponse> {
-        const path = "/api/2.1/unity-catalog/metastore_summary";
-        return (await this.client.request(
-            path,
-            "GET",
-            undefined,
-            context
-        )) as model.GetMetastoreSummaryResponse;
+        return await this._summary(context);
     }
 
-    /**
-     * Delete an assignment.
-     *
-     * Deletes a metastore assignment. The caller must be an account
-     * administrator.
-     */
     @withLogContext(ExposedLoggers.SDK)
-    async unassign(
+    private async _unassign(
         request: model.UnassignRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1007,13 +1308,21 @@ export class MetastoresService {
     }
 
     /**
-     * Update a metastore.
+     * Delete an assignment.
      *
-     * Updates information for a specific metastore. The caller must be a
-     * metastore admin.
+     * Deletes a metastore assignment. The caller must be an account
+     * administrator.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async update(
+    async unassign(
+        request: model.UnassignRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._unassign(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
         request: model.UpdateMetastore,
         @context context?: Context
     ): Promise<model.MetastoreInfo> {
@@ -1024,6 +1333,34 @@ export class MetastoresService {
             request,
             context
         )) as model.MetastoreInfo;
+    }
+
+    /**
+     * Update a metastore.
+     *
+     * Updates information for a specific metastore. The caller must be a
+     * metastore admin.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async update(
+        request: model.UpdateMetastore,
+        @context context?: Context
+    ): Promise<model.MetastoreInfo> {
+        return await this._update(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _updateAssignment(
+        request: model.UpdateMetastoreAssignment,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/workspaces/${request.workspace_id}/metastore`;
+        return (await this.client.request(
+            path,
+            "PATCH",
+            request,
+            context
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1040,13 +1377,7 @@ export class MetastoresService {
         request: model.UpdateMetastoreAssignment,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.1/unity-catalog/workspaces/${request.workspace_id}/metastore`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._updateAssignment(request, context);
     }
 }
 
@@ -1066,14 +1397,9 @@ export class ProvidersError extends ApiError {
  */
 export class ProvidersService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create an auth provider.
-     *
-     * Creates a new authentication provider minimally based on a name and
-     * authentication type. The caller must be an admin on the metastore.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateProvider,
         @context context?: Context
     ): Promise<model.ProviderInfo> {
@@ -1087,13 +1413,21 @@ export class ProvidersService {
     }
 
     /**
-     * Delete a provider.
+     * Create an auth provider.
      *
-     * Deletes an authentication provider, if the caller is a metastore admin or
-     * is the owner of the provider.
+     * Creates a new authentication provider minimally based on a name and
+     * authentication type. The caller must be an admin on the metastore.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateProvider,
+        @context context?: Context
+    ): Promise<model.ProviderInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteProviderRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1104,6 +1438,34 @@ export class ProvidersService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete a provider.
+     *
+     * Deletes an authentication provider, if the caller is a metastore admin or
+     * is the owner of the provider.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteProviderRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetProviderRequest,
+        @context context?: Context
+    ): Promise<model.ProviderInfo> {
+        const path = `/api/2.1/unity-catalog/providers/${request.name}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.ProviderInfo;
     }
 
     /**
@@ -1118,13 +1480,21 @@ export class ProvidersService {
         request: model.GetProviderRequest,
         @context context?: Context
     ): Promise<model.ProviderInfo> {
-        const path = `/api/2.1/unity-catalog/providers/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListProvidersRequest,
+        @context context?: Context
+    ): Promise<model.ListProvidersResponse> {
+        const path = "/api/2.1/unity-catalog/providers";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.ProviderInfo;
+        )) as model.ListProvidersResponse;
     }
 
     /**
@@ -1140,13 +1510,21 @@ export class ProvidersService {
         request: model.ListProvidersRequest,
         @context context?: Context
     ): Promise<model.ListProvidersResponse> {
-        const path = "/api/2.1/unity-catalog/providers";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _listShares(
+        request: model.ListSharesRequest,
+        @context context?: Context
+    ): Promise<model.ListProviderSharesResponse> {
+        const path = `/api/2.1/unity-catalog/providers/${request.name}/shares`;
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.ListProvidersResponse;
+        )) as model.ListProviderSharesResponse;
     }
 
     /**
@@ -1161,13 +1539,21 @@ export class ProvidersService {
         request: model.ListSharesRequest,
         @context context?: Context
     ): Promise<model.ListProviderSharesResponse> {
-        const path = `/api/2.1/unity-catalog/providers/${request.name}/shares`;
+        return await this._listShares(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateProvider,
+        @context context?: Context
+    ): Promise<model.ProviderInfo> {
+        const path = `/api/2.1/unity-catalog/providers/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
+            "PATCH",
             request,
             context
-        )) as model.ListProviderSharesResponse;
+        )) as model.ProviderInfo;
     }
 
     /**
@@ -1183,13 +1569,7 @@ export class ProvidersService {
         request: model.UpdateProvider,
         @context context?: Context
     ): Promise<model.ProviderInfo> {
-        const path = `/api/2.1/unity-catalog/providers/${request.name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.ProviderInfo;
+        return await this._update(request, context);
     }
 }
 
@@ -1209,13 +1589,9 @@ export class RecipientActivationError extends ApiError {
  */
 export class RecipientActivationService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Get a share activation URL.
-     *
-     * Gets an activation URL for a share.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async getActivationUrlInfo(
+    private async _getActivationUrlInfo(
         request: model.GetActivationUrlInfoRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1229,13 +1605,20 @@ export class RecipientActivationService {
     }
 
     /**
-     * Get an access token.
+     * Get a share activation URL.
      *
-     * Retrieve access token with an activation url. This is a public API without
-     * any authentication.
+     * Gets an activation URL for a share.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async retrieveToken(
+    async getActivationUrlInfo(
+        request: model.GetActivationUrlInfoRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._getActivationUrlInfo(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _retrieveToken(
         request: model.RetrieveTokenRequest,
         @context context?: Context
     ): Promise<model.RetrieveTokenResponse> {
@@ -1246,6 +1629,20 @@ export class RecipientActivationService {
             request,
             context
         )) as model.RetrieveTokenResponse;
+    }
+
+    /**
+     * Get an access token.
+     *
+     * Retrieve access token with an activation url. This is a public API without
+     * any authentication.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async retrieveToken(
+        request: model.RetrieveTokenRequest,
+        @context context?: Context
+    ): Promise<model.RetrieveTokenResponse> {
+        return await this._retrieveToken(request, context);
     }
 }
 
@@ -1265,15 +1662,9 @@ export class RecipientsError extends ApiError {
  */
 export class RecipientsService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a share recipient.
-     *
-     * Creates a new recipient with the delta sharing authentication type in the
-     * metastore. The caller must be a metastore admin or has the
-     * **CREATE_RECIPIENT** privilege on the metastore.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateRecipient,
         @context context?: Context
     ): Promise<model.RecipientInfo> {
@@ -1287,13 +1678,22 @@ export class RecipientsService {
     }
 
     /**
-     * Delete a share recipient.
+     * Create a share recipient.
      *
-     * Deletes the specified recipient from the metastore. The caller must be the
-     * owner of the recipient.
+     * Creates a new recipient with the delta sharing authentication type in the
+     * metastore. The caller must be a metastore admin or has the
+     * **CREATE_RECIPIENT** privilege on the metastore.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateRecipient,
+        @context context?: Context
+    ): Promise<model.RecipientInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteRecipientRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1304,6 +1704,34 @@ export class RecipientsService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete a share recipient.
+     *
+     * Deletes the specified recipient from the metastore. The caller must be the
+     * owner of the recipient.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteRecipientRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetRecipientRequest,
+        @context context?: Context
+    ): Promise<model.RecipientInfo> {
+        const path = `/api/2.1/unity-catalog/recipients/${request.name}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.RecipientInfo;
     }
 
     /**
@@ -1319,13 +1747,21 @@ export class RecipientsService {
         request: model.GetRecipientRequest,
         @context context?: Context
     ): Promise<model.RecipientInfo> {
-        const path = `/api/2.1/unity-catalog/recipients/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListRecipientsRequest,
+        @context context?: Context
+    ): Promise<model.ListRecipientsResponse> {
+        const path = "/api/2.1/unity-catalog/recipients";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.RecipientInfo;
+        )) as model.ListRecipientsResponse;
     }
 
     /**
@@ -1341,13 +1777,21 @@ export class RecipientsService {
         request: model.ListRecipientsRequest,
         @context context?: Context
     ): Promise<model.ListRecipientsResponse> {
-        const path = "/api/2.1/unity-catalog/recipients";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _rotateToken(
+        request: model.RotateRecipientToken,
+        @context context?: Context
+    ): Promise<model.RecipientInfo> {
+        const path = `/api/2.1/unity-catalog/recipients/${request.name}/rotate-token`;
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListRecipientsResponse;
+        )) as model.RecipientInfo;
     }
 
     /**
@@ -1362,13 +1806,21 @@ export class RecipientsService {
         request: model.RotateRecipientToken,
         @context context?: Context
     ): Promise<model.RecipientInfo> {
-        const path = `/api/2.1/unity-catalog/recipients/${request.name}/rotate-token`;
+        return await this._rotateToken(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _sharePermissions(
+        request: model.SharePermissionsRequest,
+        @context context?: Context
+    ): Promise<model.GetRecipientSharePermissionsResponse> {
+        const path = `/api/2.1/unity-catalog/recipients/${request.name}/share-permissions`;
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.RecipientInfo;
+        )) as model.GetRecipientSharePermissionsResponse;
     }
 
     /**
@@ -1382,13 +1834,21 @@ export class RecipientsService {
         request: model.SharePermissionsRequest,
         @context context?: Context
     ): Promise<model.GetRecipientSharePermissionsResponse> {
-        const path = `/api/2.1/unity-catalog/recipients/${request.name}/share-permissions`;
+        return await this._sharePermissions(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateRecipient,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/recipients/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
+            "PATCH",
             request,
             context
-        )) as model.GetRecipientSharePermissionsResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1404,13 +1864,7 @@ export class RecipientsService {
         request: model.UpdateRecipient,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.1/unity-catalog/recipients/${request.name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._update(request, context);
     }
 }
 
@@ -1434,15 +1888,9 @@ export class SchemasError extends ApiError {
  */
 export class SchemasService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a schema.
-     *
-     * Creates a new schema for catalog in the Metatastore. The caller must be a
-     * metastore admin, or have the **CREATE_SCHEMA** privilege in the parent
-     * catalog.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateSchema,
         @context context?: Context
     ): Promise<model.SchemaInfo> {
@@ -1456,13 +1904,22 @@ export class SchemasService {
     }
 
     /**
-     * Delete a schema.
+     * Create a schema.
      *
-     * Deletes the specified schema from the parent catalog. The caller must be
-     * the owner of the schema or an owner of the parent catalog.
+     * Creates a new schema for catalog in the Metatastore. The caller must be a
+     * metastore admin, or have the **CREATE_SCHEMA** privilege in the parent
+     * catalog.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateSchema,
+        @context context?: Context
+    ): Promise<model.SchemaInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteSchemaRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1473,6 +1930,34 @@ export class SchemasService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Delete a schema.
+     *
+     * Deletes the specified schema from the parent catalog. The caller must be
+     * the owner of the schema or an owner of the parent catalog.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async delete(
+        request: model.DeleteSchemaRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetSchemaRequest,
+        @context context?: Context
+    ): Promise<model.SchemaInfo> {
+        const path = `/api/2.1/unity-catalog/schemas/${request.full_name}`;
+        return (await this.client.request(
+            path,
+            "GET",
+            request,
+            context
+        )) as model.SchemaInfo;
     }
 
     /**
@@ -1487,13 +1972,21 @@ export class SchemasService {
         request: model.GetSchemaRequest,
         @context context?: Context
     ): Promise<model.SchemaInfo> {
-        const path = `/api/2.1/unity-catalog/schemas/${request.full_name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListSchemasRequest,
+        @context context?: Context
+    ): Promise<model.ListSchemasResponse> {
+        const path = "/api/2.1/unity-catalog/schemas";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.SchemaInfo;
+        )) as model.ListSchemasResponse;
     }
 
     /**
@@ -1511,13 +2004,21 @@ export class SchemasService {
         request: model.ListSchemasRequest,
         @context context?: Context
     ): Promise<model.ListSchemasResponse> {
-        const path = "/api/2.1/unity-catalog/schemas";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateSchema,
+        @context context?: Context
+    ): Promise<model.SchemaInfo> {
+        const path = `/api/2.1/unity-catalog/schemas/${request.full_name}`;
         return (await this.client.request(
             path,
-            "GET",
+            "PATCH",
             request,
             context
-        )) as model.ListSchemasResponse;
+        )) as model.SchemaInfo;
     }
 
     /**
@@ -1534,13 +2035,7 @@ export class SchemasService {
         request: model.UpdateSchema,
         @context context?: Context
     ): Promise<model.SchemaInfo> {
-        const path = `/api/2.1/unity-catalog/schemas/${request.full_name}`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.SchemaInfo;
+        return await this._update(request, context);
     }
 }
 
@@ -1560,15 +2055,9 @@ export class SharesError extends ApiError {
  */
 export class SharesService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Create a share.
-     *
-     * Creates a new share for data objects. Data objects can be added at this
-     * time or after creation with **update**. The caller must be a metastore
-     * admin or have the **CREATE_SHARE** privilege on the metastore.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async create(
+    private async _create(
         request: model.CreateShare,
         @context context?: Context
     ): Promise<model.ShareInfo> {
@@ -1582,13 +2071,22 @@ export class SharesService {
     }
 
     /**
-     * Delete a share.
+     * Create a share.
      *
-     * Deletes a data object share from the metastore. The caller must be an
-     * owner of the share.
+     * Creates a new share for data objects. Data objects can be added at this
+     * time or after creation with **update**. The caller must be a metastore
+     * admin or have the **CREATE_SHARE** privilege on the metastore.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async delete(
+    async create(
+        request: model.CreateShare,
+        @context context?: Context
+    ): Promise<model.ShareInfo> {
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
         request: model.DeleteShareRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -1602,13 +2100,21 @@ export class SharesService {
     }
 
     /**
-     * Get a share.
+     * Delete a share.
      *
-     * Gets a data object share from the metastore. The caller must be a
-     * metastore admin or the owner of the share.
+     * Deletes a data object share from the metastore. The caller must be an
+     * owner of the share.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async get(
+    async delete(
+        request: model.DeleteShareRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
         request: model.GetShareRequest,
         @context context?: Context
     ): Promise<model.ShareInfo> {
@@ -1622,6 +2128,33 @@ export class SharesService {
     }
 
     /**
+     * Get a share.
+     *
+     * Gets a data object share from the metastore. The caller must be a
+     * metastore admin or the owner of the share.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async get(
+        request: model.GetShareRequest,
+        @context context?: Context
+    ): Promise<model.ShareInfo> {
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<model.ListSharesResponse> {
+        const path = "/api/2.1/unity-catalog/shares";
+        return (await this.client.request(
+            path,
+            "GET",
+            undefined,
+            context
+        )) as model.ListSharesResponse;
+    }
+
+    /**
      * List shares.
      *
      * Gets an array of data object shares from the metastore. The caller must be
@@ -1630,13 +2163,21 @@ export class SharesService {
      */
     @withLogContext(ExposedLoggers.SDK)
     async list(@context context?: Context): Promise<model.ListSharesResponse> {
-        const path = "/api/2.1/unity-catalog/shares";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _sharePermissions(
+        request: model.SharePermissionsRequest,
+        @context context?: Context
+    ): Promise<model.PermissionsList> {
+        const path = `/api/2.1/unity-catalog/shares/${request.name}/permissions`;
         return (await this.client.request(
             path,
             "GET",
-            undefined,
+            request,
             context
-        )) as model.ListSharesResponse;
+        )) as model.PermissionsList;
     }
 
     /**
@@ -1650,13 +2191,21 @@ export class SharesService {
         request: model.SharePermissionsRequest,
         @context context?: Context
     ): Promise<model.PermissionsList> {
-        const path = `/api/2.1/unity-catalog/shares/${request.name}/permissions`;
+        return await this._sharePermissions(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateShare,
+        @context context?: Context
+    ): Promise<model.ShareInfo> {
+        const path = `/api/2.1/unity-catalog/shares/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
+            "PATCH",
             request,
             context
-        )) as model.PermissionsList;
+        )) as model.ShareInfo;
     }
 
     /**
@@ -1683,13 +2232,21 @@ export class SharesService {
         request: model.UpdateShare,
         @context context?: Context
     ): Promise<model.ShareInfo> {
-        const path = `/api/2.1/unity-catalog/shares/${request.name}`;
+        return await this._update(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _updatePermissions(
+        request: model.UpdateSharePermissions,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/shares/${request.name}/permissions`;
         return (await this.client.request(
             path,
             "PATCH",
             request,
             context
-        )) as model.ShareInfo;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1706,13 +2263,7 @@ export class SharesService {
         request: model.UpdateSharePermissions,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.1/unity-catalog/shares/${request.name}/permissions`;
-        return (await this.client.request(
-            path,
-            "PATCH",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._updatePermissions(request, context);
     }
 }
 
@@ -1744,6 +2295,21 @@ export class StorageCredentialsError extends ApiError {
  */
 export class StorageCredentialsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateStorageCredential,
+        @context context?: Context
+    ): Promise<model.StorageCredentialInfo> {
+        const path = "/api/2.1/unity-catalog/storage-credentials";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.StorageCredentialInfo;
+    }
+
     /**
      * Create a storage credential.
      *
@@ -1761,13 +2327,21 @@ export class StorageCredentialsService {
         request: model.CreateStorageCredential,
         @context context?: Context
     ): Promise<model.StorageCredentialInfo> {
-        const path = "/api/2.1/unity-catalog/storage-credentials";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteStorageCredentialRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/storage-credentials/${request.name}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.StorageCredentialInfo;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1781,13 +2355,21 @@ export class StorageCredentialsService {
         request: model.DeleteStorageCredentialRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetStorageCredentialRequest,
+        @context context?: Context
+    ): Promise<model.StorageCredentialInfo> {
         const path = `/api/2.1/unity-catalog/storage-credentials/${request.name}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.StorageCredentialInfo;
     }
 
     /**
@@ -1802,13 +2384,20 @@ export class StorageCredentialsService {
         request: model.GetStorageCredentialRequest,
         @context context?: Context
     ): Promise<model.StorageCredentialInfo> {
-        const path = `/api/2.1/unity-catalog/storage-credentials/${request.name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        @context context?: Context
+    ): Promise<Array<model.StorageCredentialInfo>> {
+        const path = "/api/2.1/unity-catalog/storage-credentials";
         return (await this.client.request(
             path,
             "GET",
-            request,
+            undefined,
             context
-        )) as model.StorageCredentialInfo;
+        )) as Array<model.StorageCredentialInfo>;
     }
 
     /**
@@ -1824,13 +2413,21 @@ export class StorageCredentialsService {
     async list(
         @context context?: Context
     ): Promise<Array<model.StorageCredentialInfo>> {
-        const path = "/api/2.1/unity-catalog/storage-credentials";
+        return await this._list(context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _update(
+        request: model.UpdateStorageCredential,
+        @context context?: Context
+    ): Promise<model.StorageCredentialInfo> {
+        const path = `/api/2.1/unity-catalog/storage-credentials/${request.name}`;
         return (await this.client.request(
             path,
-            "GET",
-            undefined,
+            "PATCH",
+            request,
             context
-        )) as Array<model.StorageCredentialInfo>;
+        )) as model.StorageCredentialInfo;
     }
 
     /**
@@ -1845,13 +2442,21 @@ export class StorageCredentialsService {
         request: model.UpdateStorageCredential,
         @context context?: Context
     ): Promise<model.StorageCredentialInfo> {
-        const path = `/api/2.1/unity-catalog/storage-credentials/${request.name}`;
+        return await this._update(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _validate(
+        request: model.ValidateStorageCredential,
+        @context context?: Context
+    ): Promise<model.ValidateStorageCredentialResponse> {
+        const path = "/api/2.1/unity-catalog/validate-storage-credentials";
         return (await this.client.request(
             path,
-            "PATCH",
+            "POST",
             request,
             context
-        )) as model.StorageCredentialInfo;
+        )) as model.ValidateStorageCredentialResponse;
     }
 
     /**
@@ -1875,13 +2480,7 @@ export class StorageCredentialsService {
         request: model.ValidateStorageCredential,
         @context context?: Context
     ): Promise<model.ValidateStorageCredentialResponse> {
-        const path = "/api/2.1/unity-catalog/validate-storage-credentials";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.ValidateStorageCredentialResponse;
+        return await this._validate(request, context);
     }
 }
 
@@ -1913,6 +2512,21 @@ export class TableConstraintsError extends ApiError {
  */
 export class TableConstraintsService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _create(
+        request: model.CreateTableConstraint,
+        @context context?: Context
+    ): Promise<model.TableConstraint> {
+        const path = "/api/2.1/unity-catalog/constraints";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.TableConstraint;
+    }
+
     /**
      * Create a table constraint.
      *
@@ -1932,13 +2546,21 @@ export class TableConstraintsService {
         request: model.CreateTableConstraint,
         @context context?: Context
     ): Promise<model.TableConstraint> {
-        const path = "/api/2.1/unity-catalog/constraints";
+        return await this._create(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteTableConstraintRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/constraints/${request.full_name}`;
         return (await this.client.request(
             path,
-            "POST",
+            "DELETE",
             request,
             context
-        )) as model.TableConstraint;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -1960,13 +2582,7 @@ export class TableConstraintsService {
         request: model.DeleteTableConstraintRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = `/api/2.1/unity-catalog/constraints/${request.full_name}`;
-        return (await this.client.request(
-            path,
-            "DELETE",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._delete(request, context);
     }
 }
 
@@ -1994,6 +2610,21 @@ export class TablesError extends ApiError {
  */
 export class TablesService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.DeleteTableRequest,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = `/api/2.1/unity-catalog/tables/${request.full_name}`;
+        return (await this.client.request(
+            path,
+            "DELETE",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
     /**
      * Delete a table.
      *
@@ -2008,13 +2639,21 @@ export class TablesService {
         request: model.DeleteTableRequest,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _get(
+        request: model.GetTableRequest,
+        @context context?: Context
+    ): Promise<model.TableInfo> {
         const path = `/api/2.1/unity-catalog/tables/${request.full_name}`;
         return (await this.client.request(
             path,
-            "DELETE",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.TableInfo;
     }
 
     /**
@@ -2031,13 +2670,21 @@ export class TablesService {
         request: model.GetTableRequest,
         @context context?: Context
     ): Promise<model.TableInfo> {
-        const path = `/api/2.1/unity-catalog/tables/${request.full_name}`;
+        return await this._get(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.ListTablesRequest,
+        @context context?: Context
+    ): Promise<model.ListTablesResponse> {
+        const path = "/api/2.1/unity-catalog/tables";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.TableInfo;
+        )) as model.ListTablesResponse;
     }
 
     /**
@@ -2055,13 +2702,21 @@ export class TablesService {
         request: model.ListTablesRequest,
         @context context?: Context
     ): Promise<model.ListTablesResponse> {
-        const path = "/api/2.1/unity-catalog/tables";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _listSummaries(
+        request: model.ListSummariesRequest,
+        @context context?: Context
+    ): Promise<model.ListTableSummariesResponse> {
+        const path = "/api/2.1/unity-catalog/table-summaries";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.ListTablesResponse;
+        )) as model.ListTableSummariesResponse;
     }
 
     /**
@@ -2085,12 +2740,6 @@ export class TablesService {
         request: model.ListSummariesRequest,
         @context context?: Context
     ): Promise<model.ListTableSummariesResponse> {
-        const path = "/api/2.1/unity-catalog/table-summaries";
-        return (await this.client.request(
-            path,
-            "GET",
-            request,
-            context
-        )) as model.ListTableSummariesResponse;
+        return await this._listSummaries(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/workspace/api.ts
+++ b/packages/databricks-sdk-js/src/apis/workspace/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class WorkspaceRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -31,6 +32,21 @@ export class WorkspaceError extends ApiError {
  */
 export class WorkspaceService {
     constructor(readonly client: ApiClient) {}
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _delete(
+        request: model.Delete,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/workspace/delete";
+        return (await this.client.request(
+            path,
+            "POST",
+            request,
+            context
+        )) as model.EmptyResponse;
+    }
+
     /**
      * Delete a workspace object.
      *
@@ -48,13 +64,21 @@ export class WorkspaceService {
         request: model.Delete,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/workspace/delete";
+        return await this._delete(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _export(
+        request: model.Export,
+        @context context?: Context
+    ): Promise<model.ExportResponse> {
+        const path = "/api/2.0/workspace/export";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.ExportResponse;
     }
 
     /**
@@ -74,13 +98,21 @@ export class WorkspaceService {
         request: model.Export,
         @context context?: Context
     ): Promise<model.ExportResponse> {
-        const path = "/api/2.0/workspace/export";
+        return await this._export(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _getStatus(
+        request: model.GetStatus,
+        @context context?: Context
+    ): Promise<model.ObjectInfo> {
+        const path = "/api/2.0/workspace/get-status";
         return (await this.client.request(
             path,
             "GET",
             request,
             context
-        )) as model.ExportResponse;
+        )) as model.ObjectInfo;
     }
 
     /**
@@ -94,13 +126,21 @@ export class WorkspaceService {
         request: model.GetStatus,
         @context context?: Context
     ): Promise<model.ObjectInfo> {
-        const path = "/api/2.0/workspace/get-status";
+        return await this._getStatus(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _import(
+        request: model.Import,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/workspace/import";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ObjectInfo;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -116,13 +156,21 @@ export class WorkspaceService {
         request: model.Import,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/workspace/import";
+        return await this._import(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _list(
+        request: model.List,
+        @context context?: Context
+    ): Promise<model.ListResponse> {
+        const path = "/api/2.0/workspace/list";
         return (await this.client.request(
             path,
-            "POST",
+            "GET",
             request,
             context
-        )) as model.EmptyResponse;
+        )) as model.ListResponse;
     }
 
     /**
@@ -137,13 +185,21 @@ export class WorkspaceService {
         request: model.List,
         @context context?: Context
     ): Promise<model.ListResponse> {
-        const path = "/api/2.0/workspace/list";
+        return await this._list(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _mkdirs(
+        request: model.Mkdirs,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        const path = "/api/2.0/workspace/mkdirs";
         return (await this.client.request(
             path,
-            "GET",
+            "POST",
             request,
             context
-        )) as model.ListResponse;
+        )) as model.EmptyResponse;
     }
 
     /**
@@ -161,12 +217,6 @@ export class WorkspaceService {
         request: model.Mkdirs,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
-        const path = "/api/2.0/workspace/mkdirs";
-        return (await this.client.request(
-            path,
-            "POST",
-            request,
-            context
-        )) as model.EmptyResponse;
+        return await this._mkdirs(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/apis/workspaceconf/api.ts
+++ b/packages/databricks-sdk-js/src/apis/workspaceconf/api.ts
@@ -10,6 +10,7 @@ import {CancellationToken} from "../../types";
 import {ApiError, ApiRetriableError} from "../apiError";
 import {context, Context} from "../../context";
 import {ExposedLoggers, withLogContext} from "../../logging";
+import {Waiter, asWaiter} from "../../wait";
 
 export class WorkspaceConfRetriableError extends ApiRetriableError {
     constructor(method: string, message?: string) {
@@ -27,13 +28,9 @@ export class WorkspaceConfError extends ApiError {
  */
 export class WorkspaceConfService {
     constructor(readonly client: ApiClient) {}
-    /**
-     * Check configuration status.
-     *
-     * Gets the configuration status for a workspace.
-     */
+
     @withLogContext(ExposedLoggers.SDK)
-    async getStatus(
+    private async _getStatus(
         request: model.GetStatus,
         @context context?: Context
     ): Promise<model.WorkspaceConf> {
@@ -47,13 +44,20 @@ export class WorkspaceConfService {
     }
 
     /**
-     * Enable/disable features.
+     * Check configuration status.
      *
-     * Sets the configuration status for a workspace, including enabling or
-     * disabling it.
+     * Gets the configuration status for a workspace.
      */
     @withLogContext(ExposedLoggers.SDK)
-    async setStatus(
+    async getStatus(
+        request: model.GetStatus,
+        @context context?: Context
+    ): Promise<model.WorkspaceConf> {
+        return await this._getStatus(request, context);
+    }
+
+    @withLogContext(ExposedLoggers.SDK)
+    private async _setStatus(
         request: model.WorkspaceConf,
         @context context?: Context
     ): Promise<model.EmptyResponse> {
@@ -64,5 +68,19 @@ export class WorkspaceConfService {
             request,
             context
         )) as model.EmptyResponse;
+    }
+
+    /**
+     * Enable/disable features.
+     *
+     * Sets the configuration status for a workspace, including enabling or
+     * disabling it.
+     */
+    @withLogContext(ExposedLoggers.SDK)
+    async setStatus(
+        request: model.WorkspaceConf,
+        @context context?: Context
+    ): Promise<model.EmptyResponse> {
+        return await this._setStatus(request, context);
     }
 }

--- a/packages/databricks-sdk-js/src/services/Cluster.ts
+++ b/packages/databricks-sdk-js/src/services/Cluster.ts
@@ -269,20 +269,21 @@ export class Cluster {
         token?: CancellationToken,
         onProgress?: (newPollResponse: ClusterInfo) => Promise<void>
     ) {
-        this.details = await this.clusterApi.deleteAndWait(
-            {
-                cluster_id: this.id,
-            },
-            {
-                onProgress: async (clusterInfo) => {
-                    this.details = clusterInfo;
-                    if (onProgress) {
-                        await onProgress(clusterInfo);
-                    }
+        this.details = await (
+            await this.clusterApi.delete(
+                {
+                    cluster_id: this.id,
                 },
+                new Context({cancellationToken: token})
+            )
+        ).wait({
+            onProgress: async (clusterInfo) => {
+                this.details = clusterInfo;
+                if (onProgress) {
+                    await onProgress(clusterInfo);
+                }
             },
-            new Context({cancellationToken: token})
-        );
+        });
     }
 
     async createExecutionContext(

--- a/packages/databricks-sdk-js/src/services/ExecutionContext.ts
+++ b/packages/databricks-sdk-js/src/services/ExecutionContext.ts
@@ -23,10 +23,12 @@ export class ExecutionContext {
         language: Language = "python"
     ): Promise<ExecutionContext> {
         const context = new ExecutionContext(client, cluster, language);
-        const response = await context.executionContextApi.createAndWait({
-            clusterId: context.cluster.id,
-            language: context.language,
-        });
+        const response = await (
+            await context.executionContextApi.create({
+                clusterId: context.cluster.id,
+                language: context.language,
+            })
+        ).wait();
 
         context.id = response.id;
         return context;

--- a/packages/databricks-sdk-js/src/wait.ts
+++ b/packages/databricks-sdk-js/src/wait.ts
@@ -1,0 +1,33 @@
+import Time from "./retries/Time";
+
+export interface AndWait<P> {
+    wait(options?: {
+        onProgress?: ProgressCallback<P>;
+        timeout?: Time;
+    }): Promise<P>;
+}
+
+export type ProgressCallback<P> = (p: P) => Promise<void>;
+export type Waiter<C, P> = C & AndWait<P>;
+
+/**
+ * Takes an API response object and adds a wait method that polls
+ * the API until the response is ready.
+ *
+ * This function is used for long running operations that complete
+ * asynchronously.
+ */
+export function asWaiter<C, P>(
+    response: C,
+    poll: (options?: {
+        onProgress?: ProgressCallback<P>;
+        timeout?: Time;
+    }) => Promise<P>
+): Waiter<C, P> {
+    return {
+        ...response,
+        wait: async (options) => {
+            return await poll(options);
+        },
+    };
+}


### PR DESCRIPTION
## Changes
Use waiter to handle long running calls inspired by the Python SDK.

Previously we had two functions for long running operations:

- `cluster.create(): Promise<CreateClusterResponse>`
- `cluster.createAndWait(): Promise<ClusterInfo>`

where the first would just make the API call to trigger the creation and the second function would wait for completion and return the result of the last polling operation.

This change collapses these two function into one:

```create(...): Promise<Waiter<CreateClusterResponse, ClusterInfo>>```

The returned waiter is compatible with the return value of the previous `create` call. If users want to wait they can call `.wait()` on the return value, which will be equivalent to the `createAndWait` call.

## Example

```typescript
        this.details = await (
            await this.clusterApi.delete(
                {
                    cluster_id: this.id,
                },
                new Context({cancellationToken: token})
            )
        ).wait({
            onProgress: async (clusterInfo) => {
                this.details = clusterInfo;
                if (onProgress) {
                    await onProgress(clusterInfo);
                }
            },
        });
```

