### PR TITLE
Match files without extension to a notebook when using `%run file`

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -301,10 +301,14 @@ def register_magics(cfg: LocalDatabricksNotebookConfig):
             
             if lmagic == "run":
                 rest = lines[0].strip().split(" ")[1:]
-                filename = ""
-                for arg in rest:
-                    if arg.endswith((".py", ".ipy", ".ipynb")):
-                        filename = arg
+                if len(rest) == 0:
+                    return lines
+                
+                filename = rest[0]
+
+                for suffix in ["", ".py", ".ipynb", ".ipy"]:
+                    if os.path.exists(os.path.join(os.getcwd(), filename + suffix)):
+                        filename = filename + suffix
                         break
                 
                 return [


### PR DESCRIPTION
## Changes
When using `%run file` databricks webapp searches for a matching notebook, in case the file does not have any extension. We do the same locally. 

## Tests
Manual
