### PR TITLE
Treat cluster in RESIZING state as running clusters

### DIFF
--- a/packages/databricks-vscode/src/cluster/ClusterListDataProvider.ts
+++ b/packages/databricks-vscode/src/cluster/ClusterListDataProvider.ts
@@ -72,13 +72,13 @@ export class ClusterListDataProvider
     public static clusterNodeToTreeItem(element: Cluster): TreeItem {
         let icon: ThemeIcon;
         switch (element.state) {
+            case "RESIZING":
             case "RUNNING":
                 icon = new ThemeIcon("debug-start");
                 break;
 
             case "RESTARTING":
             case "PENDING":
-            case "RESIZING":
                 icon = new ThemeIcon("debug-restart");
                 break;
 

--- a/packages/databricks-vscode/src/configuration/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ConfigurationDataProvider.ts
@@ -98,11 +98,11 @@ export class ConfigurationDataProvider
                     "databricks.cluster.terminated";
 
                 switch (cluster.state) {
+                    case "RESIZING":
                     case "RUNNING":
                         contextValue = "databricks.cluster.running";
                         break;
                     case "PENDING":
-                    case "RESIZING":
                     case "RESTARTING":
                         contextValue = "databricks.cluster.pending";
                         break;

--- a/packages/databricks-vscode/src/run/DatabricksRuntime.ts
+++ b/packages/databricks-vscode/src/run/DatabricksRuntime.ts
@@ -27,7 +27,6 @@ import {parseErrorResult} from "./ErrorParser";
 import path from "node:path";
 import {WorkspaceFsAccessVerifier} from "../workspace-fs";
 import {Time, TimeUnits} from "@databricks/databricks-sdk";
-import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 export interface OutputEvent {
     type: "prio" | "out" | "err";
@@ -132,9 +131,7 @@ export class DatabricksRuntime implements Disposable {
             }
 
             await this.wsfsAccessVerifier.verifyCluster(cluster);
-            if (workspaceConfigs.syncDestinationType === "workspace") {
-                await this.wsfsAccessVerifier.switchIfNotEnabled();
-            }
+            await this.wsfsAccessVerifier.verifyWorkspaceConfigs();
             const isClusterRunning = await promptForClusterStart(
                 cluster,
                 async () => {

--- a/packages/databricks-vscode/src/run/DatabricksWorkflowDebugAdapter.ts
+++ b/packages/databricks-vscode/src/run/DatabricksWorkflowDebugAdapter.ts
@@ -27,7 +27,6 @@ import {CodeSynchronizer} from "../sync/CodeSynchronizer";
 import {LocalUri} from "../sync/SyncDestination";
 import {WorkspaceFsAccessVerifier} from "../workspace-fs";
 import {isNotebook} from "../utils";
-import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 /**
  * This interface describes the mock-debug specific launch attributes
@@ -192,9 +191,7 @@ export class DatabricksWorkflowDebugSession extends LoggingDebugSession {
 
         await cluster.refresh();
         await this.wsfsAccessVerifier.verifyCluster(cluster);
-        if (workspaceConfigs.syncDestinationType === "workspace") {
-            await this.wsfsAccessVerifier.switchIfNotEnabled();
-        }
+        await this.wsfsAccessVerifier.verifyWorkspaceConfigs();
         const isClusterRunning = await promptForClusterStart(
             cluster,
             async () => {

--- a/packages/databricks-vscode/src/run/prompts.ts
+++ b/packages/databricks-vscode/src/run/prompts.ts
@@ -6,7 +6,7 @@ export async function promptForClusterStart(
     onReject: () => Promise<void>,
     onAccept: () => Promise<void> = async () => {}
 ) {
-    if (cluster.state !== "RUNNING") {
+    if (["RUNNING", "RESIZING"].includes(cluster.state)) {
         const response = await window.showErrorMessage(
             "The attached cluster is not running.",
             "Start Cluster",

--- a/packages/databricks-vscode/src/run/prompts.ts
+++ b/packages/databricks-vscode/src/run/prompts.ts
@@ -6,7 +6,7 @@ export async function promptForClusterStart(
     onReject: () => Promise<void>,
     onAccept: () => Promise<void> = async () => {}
 ) {
-    if (["RUNNING", "RESIZING"].includes(cluster.state)) {
+    if (!["RUNNING", "RESIZING"].includes(cluster.state)) {
         const response = await window.showErrorMessage(
             "The attached cluster is not running.",
             "Start Cluster",

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsAccessVerifier.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsAccessVerifier.ts
@@ -32,7 +32,7 @@ export class WorkspaceFsAccessVerifier implements Disposable {
             }),
             this._connectionManager.onDidChangeState(async (state) => {
                 if (state === "CONNECTED") {
-                    await this.switchIfNotEnabled();
+                    await this.verifyWorkspaceConfigs();
                 } else {
                     this._isEnabled = undefined;
                 }
@@ -92,7 +92,7 @@ export class WorkspaceFsAccessVerifier implements Disposable {
         }
     }
 
-    async isEnabledForWorkspace() {
+    private async isEnabledForWorkspace() {
         if (this._connectionManager.state === "DISCONNECTED") {
             return false;
         }
@@ -136,7 +136,7 @@ export class WorkspaceFsAccessVerifier implements Disposable {
         return this._isEnabled;
     }
 
-    async switchIfNotEnabled() {
+    async verifyWorkspaceConfigs() {
         if (
             workspaceConfigs.enableFilesInWorkspace &&
             !(await this.isEnabledForWorkspace())


### PR DESCRIPTION
## Changes
* Clusters in RESIZING state should allow execution to be queued on them. They should be treated same as RUNNING clusters. This PR makes it so.
 
fixes #618
