### PR TITLE
[DECO-669] Instrument extension activation & connection state changes 

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -90,7 +90,6 @@ export async function activate(
     }
 
     const telemetry = Telemetry.createDefault();
-    telemetry.recordEvent(Events.EXTENSION_ACTIVATED);
 
     const packageMetadata = await PackageJsonUtils.getMetadata(context);
     NamedLogger.getOrCreate(Loggers.Extension).debug("Metadata", {
@@ -449,6 +448,7 @@ export async function activate(
     });
 
     CustomWhenContext.setActivated(true);
+    telemetry.recordEvent(Events.EXTENSION_ACTIVATED);
     return {
         connectionManager: connectionManager,
     };

--- a/packages/databricks-vscode/src/telemetry/index.ts
+++ b/packages/databricks-vscode/src/telemetry/index.ts
@@ -3,7 +3,7 @@ import {DatabricksWorkspace} from "../configuration/DatabricksWorkspace";
 import {isDevExtension} from "../utils/developmentUtils";
 import {
     DEV_APP_INSIGHTS_CONFIGURATION_STRING,
-    EventType,
+    EventProperties,
     EventTypes,
     ExtraMetadata,
     Metadata,
@@ -110,7 +110,7 @@ export class Telemetry {
      */
     recordEvent<E extends keyof EventTypes>(
         eventName: E,
-        propsAndMetrics?: EventTypes[E] extends EventType<infer R> ? R : never
+        propsAndMetrics?: EventProperties[E]
     ) {
         // If telemetry reporter cannot be initialized, don't report the event.
         if (!this.reporter) {


### PR DESCRIPTION
## Changes
This PR instruments extension activation and connection state changes. No additional metadata is tracked during activation, whereas the new state is tracked during connection state changes.

Additionally, this PR extends support for events with no additional metadata. When defining such events, use `undefined` as the type parameter.

## Tests
- [x] Manual tests: started the extension in dev mode & saw the expected logs appear in the log analytics workspace.
<img width="866" alt="Screenshot 2023-04-12 at 13 25 56" src="https://user-images.githubusercontent.com/1850319/231443889-b045285d-20d9-455e-9dc3-5b7c890bb90f.png">
<img width="834" alt="Screenshot 2023-04-12 at 13 26 07" src="https://user-images.githubusercontent.com/1850319/231443893-9cc6e84b-bfb7-499f-acd7-d6e7175d91f8.png">
