### PR TITLE
Fix DATABRICKS_AUTH_TYPE export and telemetry error handling

### DIFF
--- a/packages/databricks-vscode/src/cluster/ClusterCommands.ts
+++ b/packages/databricks-vscode/src/cluster/ClusterCommands.ts
@@ -13,10 +13,8 @@ export class ClusterCommands {
     /**
      * Refresh cluster tree view by reloading them throug the API
      */
-    refreshCommand() {
-        return () => {
-            this.clusterModel.refresh();
-        };
+    async refreshCommand() {
+        this.clusterModel.refresh();
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -66,16 +66,12 @@ export class ConnectionCommands implements Disposable {
     /**
      * Disconnect from Databricks and reset project settings.
      */
-    logoutCommand() {
-        return () => {
-            this.connectionManager.logout();
-        };
+    async logoutCommand() {
+        this.connectionManager.logout();
     }
 
-    configureWorkspaceCommand() {
-        return () => {
-            this.connectionManager.configureWorkspace();
-        };
+    async configureWorkspaceCommand() {
+        await this.connectionManager.configureWorkspace();
     }
 
     openDatabricksConfigFileCommand() {
@@ -327,10 +323,8 @@ export class ConnectionCommands implements Disposable {
     /**
      * Set workspace to undefined and remove workspace path from settings file.
      */
-    detachWorkspaceCommand() {
-        return () => {
-            this.connectionManager.detachSyncDestination();
-        };
+    async detachWorkspaceCommand() {
+        this.connectionManager.detachSyncDestination();
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -113,7 +113,6 @@ export class ProfileAuthProvider extends AuthProvider {
     toEnv(): Record<string, string> {
         return {
             DATABRICKS_HOST: this.host.toString(),
-            DATABRICKS_AUTH_TYPE: this.authType,
             DATABRICKS_CONFIG_PROFILE: this.profile,
         };
     }
@@ -157,7 +156,7 @@ export class DatabricksCliAuthProvider extends AuthProvider {
     toEnv(): Record<string, string> {
         return {
             DATABRICKS_HOST: this.host.toString(),
-            DATABRICKS_AUTH_TYPE: this.authType,
+            DATABRICKS_AUTH_TYPE: "databricks-cli",
             DATABRICKS_CLI_PATH: this.databricksPath,
         };
     }
@@ -212,7 +211,7 @@ export class AzureCliAuthProvider extends AuthProvider {
     toEnv(): Record<string, string> {
         const envVars: Record<string, string> = {
             DATABRICKS_HOST: this.host.toString(),
-            DATABRICKS_AUTH_TYPE: this.authType,
+            DATABRICKS_AUTH_TYPE: "azure-cli",
         };
         if (this.appId) {
             envVars["DATABRICKS_AZURE_LOGIN_APP_ID"] = this.appId;

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -270,12 +270,12 @@ export async function activate(
         ),
         telemetry.registerCommand(
             "databricks.connection.logout",
-            connectionCommands.logoutCommand(),
+            connectionCommands.logoutCommand,
             connectionCommands
         ),
         telemetry.registerCommand(
             "databricks.connection.configureWorkspace",
-            connectionCommands.configureWorkspaceCommand(),
+            connectionCommands.configureWorkspaceCommand,
             connectionCommands
         ),
         telemetry.registerCommand(
@@ -305,7 +305,7 @@ export async function activate(
         ),
         telemetry.registerCommand(
             "databricks.connection.detachSyncDestination",
-            connectionCommands.detachWorkspaceCommand(),
+            connectionCommands.detachWorkspaceCommand,
             connectionCommands
         )
     );
@@ -359,7 +359,7 @@ export async function activate(
 
         telemetry.registerCommand(
             "databricks.cluster.refresh",
-            clusterCommands.refreshCommand(),
+            clusterCommands.refreshCommand,
             clusterCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/telemetry/commandExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/commandExtensions.ts
@@ -1,5 +1,5 @@
 import {Events, Telemetry} from ".";
-import {commands, Disposable} from "vscode";
+import {commands, Disposable, window} from "vscode";
 
 declare module "." {
     interface Telemetry {
@@ -24,14 +24,16 @@ Telemetry.prototype.registerCommand = function (
 ) {
     return commands.registerCommand(
         command,
-        (...args) => {
+        async (...args) => {
             const start = performance.now();
             let success = true;
             try {
-                return callback.call(thisArg, ...args);
+                return await Promise.resolve(callback.call(thisArg, ...args));
             } catch (e: any) {
                 success = false;
-                throw e;
+                window.showErrorMessage(
+                    `Error running command ${command}: ${e.message}`
+                );
             } finally {
                 const end = performance.now();
                 this.recordEvent(Events.COMMAND_EXECUTION, {


### PR DESCRIPTION
## Changes
* DATABRICKS_AUTH_TYPE was being incorrectly exported, leading authentication errors in python SDK.
* Errors thrown by commands were being routed to `telemetry.sendError` which is not supported by our telemetry library. This lead to huge error noise. Now any errors will be shown as a small popup. 

## Tests
* manula
