### PR TITLE
Update Databricks Connect V2 setup prompts

### DIFF
--- a/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
+++ b/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
@@ -92,7 +92,7 @@ export class DbConnectAccessVerifier extends MultiStepAccessVerifier {
                 "checkCluster",
                 `Cluster doesn't have UC enabled.`,
                 this.promptForAttachingCluster(
-                    `Databricks Connect requires cluster Access Mode to be "Single User" or "Shared"). Currently it is ${
+                    `Databricks Connect requires a Unity Catalog enabled cluster with Access Mode "Single User" or "Shared". Currently it is ${
                         cluster.accessMode ?? "custom"
                     }. Please attach a new cluster.`
                 )

--- a/packages/databricks-vscode/src/language/DbConnectInstallPrompt.ts
+++ b/packages/databricks-vscode/src/language/DbConnectInstallPrompt.ts
@@ -18,6 +18,7 @@ export class DbConnectInstallPrompt implements Disposable {
     async show(advertisement = false, cb: () => void = () => {}) {
         const executable = await this.pythonExtension.getPythonExecutable();
         if (
+            advertisement &&
             executable &&
             this.workspaceState.skippedEnvsForDbConnect.includes(executable)
         ) {
@@ -53,12 +54,13 @@ export class DbConnectInstallPrompt implements Disposable {
             : "";
         const message = `${mainMessagePart} ${envMessagePart}. ${pkgUpdateMessagePart}`;
 
-        const choice = await window.showInformationMessage(
-            message,
+        const choices = [
             "Install",
             "Change environment",
-            "Never for this environment"
-        );
+            advertisement ? "Never for this environment" : undefined,
+        ].filter((value) => value !== undefined) as string[];
+
+        const choice = await window.showInformationMessage(message, ...choices);
 
         switch (choice) {
             case "Install":


### PR DESCRIPTION
## Changes
* Update language of cluster "Access Mode" popup.
* Always show "Install dbconnect" popup on clicking the "Databricks Connect Disable" button. 
## Tests
<!-- How is this tested? -->

