### PR TITLE
Pin databricks connect installer to databricks-connect=13.3.2

### DIFF
--- a/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
+++ b/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
@@ -8,6 +8,7 @@ import {Loggers} from "../logger";
 import {Context, context} from "@databricks/databricks-sdk/dist/context";
 import {DbConnectInstallPrompt} from "./DbConnectInstallPrompt";
 import {FeatureState} from "../feature-manager/FeatureManager";
+import {DATABRICKS_CONNECT_VERSION} from "../utils/constants";
 
 export class DbConnectAccessVerifier extends MultiStepAccessVerifier {
     constructor(
@@ -155,7 +156,7 @@ export class DbConnectAccessVerifier extends MultiStepAccessVerifier {
         try {
             const exists = await this.pythonExtension.findPackageInEnvironment(
                 "databricks-connect",
-                "13.3.2"
+                DATABRICKS_CONNECT_VERSION
             );
             if (exists) {
                 return this.acceptStep("checkDbConnectInstall");

--- a/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
+++ b/packages/databricks-vscode/src/language/DbConnectAccessVerifier.ts
@@ -155,7 +155,7 @@ export class DbConnectAccessVerifier extends MultiStepAccessVerifier {
         try {
             const exists = await this.pythonExtension.findPackageInEnvironment(
                 "databricks-connect",
-                "latest"
+                "13.3.2"
             );
             if (exists) {
                 return this.acceptStep("checkDbConnectInstall");

--- a/packages/databricks-vscode/src/language/DbConnectInstallPrompt.ts
+++ b/packages/databricks-vscode/src/language/DbConnectInstallPrompt.ts
@@ -3,6 +3,7 @@ import {window} from "vscode";
 import {Disposable} from "vscode";
 import {WorkspaceStateManager} from "../vscode-objs/WorkspaceState";
 import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
+import {DATABRICKS_CONNECT_VERSION} from "../utils/constants";
 
 export class DbConnectInstallPrompt implements Disposable {
     private disposables: Disposable[] = [];
@@ -73,7 +74,7 @@ export class DbConnectInstallPrompt implements Disposable {
                     );
                     await this.pythonExtension.installPackageInEnvironment(
                         "databricks-connect",
-                        "latest"
+                        DATABRICKS_CONNECT_VERSION
                     );
                     cb();
                 } catch (e: unknown) {

--- a/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
+++ b/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
@@ -153,7 +153,10 @@ export class MsPythonExtensionWrapper implements Disposable {
         }
     }
 
-    async getPackageDetailsFromEnvironment(name: string, version?: string) {
+    async getPackageDetailsFromEnvironment(
+        name: string,
+        version?: string | RegExp
+    ) {
         const executable = await this.getPythonExecutable();
         if (!executable) {
             return undefined;
@@ -180,18 +183,19 @@ export class MsPythonExtensionWrapper implements Disposable {
         return data.find(
             (item) =>
                 item.name === name &&
-                (version === undefined || item.version === version)
+                (version === undefined ||
+                    item.version.match(version) !== undefined)
         );
     }
 
-    async findPackageInEnvironment(name: string, version?: string) {
+    async findPackageInEnvironment(name: string, version?: string | RegExp) {
         return (
             (await this.getPackageDetailsFromEnvironment(name, version)) !==
             undefined
         );
     }
 
-    async installPackageInEnvironment(name: string, version?: string) {
+    async installPackageInEnvironment(name: string, version?: string | RegExp) {
         const executable = await this.getPythonExecutable();
         if (!executable) {
             throw Error("No python executable found");

--- a/packages/databricks-vscode/src/utils/constants.ts
+++ b/packages/databricks-vscode/src/utils/constants.ts
@@ -1,1 +1,3 @@
 export type Cloud = "aws" | "azure" | "gcp";
+
+export const DATABRICKS_CONNECT_VERSION = "13.3.2";


### PR DESCRIPTION
## Changes
Earlier we had pinned the check for enabling dbconnect to check for client version 13.3.2. 
This PR also pins the installer to always install the pinned version. 

## Tests
Manual
