### PR TITLE
Don't import `dbutils.widget` until explicitly called by the user

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -75,7 +75,12 @@ def create_and_register_databricks_globals():
     # "table", "sc", "sqlContext" are missing
     spark: SparkSession = DatabricksSession.builder.getOrCreate()
     sql = spark.sql
-    getArgument = dbutils.widgets.getArgument
+
+    # We do this to prevent importing widgets implementation prematurely
+    # The widget import should prompt users to use the implementation
+    # which has ipywidget support.
+    def getArgument(*args, **kwargs):
+        return dbutils.widgets.getArgument(*args, **kwargs)
 
     globals()['dbutils'] = dbutils
     globals()['spark'] = spark

--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -153,7 +153,7 @@ def strip_hash_magic(lines: List[str]) -> List[str]:
     if len(lines) == 0:
         return lines
     if lines[0].startswith("# MAGIC"):
-        return [line.partition("# MAGIC")[2] for line in lines]
+        return [line.partition("# MAGIC ")[2] for line in lines]
     return lines
 
 def convert_databricks_notebook_to_ipynb(py_file: str):
@@ -240,7 +240,7 @@ def register_magics(cfg: LocalDatabricksNotebookConfig):
         def get_cell_magic(lines: List[str]):
             if len(lines) == 0:
                 return
-            if lines[0].startswith("%%"):
+            if lines[0].strip().startswith("%%"):
                 return lines[0].split(" ")[0].strip()
             
         def handle(lines: List[str]):
@@ -258,7 +258,7 @@ def register_magics(cfg: LocalDatabricksNotebookConfig):
         def get_line_magic(lines: List[str]):
             if len(lines) == 0:
                 return
-            if lines[0].startswith("%"):
+            if lines[0].strip().startswith("%"):
                 return lines[0].split(" ")[0].strip().strip("%")
             
         def handle(lines: List[str]):
@@ -316,7 +316,14 @@ def register_magics(cfg: LocalDatabricksNotebookConfig):
     def parse_line_for_databricks_magics(lines: List[str]):
         if len(lines) == 0:
             return lines
+        
+        lines = [line for line in lines 
+                    if line.strip() != "# Databricks notebook source" and \
+                    line.strip() != "# COMMAND ----------"
+                ]
+        lines = ''.join(lines).strip().splitlines(keepends=True)
         lines = strip_hash_magic(lines)
+
         for magic_check in [is_cell_magic, is_line_magic]:
             if magic_check(lines):
                 return magic_check.handle(lines)

--- a/packages/databricks-vscode/src/language/notebooks/restartNotebookDialogue.ts
+++ b/packages/databricks-vscode/src/language/notebooks/restartNotebookDialogue.ts
@@ -18,8 +18,7 @@ export function showRestartNotebookDialogue(
                     {
                         modal: true,
                     },
-                    "Restart All Jupyter Kernels",
-                    "Cancel"
+                    "Restart All Jupyter Kernels"
                 );
 
                 if (choice === "Restart All Jupyter Kernels") {
@@ -27,11 +26,19 @@ export function showRestartNotebookDialogue(
                         if (doc.isClosed) {
                             return;
                         }
-                        await doc.save();
+
+                        if (doc.notebookType.includes("jupyter")) {
+                            await doc.save();
+                        }
                         await window.showNotebookDocument(doc);
                         await commands.executeCommand(
                             "workbench.action.closeActiveEditor"
                         );
+                        if (doc.notebookType.includes("jupyter")) {
+                            await window.showNotebookDocument(
+                                await workspace.openNotebookDocument(doc.uri)
+                            );
+                        }
                     }
                 }
             } finally {


### PR DESCRIPTION
## Changes
We should not call dbutils.widget in the init script. This causes dbutils to internally try to import the widget implementation. When in notebook environment, the widget implementation shows a special warning which prompts users to install the sdk version with ipywidget support. 

<img width="1059" alt="Screenshot 2023-09-05 at 19 28 24" src="https://github.com/databricks/databricks-vscode/assets/88345179/59c65c39-5808-4601-8fa9-d17858520835">

## Tests
<!-- How is this tested? -->

