### PR TITLE
Fix wsfs wrapper preamble being ignored when %pip install restarts jupyter kernel

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -632,6 +632,11 @@
                         "type": "string",
                         "default": "",
                         "description": "Similar to python.envFile. Absolute path to a file containing environment variable definitions."
+                    },
+                    "databricks.wsfs.rearrangeCells": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Enable/disable rearranging cells in wrapper files created when using `workspace` as the sync destination. **Note:** It is recommended to NOT disable this setting. If you do disable it, you will need to manually handle sys.path for local imports in your notebooks."
                     }
                 }
             }

--- a/packages/databricks-vscode/src/utils/envVarGenerators.ts
+++ b/packages/databricks-vscode/src/utils/envVarGenerators.ts
@@ -114,7 +114,7 @@ export function getProxyEnvVars() {
 }
 
 export function removeUndefinedKeys<
-    T extends Record<string, string | undefined>
+    T extends Record<string, string | undefined>,
 >(envVarMap?: T): T | undefined {
     if (envVarMap === undefined) {
         return;

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -144,4 +144,12 @@ export const workspaceConfigs = {
                 ConfigurationTarget.Workspace
             );
     },
+
+    get wsfsRearrangeCells(): boolean {
+        return (
+            workspace
+                .getConfiguration("databricks")
+                .get<boolean>("wsfs.rearrangeCells") ?? true
+        );
+    },
 };

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsWorkflowWrapper.test.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsWorkflowWrapper.test.ts
@@ -29,7 +29,22 @@ describe(__filename, async () => {
         "python"
     );
 
-    beforeEach(async () => {
+    function verifyMockServiceCalledWithExpectedData(
+        expected: string,
+        wrappedFilePath: string
+    ) {
+        verify(
+            mockWorkspaceService.import(
+                objectContaining({
+                    content: Buffer.from(expected).toString("base64"),
+                    path: wrappedFilePath,
+                }),
+                anything()
+            )
+        ).once();
+    }
+
+    function createMocks() {
         mockWorkspaceService = mock(WorkspaceService);
         when(
             mockWorkspaceService.getStatus(
@@ -60,51 +75,58 @@ describe(__filename, async () => {
                 return path.resolve(extensionRootDirPath, relativePath);
             }
         );
-    });
+    }
 
-    it("should create wrapper for files", async () => {
-        const originalFilePath = posix.join(testDirPath, "remoteFile.py");
-        const wrappedFilePath = posix.join(
-            testDirPath,
-            "remoteFile.databricks.file.workflow-wrapper.py"
-        );
-        when(
-            mockWorkspaceService.getStatus(
-                objectContaining({
-                    path: wrappedFilePath,
-                }),
-                anything()
-            )
-        ).thenResolve({
-            path: wrappedFilePath,
-            object_type: "FILE",
-            object_id: 1235,
-        });
-
-        await new WorkspaceFsWorkflowWrapper(
-            instance(mockConnectionManager),
-            instance(mockExtensionContext)
-        ).createPythonFileWrapper(new RemoteUri(originalFilePath));
-
-        const wrapperData = await readFile(
-            path.join(resourceDirPath, "file.workflow-wrapper.py"),
-            "utf-8"
-        );
-        verify(
-            mockWorkspaceService.import(
-                objectContaining({
-                    content: Buffer.from(wrapperData).toString("base64"),
-                    path: wrappedFilePath,
-                }),
-                anything()
-            )
-        ).once();
-    });
-
-    it("should create wrapper for databricks python notebook", async () => {
-        await withFile(async (localFilePath) => {
+    describe("python files", () => {
+        beforeEach(createMocks);
+        it("should create wrapper for files", async () => {
             const originalFilePath = posix.join(testDirPath, "remoteFile.py");
             const wrappedFilePath = posix.join(
+                testDirPath,
+                "remoteFile.databricks.file.workflow-wrapper.py"
+            );
+            when(
+                mockWorkspaceService.getStatus(
+                    objectContaining({
+                        path: wrappedFilePath,
+                    }),
+                    anything()
+                )
+            ).thenResolve({
+                path: wrappedFilePath,
+                object_type: "FILE",
+                object_id: 1235,
+            });
+
+            await new WorkspaceFsWorkflowWrapper(
+                instance(mockConnectionManager),
+                instance(mockExtensionContext)
+            ).createPythonFileWrapper(new RemoteUri(originalFilePath));
+
+            const wrapperData = await readFile(
+                path.join(resourceDirPath, "file.workflow-wrapper.py"),
+                "utf-8"
+            );
+            verify(
+                mockWorkspaceService.import(
+                    objectContaining({
+                        content: Buffer.from(wrapperData).toString("base64"),
+                        path: wrappedFilePath,
+                    }),
+                    anything()
+                )
+            ).once();
+        });
+    });
+
+    describe("dbnb notebooks", () => {
+        let originalFilePath: string;
+        let wrappedFilePath: string;
+
+        beforeEach(() => {
+            createMocks();
+            originalFilePath = posix.join(testDirPath, "remoteFile.py");
+            wrappedFilePath = posix.join(
                 testDirPath,
                 "remoteFile.databricks.notebook.workflow-wrapper.py"
             );
@@ -141,26 +163,10 @@ describe(__filename, async () => {
                 object_type: "NOTEBOOK",
                 object_id: 1236,
             });
+        });
 
-            const comment = ["# Databricks notebook source"];
-            const data = ["print('hello')", "print('world')"];
-            writeFile(
-                localFilePath.path,
-                comment.concat(data).join("\n"),
-                "utf-8"
-            );
-
-            await new WorkspaceFsWorkflowWrapper(
-                instance(mockConnectionManager),
-                instance(mockExtensionContext)
-            ).createNotebookWrapper(
-                new LocalUri(localFilePath.path),
-                new RemoteUri(originalFilePath),
-                new RemoteUri(testDirPath),
-                "PY_DBNB"
-            );
-
-            const wrapperData = (
+        async function getWrapperData() {
+            return (
                 await readFile(
                     path.join(resourceDirPath, "notebook.workflow-wrapper.py"),
                     "utf-8"
@@ -174,31 +180,104 @@ describe(__filename, async () => {
                     "{{DATABRICKS_PROJECT_ROOT}}",
                     new RemoteUri(testDirPath).workspacePrefixPath
                 );
-            const expected = comment
-                .concat(wrapperData.split(/\r?\n/))
-                .concat(["# COMMAND ----------"])
-                .concat(data)
-                .join("\n");
+        }
 
-            verify(
-                mockWorkspaceService.import(
-                    objectContaining({
-                        content: Buffer.from(expected).toString("base64"),
-                        path: wrappedFilePath,
-                    }),
-                    anything()
-                )
-            ).once();
+        it("should create wrapper for databricks python notebook", async () => {
+            await withFile(async (localFilePath) => {
+                const comment = ["# Databricks notebook source"];
+                const data = ["print('hello')", "print('world')"];
+                writeFile(
+                    localFilePath.path,
+                    comment.concat(data).join("\n"),
+                    "utf-8"
+                );
+
+                await new WorkspaceFsWorkflowWrapper(
+                    instance(mockConnectionManager),
+                    instance(mockExtensionContext)
+                ).createNotebookWrapper(
+                    new LocalUri(localFilePath.path),
+                    new RemoteUri(originalFilePath),
+                    new RemoteUri(testDirPath),
+                    "PY_DBNB"
+                );
+
+                const wrapperData = await getWrapperData();
+                const expected = comment
+                    .concat(wrapperData.split(/\r?\n/))
+                    .concat(["# COMMAND ----------"])
+                    .concat(data)
+                    .join("\n");
+
+                verifyMockServiceCalledWithExpectedData(
+                    expected,
+                    wrappedFilePath
+                );
+            });
+        });
+
+        it("should rearrange kernel restart commands to the beginning", async () => {
+            await withFile(async (localFilePath) => {
+                const comment = ["# Databricks notebook source"];
+                const data = [
+                    "print('hello')",
+                    "print('world')",
+                    "# COMMAND ----------",
+                    "# MAGIC %pip install pandas",
+                    "# COMMAND ----------",
+                    "dbutils.library.restartPython()",
+                    "print('hello2')",
+                ];
+                writeFile(
+                    localFilePath.path,
+                    comment.concat(data).join("\n"),
+                    "utf-8"
+                );
+
+                await new WorkspaceFsWorkflowWrapper(
+                    instance(mockConnectionManager),
+                    instance(mockExtensionContext)
+                ).createNotebookWrapper(
+                    new LocalUri(localFilePath.path),
+                    new RemoteUri(originalFilePath),
+                    new RemoteUri(testDirPath),
+                    "PY_DBNB"
+                );
+
+                const wrapperData = await getWrapperData();
+                const expected = comment
+                    .concat([
+                        "# MAGIC %pip install pandas",
+                        "# COMMAND ----------",
+                        "dbutils.library.restartPython()",
+                        "# COMMAND ----------",
+                    ])
+                    .concat(wrapperData.split(/\r?\n/))
+                    .concat([
+                        "# COMMAND ----------",
+                        "print('hello')",
+                        "print('world')",
+                        "# COMMAND ----------",
+                        "print('hello2')",
+                    ])
+                    .join("\n");
+
+                verifyMockServiceCalledWithExpectedData(
+                    expected,
+                    wrappedFilePath
+                );
+            });
         });
     });
 
-    it("should create wrapper for databricks jupyter notebook", async () => {
-        await withFile(async (localFilePath) => {
-            const originalFilePath = posix.join(
-                testDirPath,
-                "remoteFile.ipynb"
-            );
-            const wrappedFilePath = posix.join(
+    describe("ipynb notebooks", () => {
+        let originalFilePath: string;
+        let wrappedFilePath: string;
+
+        beforeEach(() => {
+            createMocks();
+            originalFilePath = posix.join(testDirPath, "remoteFile.ipynb");
+            wrappedFilePath = posix.join(
                 testDirPath,
                 "remoteFile.databricks.notebook.workflow-wrapper.ipynb"
             );
@@ -235,91 +314,155 @@ describe(__filename, async () => {
                 object_type: "NOTEBOOK",
                 object_id: 1236,
             });
+        });
 
-            const originalData = {
-                metadata: {
-                    "application/vnd.databricks.v1+notebook": {
-                        notebookName: "something",
-                        dashboards: [],
-                        notebookMetadata: {
-                            pythonIndentUnit: 4,
-                        },
-                        language: "python",
-                        widgets: {},
-                        notebookOrigID: 2124901766713480,
-                    },
-                },
-                nbformat: 4,
-                nbformat_minor: 0,
-                cells: [
-                    {
-                        cell_type: "code",
-                        source: ["b = 2"],
-                        metadata: {
-                            "application/vnd.databricks.v1+cell": {
-                                showTitle: false,
-                                cellMetadata: {
-                                    rowLimit: 10000,
-                                    byteLimit: 2048000,
-                                },
-                                nuid: "1fb559af-eaf5-456f-9e12-c80b82a9baab",
-                                inputWidgets: {},
-                                title: "",
-                            },
-                        },
-                        outputs: [],
-                        execution_count: 0,
-                    },
-                ],
-            };
-            writeFile(
-                localFilePath.path,
-                JSON.stringify(originalData),
-                "utf-8"
-            );
-
-            await new WorkspaceFsWorkflowWrapper(
-                instance(mockConnectionManager),
-                instance(mockExtensionContext)
-            ).createNotebookWrapper(
-                new LocalUri(localFilePath.path),
-                new RemoteUri(originalFilePath),
-                new RemoteUri(testDirPath),
-                "IPYNB"
-            );
-
-            const wrapperData = (
-                await readFile(
-                    path.join(
-                        resourceDirPath,
-                        "generated",
-                        "notebook.workflow-wrapper.json"
-                    ),
-                    "utf-8"
-                )
-            )
-                .replace(
-                    "{{DATABRICKS_SOURCE_FILE}}",
-                    new RemoteUri(originalFilePath).workspacePrefixPath
-                )
-                .replace(
-                    "{{DATABRICKS_PROJECT_ROOT}}",
-                    new RemoteUri(testDirPath).workspacePrefixPath
-                );
-            const expected = originalData;
-            expected.cells = [JSON.parse(wrapperData)].concat(expected.cells);
-
-            verify(
-                mockWorkspaceService.import(
-                    objectContaining({
-                        content: Buffer.from(JSON.stringify(expected)).toString(
-                            "base64"
+        async function getWrapperData() {
+            const wrapperData = JSON.parse(
+                (
+                    await readFile(
+                        path.join(
+                            resourceDirPath,
+                            "generated",
+                            "notebook.workflow-wrapper.json"
                         ),
-                        path: wrappedFilePath,
-                    }),
-                    anything()
+                        "utf-8"
+                    )
                 )
-            ).once();
+                    .replace(
+                        "{{DATABRICKS_SOURCE_FILE}}",
+                        new RemoteUri(originalFilePath).workspacePrefixPath
+                    )
+                    .replace(
+                        "{{DATABRICKS_PROJECT_ROOT}}",
+                        new RemoteUri(testDirPath).workspacePrefixPath
+                    )
+            );
+
+            wrapperData.source = wrapperData.source.map((cell: string) =>
+                cell.trimEnd()
+            );
+            return wrapperData;
+        }
+
+        const notebookMetadata = {
+            metadata: {
+                "application/vnd.databricks.v1+notebook": {
+                    notebookName: "something",
+                    dashboards: [],
+                    notebookMetadata: {
+                        pythonIndentUnit: 4,
+                    },
+                    language: "python",
+                    widgets: {},
+                    notebookOrigID: 2124901766713480,
+                },
+            },
+            nbformat: 4,
+            nbformat_minor: 0,
+        };
+
+        const cellMetadata = {
+            cell_type: "code",
+            metadata: {
+                "application/vnd.databricks.v1+cell": {
+                    showTitle: false,
+                    cellMetadata: {
+                        rowLimit: 10000,
+                        byteLimit: 2048000,
+                    },
+                    nuid: "1fb559af-eaf5-456f-9e12-c80b82a9baab",
+                    inputWidgets: {},
+                    title: "",
+                },
+            },
+            outputs: [],
+            execution_count: 0,
+        };
+
+        it("should create wrapper for databricks jupyter notebook", async () => {
+            await withFile(async (localFilePath) => {
+                const originalData = {
+                    ...notebookMetadata,
+                    cells: [{...cellMetadata, source: ["b = 2"]}],
+                };
+                writeFile(
+                    localFilePath.path,
+                    JSON.stringify(originalData),
+                    "utf-8"
+                );
+
+                await new WorkspaceFsWorkflowWrapper(
+                    instance(mockConnectionManager),
+                    instance(mockExtensionContext)
+                ).createNotebookWrapper(
+                    new LocalUri(localFilePath.path),
+                    new RemoteUri(originalFilePath),
+                    new RemoteUri(testDirPath),
+                    "IPYNB"
+                );
+
+                const wrapperData = await getWrapperData();
+                const expected = originalData;
+                expected.cells = [wrapperData].concat(expected.cells);
+
+                verifyMockServiceCalledWithExpectedData(
+                    JSON.stringify(expected),
+                    wrappedFilePath
+                );
+            });
+        });
+
+        it("should rearrange kernel restart commands to the beginning", async () => {
+            await withFile(async (localFilePath) => {
+                const originalData = {
+                    ...notebookMetadata,
+                    cells: [
+                        {...cellMetadata, source: ["print('hello')"]},
+                        {...cellMetadata, source: ["%pip install x"]},
+                        {
+                            ...cellMetadata,
+                            source: [
+                                "dbutils.library.restartPython()\nprint('hello2')\n",
+                            ],
+                        },
+                    ],
+                };
+                writeFile(
+                    localFilePath.path,
+                    JSON.stringify(originalData),
+                    "utf-8"
+                );
+
+                await new WorkspaceFsWorkflowWrapper(
+                    instance(mockConnectionManager),
+                    instance(mockExtensionContext)
+                ).createNotebookWrapper(
+                    new LocalUri(localFilePath.path),
+                    new RemoteUri(originalFilePath),
+                    new RemoteUri(testDirPath),
+                    "IPYNB"
+                );
+
+                const wrapperData = await getWrapperData();
+                const expected = {
+                    ...notebookMetadata,
+                    cells: [
+                        {...wrapperData, source: ["%pip install x"]},
+                        {
+                            ...wrapperData,
+                            source: ["dbutils.library.restartPython()"],
+                        },
+                        wrapperData,
+                        {...cellMetadata, source: ["print('hello')"]},
+                        {...cellMetadata, source: ["print('hello2')"]},
+                    ],
+                };
+
+                verifyMockServiceCalledWithExpectedData(
+                    JSON.stringify(expected),
+                    wrappedFilePath
+                );
+            });
         });
     });
 });

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsWorkflowWrapper.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsWorkflowWrapper.ts
@@ -12,6 +12,7 @@ import {ConnectionManager} from "../configuration/ConnectionManager";
 import {Loggers} from "../logger";
 import {LocalUri, RemoteUri} from "../sync/SyncDestination";
 import {FileUtils} from "../utils";
+import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 function getWrapperPath(remoteFilePath: RemoteUri, extraParts: string[]) {
     return new RemoteUri(
@@ -42,6 +43,48 @@ async function readBootstrap(
             "{{DATABRICKS_PROJECT_ROOT}}",
             dbProjectRoot.workspacePrefixPath
         );
+}
+
+type Cell = {
+    source: string[];
+    type: "code" | "not_code";
+    originalCell?: any;
+};
+function rearrangeCells(cells: Cell[]) {
+    if (!workspaceConfigs.wsfsRearrangeCells) {
+        return cells;
+    }
+    const begingingCells: Cell[] = [];
+    const endingCells: Cell[] = [];
+
+    for (const cell of cells) {
+        if (cell.type === "not_code") {
+            endingCells.push(cell);
+            continue;
+        }
+        const newCell: Cell = {
+            source: [],
+            type: "code",
+            originalCell: cell.originalCell,
+        };
+        for (const line of cell.source) {
+            // Add each 0-indent line starting with %pip install or dbutils.library.restartPython(),
+            // as a new cell to the beginging and remove it from the original cell
+            if (
+                line.startsWith("%pip install") ||
+                line.startsWith("# MAGIC %pip install") ||
+                line.startsWith("dbutils.library.restartPython()")
+            ) {
+                begingingCells.push({source: [line], type: "code"});
+                continue;
+            }
+            newCell.source.push(line);
+        }
+        endingCells.push(newCell);
+    }
+    return [...begingingCells, ...endingCells].filter(
+        (cell) => cell.source.length !== 0
+    );
 }
 
 export class WorkspaceFsWorkflowWrapper {
@@ -90,8 +133,11 @@ export class WorkspaceFsWorkflowWrapper {
         dbProjectRoot: RemoteUri,
         @context ctx?: Context
     ) {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        type JupyterCell = {source: string[]; cell_type: string};
         const data = await readFile(localFilePath.path, "utf-8");
-        const originalJson: {cells: any[] | undefined} = JSON.parse(data);
+        const originalJson: {cells: JupyterCell[] | undefined} =
+            JSON.parse(data);
 
         const bootstrapPath = this.extensionContext.asAbsolutePath(
             path.join(
@@ -101,12 +147,30 @@ export class WorkspaceFsWorkflowWrapper {
                 "notebook.workflow-wrapper.json"
             )
         );
-        const bootstrapJson = JSON.parse(
+        const bootstrapJson: JupyterCell = JSON.parse(
             await readBootstrap(bootstrapPath, remoteFilePath, dbProjectRoot)
         );
-        originalJson["cells"] = [bootstrapJson].concat(
-            originalJson["cells"] ?? []
+        const cells = [bootstrapJson].concat(originalJson["cells"] ?? []).map(
+            // Since each cell.source is a string array where each string can be
+            // multiple lines, we need to split each string by \n and then flatten
+            (cell) =>
+                ({
+                    source: cell.source?.flatMap((line) =>
+                        line.trimEnd().split(/\r?\n/)
+                    ),
+                    type: cell.cell_type === "code" ? "code" : "not_code",
+                    originalCell: cell,
+                }) as Cell
         );
+        originalJson["cells"] = rearrangeCells(cells).map((cell) => {
+            if (cell.type === "not_code") {
+                return cell.originalCell;
+            }
+            return {
+                ...(cell.originalCell ?? bootstrapJson),
+                source: [cell.source.join("\n")],
+            };
+        });
         return this.createFile(
             getWrapperPath(remoteFilePath, [
                 "databricks",
@@ -136,10 +200,24 @@ export class WorkspaceFsWorkflowWrapper {
         const bootstrapCode = (
             await readBootstrap(bootstrapPath, remoteFilePath, dbProjectRoot)
         ).split(/\r?\n/);
-        const wrappedCode = ["# Databricks notebook source"]
-            .concat(bootstrapCode)
-            .concat(["# COMMAND ----------"])
-            .concat(originalCode);
+
+        // Split original code into cells by # COMMAND ----------\n
+        // and add the bootstrap code to the beginning as a new cell
+        const cells = [bootstrapCode]
+            .concat(
+                originalCode
+                    .join("\n")
+                    .split(/# COMMAND ----------\r?\n/)
+                    .map((cell) => cell.trimEnd().split(/\r?\n/))
+            )
+            .map((cell) => ({source: cell, type: "code"}) as Cell);
+        const rearrangedCells = rearrangeCells(cells);
+        // Add # Databricks notebook source to the beginning of the first cell
+        rearrangedCells.at(0)?.source.unshift("# Databricks notebook source");
+
+        const wrappedCode = rearrangedCells
+            .map((cell) => cell.source.join("\n"))
+            .join("\n# COMMAND ----------\n");
 
         return this.createFile(
             getWrapperPath(remoteFilePath, [
@@ -147,7 +225,7 @@ export class WorkspaceFsWorkflowWrapper {
                 "notebook",
                 "workflow-wrapper",
             ]),
-            wrappedCode.join("\n"),
+            wrappedCode,
             ctx
         );
     }


### PR DESCRIPTION
## Changes
* %pip install restarts the kernel, leading to all the code before %pip (including our preamble) being ignored for notebooks. 
* This PR adds a mechanism to find all the %pip and dbutils.library.restartPython and move them to the beginning of the notebook (before the preamble). 
* We also add a way to opt out of this behaviour.

## Tests
* manual
* unit

fixes #823
