### PR TITLE
IDE: Allow profiles with AWS OAuth and Azure Client Secret auth

### DIFF
--- a/packages/databricks-vscode/src/configuration/configureWorkspaceWizard.ts
+++ b/packages/databricks-vscode/src/configuration/configureWorkspaceWizard.ts
@@ -208,7 +208,13 @@ async function listProfiles(cliWrapper: CliWrapper) {
     });
 
     return profiles.filter((profile) => {
-        return ["pat", "basic", "azure-cli"].includes(profile.authType);
+        return [
+            "pat",
+            "basic",
+            "azure-cli",
+            "oauth-m2m",
+            "azure-client-secret",
+        ].includes(profile.authType);
     });
 }
 


### PR DESCRIPTION
## Changes
Allow profiles with AWS OAuth and Azure Client Secret auth

## Tests
Manually tested with pre-configured profiles

