### PR TITLE
Pin typescript to v5.1.6 to enable eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "ts-mockito": "^2.6.1",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
     },
     "resolutions": {
         "json5": "2.2.2"

--- a/packages/databricks-vscode-types/package.json
+++ b/packages/databricks-vscode-types/package.json
@@ -26,7 +26,7 @@
         "@types/vscode": "^1.69.1",
         "eslint": "^8.51.0",
         "prettier": "^3.0.0",
-        "typescript": "^5.2.2"
+        "typescript": "5.1.6"
     },
     "dependencies": {
         "@databricks/databricks-sdk": "../../vendor/databricks-sdk.tgz",

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -735,7 +735,7 @@
         "ts-mocha": "^10.0.0",
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2",
+        "typescript": "5.1.6",
         "vsce": "^2.15.0",
         "wdio-video-reporter": "^4.0.3",
         "wdio-vscode-service": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,7 +404,7 @@ __metadata:
     databricks: "*"
     eslint: ^8.51.0
     prettier: ^3.0.0
-    typescript: ^5.2.2
+    typescript: 5.1.6
   languageName: unknown
   linkType: soft
 
@@ -420,7 +420,7 @@ __metadata:
     eslint-config-prettier: ^8.8.0
     eslint-plugin-no-only-tests: ^3.1.0
     ts-mockito: ^2.6.1
-    typescript: ^5.2.2
+    typescript: 5.1.6
   languageName: unknown
   linkType: soft
 
@@ -3712,7 +3712,7 @@ __metadata:
     ts-mocha: ^10.0.0
     ts-mockito: ^2.6.1
     ts-node: ^10.9.1
-    typescript: ^5.2.2
+    typescript: 5.1.6
     vsce: ^2.15.0
     wdio-video-reporter: ^4.0.3
     wdio-vscode-service: ^5.2.0
@@ -10491,23 +10491,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:5.1.6":
+  version: 5.1.6
+  resolution: "typescript@npm:5.1.6"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: b2f2c35096035fe1f5facd1e38922ccb8558996331405eb00a5111cc948b2e733163cc22fab5db46992aba7dd520fff637f2c1df4996ff0e134e77d3249a7350
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=7ad353"
+"typescript@patch:typescript@5.1.6#~builtin<compat/typescript>":
+  version: 5.1.6
+  resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
+  checksum: 21e88b0a0c0226f9cb9fd25b9626fb05b4c0f3fddac521844a13e1f30beb8f14e90bd409a9ac43c812c5946d714d6e0dee12d5d02dfc1c562c5aacfa1f49b606
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- How is this tested? -->

