### PR TITLE
Use minimum supported vscode version (from package.json) for integration tests

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -6,7 +6,7 @@
     "license": "LicenseRef-LICENSE",
     "version": "0.3.7",
     "engines": {
-        "vscode": "^1.69.1"
+        "vscode": "^1.76.0"
     },
     "categories": [
         "Data Science",

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -12,7 +12,7 @@ import {initialiseCustomCommands} from "./customCommands";
 import {execFile, ExecFileOptions} from "node:child_process";
 import {mkdirSync} from "node:fs";
 import {tmpdir} from "node:os";
-import {version, name} from "../../../package.json";
+import {version, name, engines} from "../../../package.json";
 import {sleep} from "wdio-vscode-service";
 
 const WORKSPACE_PATH = path.resolve(__dirname, "workspace");
@@ -103,7 +103,7 @@ export const config: Options.Testrunner = {
         return [
             {
                 "browserName": "vscode",
-                "browserVersion": "1.71.1",
+                "browserVersion": engines.vscode.replace("^", ""),
                 "wdio:vscodeOptions": {
                     extensionPath: path.resolve(
                         __dirname,


### PR DESCRIPTION
## Changes
* Also bump our minimum supported vscode version. This is because the latest ms-python release breaks on older versions of vscode. 

