### PR TITLE
Update telemetry connection strings

### DIFF
--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -1,7 +1,8 @@
 import {AuthType} from "../configuration/auth/AuthProvider";
 
 /** The production application insights configuration string for Databricks. */
-export const PROD_APP_INSIGHTS_CONFIGURATION_STRING = "";
+export const PROD_APP_INSIGHTS_CONFIGURATION_STRING =
+    "InstrumentationKey=ebe191c5-f06b-4189-b68c-34fb5fbdb3f0;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";
 /** The application insights configuration string used while developing on the VS Code extension */
 export const DEV_APP_INSIGHTS_CONFIGURATION_STRING =
     "InstrumentationKey=257d1561-5005-4a76-a3a8-7955df129e86;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -4,7 +4,7 @@ import {AuthType} from "../configuration/auth/AuthProvider";
 export const PROD_APP_INSIGHTS_CONFIGURATION_STRING = "";
 /** The application insights configuration string used while developing on the VS Code extension */
 export const DEV_APP_INSIGHTS_CONFIGURATION_STRING =
-    "InstrumentationKey=ae4b0735-b53b-409a-97d2-d77b6ec584a2;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";
+    "InstrumentationKey=257d1561-5005-4a76-a3a8-7955df129e86;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";
 
 /** The list of all events which can be monitored. */
 /* eslint-disable @typescript-eslint/naming-convention */


### PR DESCRIPTION
## Changes
This PR updates the connection string for Application Insights for the telemetry collection of the extension.

## Tests
- [x] When using the Run Extension launch configuration without change, telemetry is uploaded to our development Application Insights instance.
- [x] Manually removed the `EXTENSION_DEVELOPMENT` environment variable from the Run Extension launch configuration and verified that the new telemetry was uploaded to our production Application Insights instance.

