### PR TITLE
Gracefully handle virtual /Repos/me folder

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -106,7 +106,7 @@ export class ConnectionManager {
         try {
             await this._login(interactive, force);
         } catch (e) {
-            NamedLogger.getOrCreate("Extension").error("Login Error", e);
+            NamedLogger.getOrCreate("Extension").error("Login Error:", e);
             if (interactive && e instanceof Error) {
                 window.showErrorMessage(`Login error: ${e.message}`);
             }

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -107,8 +107,8 @@ export class ConnectionManager {
             await this._login(interactive, force);
         } catch (e) {
             NamedLogger.getOrCreate("Extension").error("Login Error", e);
-            if (interactive) {
-                window.showErrorMessage(`Login error ${JSON.stringify(e)}`);
+            if (interactive && e instanceof Error) {
+                window.showErrorMessage(`Login error: ${e.message}`);
             }
             this.updateState("DISCONNECTED");
             await this.logout();
@@ -220,44 +220,39 @@ export class ConnectionManager {
             this.updateSyncDestination(undefined);
         }
 
-        if (
-            this.databricksWorkspace &&
-            (workspaceConfigs.enableFilesInWorkspace ||
-                this.workspaceState.wsfsFeatureFlag)
-        ) {
-            await this.createRootDirectory(
-                workspaceClient,
-                this.databricksWorkspace.currentFsRoot,
-                this.databricksWorkspace.userName
-            );
-        }
-
+        await this.createWsFsRootDirectory(workspaceClient);
         this.updateState("CONNECTED");
     }
 
-    async createRootDirectory(
-        wsClient: WorkspaceClient,
-        rootDirPath: RemoteUri,
-        me: string
-    ) {
+    async createWsFsRootDirectory(wsClient: WorkspaceClient) {
+        if (
+            !this.databricksWorkspace ||
+            !(
+                workspaceConfigs.enableFilesInWorkspace ||
+                this.workspaceState.wsfsFeatureFlag
+            )
+        ) {
+            return;
+        }
+        const rootDirPath = this.databricksWorkspace.workspaceFsRoot;
+        const me = this.databricksWorkspace.userName;
         let rootDir = await WorkspaceFsEntity.fromPath(
             wsClient,
             rootDirPath.path
         );
+        if (rootDir) {
+            return;
+        }
+        const meDir = await WorkspaceFsEntity.fromPath(
+            wsClient,
+            `/Users/${me}`
+        );
+        if (WorkspaceFsUtils.isDirectory(meDir)) {
+            rootDir = await meDir.mkdir(rootDirPath.path);
+        }
         if (!rootDir) {
-            const meDir = await WorkspaceFsEntity.fromPath(
-                wsClient,
-                `/Users/${me}`
-            );
-            if (WorkspaceFsUtils.isDirectory(meDir)) {
-                rootDir = await meDir.mkdir(rootDirPath.path);
-            }
-            if (!rootDir) {
-                window.showErrorMessage(
-                    `Can't find or create ${rootDirPath.path}`
-                );
-                return;
-            }
+            window.showErrorMessage(`Can't find or create ${rootDirPath.path}`);
+            return;
         }
     }
 


### PR DESCRIPTION
## Changes
The extension tries to find the root folder (/Repos/me or /Users/me/.ide) depending on what the sync destination type is (repos or workspace). The current root is stored in `currentFsRoot`. In case it fails in finding the `currentFsRoot` (/Repos/me and /Users/me can be virtual when a user hasn't interacted with these folders yet), it always tries to create it under /User/me. This can be an issue if `currentFsRoot` points to /Repos/me. 

* This PR fixes this behaviour, by only allowing creation of `workspaceFsRoot` (which always points to /Users/me/.ide) under /User/me and not `currentFsRoot`. 
* Also fix error reporting to show more verbose errors.

Creating a repo from the extension automatically handles generation of /Repos/me folder as well. 

Fixes #683  #691 #688 

## Tests
* Manually verified to work after the change.
