### PR TITLE
Fix infinite recursion error in `generate-notice.sh`

### DIFF
--- a/scripts/generate_notice.js
+++ b/scripts/generate_notice.js
@@ -22,7 +22,9 @@ async function* crawlLicenses(start) {
         if (folder.startsWith(".")) {
             continue;
         }
-
+        if (folder === "databricks" || folder.startsWith("@databricks")) {
+            continue;
+        }
         if (folder.startsWith("@")) {
             yield* crawlLicenses(start + "/" + folder);
             continue;


### PR DESCRIPTION
## Changes
* the script was erroring with the following error
```
➤ YN0000: [Error: ENAMETOOLONG: name too long, open '/Users/runner/work/databricks-vscode/databricks-vscode/packages/databricks-vscode/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@azure/opentelemetry-instrumentation-azure-sdk/package.json'] {
➤ YN0000:   errno: -63,
➤ YN0000:   code: 'ENAMETOOLONG',
➤ YN0000:   syscall: 'open',
➤ YN0000:   path: '/Users/runner/work/databricks-vscode/databricks-vscode/packages/databricks-vscode/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@databricks/databricks-vscode-types/node_modules/databricks/node_modules/@azure/opentelemetry-instrumentation-azure-sdk/package.json'
```

## Tests
Manual
