### PR TITLE
Prepend cwd to PYTHONPATH so that local changes take precedence over installed libraries

### DIFF
--- a/packages/databricks-vscode/CHANGELOG.md
+++ b/packages/databricks-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## <small>0.3.10 (2023-04-20)</small>
 
--   Fix: Method for finding installed python packages was failing on windows. 
+-   Fix: Method for finding installed python packages was failing on windows.
 
 # Release: v0.3.9
 

--- a/packages/databricks-vscode/resources/python/bootstrap.py
+++ b/packages/databricks-vscode/resources/python/bootstrap.py
@@ -12,8 +12,8 @@ env = {}
 os.chdir(os.path.dirname(python_file))
 
 # update python path
-sys.path.append(repo_path)
-sys.path.append(os.path.dirname(python_file))
+sys.path.insert(0, repo_path)
+sys.path.insert(0, os.path.dirname(python_file))
 
 # inject command line arguments
 sys.argv = args

--- a/packages/databricks-vscode/resources/python/file.workflow-wrapper.py
+++ b/packages/databricks-vscode/resources/python/file.workflow-wrapper.py
@@ -29,7 +29,7 @@ sys.argv = [value for i,value in enumerate(sys.argv) if i not in databricks_arg_
 os.chdir(os.path.dirname(python_file))
 
 # update python path
-sys.path.append(project_root)
+sys.path.insert(0, project_root)
 
 # provide spark globals
 user_ns = {

--- a/packages/databricks-vscode/resources/python/notebook.workflow-wrapper.py
+++ b/packages/databricks-vscode/resources/python/notebook.workflow-wrapper.py
@@ -9,4 +9,4 @@ if dbutils.widgets.get("DATABRICKS_SOURCE_FILE") != "":
 
 if dbutils.widgets.get("DATABRICKS_PROJECT_ROOT") != "":
 	import sys
-	sys.path.append(dbutils.widgets.get("DATABRICKS_PROJECT_ROOT"))
+	sys.path.insert(0, dbutils.widgets.get("DATABRICKS_PROJECT_ROOT"))


### PR DESCRIPTION
## Issue
When running code using context-exection, we append the `cwd` to the **end** of `sys.path`. This means that local code has lower priority than the installed library, when python is resolving imports ([for Regular Python Packages only - the ones with __init__.py](https://docs.python.org/3/reference/import.html#regular-packages)). When running the same code from webui (or using "Run File as Workflow on Databricks"), the `cwd` is automatically added to `sys.path` **before** library paths. Hence the local changes take precedence.

## Changes
- Prepend `cwd` and `repo path` to `sys.path` instead of append.

## Tests
- manual

Fixes #673 
