### PR TITLE
Use databricks CLI log-file option to capture the logs

### DIFF
--- a/packages/databricks-vscode/DATABRICKS.quickstart.md
+++ b/packages/databricks-vscode/DATABRICKS.quickstart.md
@@ -75,7 +75,6 @@ This extension contributes the following settings:
 -   `databricks.logs.maxArrayLength`: The maximum number of items to show for array fields
 -   `databricks.logs.enabled`: Enable/disable logging. Reload window for changes to take effect
 -   `databricks.clusters.onlyShowAccessibleClusters`: Only show clusters that the user has access to
--   `databricks.cli.verboseMode`: Show debug logs for the sync command
 
 ## <a id="commands"></a>`Databricks:` Commands
 

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -586,11 +586,6 @@
                         "default": false,
                         "description": "Enable/disable filtering for only accessible clusters (clusters on which the current user can run code)"
                     },
-                    "databricks.cli.verboseMode": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Enable verbose logging for databricks CLI (sync mode)."
-                    },
                     "databricks.sync.destinationType": {
                         "type": "string",
                         "default": "workspace",

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -56,7 +56,6 @@ describe(__filename, () => {
         const configsSpy = spy(workspaceConfigs);
         mocks.push(configsSpy);
         when(configsSpy.loggingEnabled).thenReturn(true);
-        when(configsSpy.cliVerboseMode).thenReturn(true);
         const cli = createCliWrapper(logFilePath);
         await execFile(cli.cliPath, ["version", ...cli.loggingArguments]);
         const file = await readFile(logFilePath);
@@ -78,23 +77,17 @@ describe(__filename, () => {
         );
 
         const syncCommand = `${cliPath} sync . /Repos/user@databricks.com/project --watch --output json`;
+        const loggingArgs = `--log-level debug --log-file ${logFilePath} --log-format json`;
         let {command, args} = cli.getSyncCommand(mapper, "incremental");
         assert.equal(
             [command, ...args].join(" "),
-            [
-                syncCommand,
-                `--log-level error --log-file ${logFilePath} --log-format json`,
-            ].join(" ")
+            [syncCommand, loggingArgs].join(" ")
         );
 
         ({command, args} = cli.getSyncCommand(mapper, "full"));
         assert.equal(
             [command, ...args].join(" "),
-            [
-                syncCommand,
-                `--log-level error --log-file ${logFilePath} --log-format json`,
-                "--full",
-            ].join(" ")
+            [syncCommand, loggingArgs, "--full"].join(" ")
         );
 
         const configsSpy = spy(workspaceConfigs);
@@ -102,17 +95,6 @@ describe(__filename, () => {
         when(configsSpy.loggingEnabled).thenReturn(false);
         ({command, args} = cli.getSyncCommand(mapper, "incremental"));
         assert.equal([command, ...args].join(" "), syncCommand);
-
-        when(configsSpy.loggingEnabled).thenReturn(true);
-        when(configsSpy.cliVerboseMode).thenReturn(true);
-        ({command, args} = cli.getSyncCommand(mapper, "incremental"));
-        assert.equal(
-            [command, ...args].join(" "),
-            [
-                syncCommand,
-                `--log-level debug --log-file ${logFilePath} --log-format json`,
-            ].join(" ")
-        );
     });
 
     it("should create an 'add profile' command", () => {

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -45,12 +45,13 @@ describe(__filename, () => {
             )
         );
 
+        const logFile = path.join(logUri.fsPath, "databricks-cli-logs.json");
         let {command, args} = cli.getSyncCommand(mapper, "incremental");
         assert.equal(
             [command, ...args].join(" "),
             [
                 "./bin/databricks sync . /Repos/fabian.jakobs@databricks.com/notebook-best-practices --watch --output json",
-                `--log-level error --log-file ${logUri.fsPath}/databricks-cli-logs.json --log-format json`,
+                `--log-level error --log-file ${logFile} --log-format json`,
             ].join(" ")
         );
 
@@ -59,7 +60,7 @@ describe(__filename, () => {
             [command, ...args].join(" "),
             [
                 "./bin/databricks sync . /Repos/fabian.jakobs@databricks.com/notebook-best-practices --watch --output json",
-                `--log-level error --log-file ${logUri.fsPath}/databricks-cli-logs.json --log-format json`,
+                `--log-level error --log-file ${logFile} --log-format json`,
                 "--full",
             ].join(" ")
         );

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -31,7 +31,8 @@ function createCliWrapper(logFilePath?: string, absolutePrefix?: string) {
     return new CliWrapper(
         {
             asAbsolutePath(relativePath: string) {
-                return path.join(absolutePrefix || "", relativePath);
+                if (!absolutePrefix) return relativePath;
+                return path.join(absolutePrefix, relativePath);
             },
         } as any,
         logFilePath
@@ -81,7 +82,7 @@ describe(__filename, () => {
         );
 
         const syncCommand =
-            "bin/databricks sync . /Repos/user@databricks.com/project --watch --output json";
+            "./bin/databricks sync . /Repos/user@databricks.com/project --watch --output json";
         let {command, args} = cli.getSyncCommand(mapper, "incremental");
         assert.equal(
             [command, ...args].join(" "),
@@ -129,7 +130,7 @@ describe(__filename, () => {
 
         assert.equal(
             [command, ...args].join(" "),
-            "bin/databricks configure --no-interactive --profile DEFAULT --host https://databricks.com/ --token"
+            "./bin/databricks configure --no-interactive --profile DEFAULT --host https://databricks.com/ --token"
         );
     });
 

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -56,7 +56,7 @@ export class CliWrapper {
         }
         return [
             "--log-level",
-            workspaceConfigs.cliVerboseMode ? "debug" : "error",
+            "debug",
             "--log-file",
             this.logFilePath ?? "stderr",
             "--log-format",

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -143,7 +143,16 @@ export async function activate(
     );
 
     // Configuration group
-    const cli = new CliWrapper(context);
+    let cliLogFilePath;
+    try {
+        cliLogFilePath = await loggerManager.getLogFile("databricks-cli");
+    } catch (e) {
+        logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+            "Failed to create a log file for the CLI",
+            e
+        );
+    }
+    const cli = new CliWrapper(context, cliLogFilePath);
     const connectionManager = new ConnectionManager(cli, stateStorage);
     context.subscriptions.push(
         connectionManager.onDidChangeState(async (state) => {

--- a/packages/databricks-vscode/src/logger/LoggerManager.test.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.test.ts
@@ -26,7 +26,6 @@ describe(__filename, function () {
         logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
             "test message"
         );
-        logging.NamedLogger.getOrCreate(Loggers.CLI).debug("test message");
 
         await new Promise((resolve) =>
             setTimeout(
@@ -34,17 +33,12 @@ describe(__filename, function () {
                 new Time(0.5, TimeUnits.seconds).toMillSeconds().value
             )
         );
-        ["sdk-and-extension-logs.json", "databricks-cli-logs.json"].forEach(
-            async (logfile) => {
-                const rawLogs = await readFile(path.join(tempDir, logfile), {
-                    encoding: "utf-8",
-                });
+        const logfile = path.join(tempDir, "sdk-and-extension-logs.json");
+        const rawLogs = await readFile(logfile, {encoding: "utf-8"});
 
-                const logs = rawLogs.split("\n");
-                assert.ok(logs.length !== 0);
-                assert.ok(logs[0].includes("test message"));
-            }
-        );
+        const logs = rawLogs.split("\n");
+        assert.ok(logs.length !== 0);
+        assert.ok(logs[0].includes("test message"));
     });
 
     afterEach(async () => {

--- a/packages/databricks-vscode/src/logger/LoggerManager.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.ts
@@ -68,7 +68,7 @@ export class LoggerManager {
 
         // This logger collects all the logs in the extension.
         NamedLogger.getOrCreate(
-            "Extension",
+            Loggers.Extension,
             {
                 factory: (name) => {
                     return loggers.add(name, {

--- a/packages/databricks-vscode/src/logger/LoggerManager.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.ts
@@ -12,6 +12,7 @@ export class LoggerManager {
     constructor(readonly context: ExtensionContext) {}
 
     async getLogFile(prefix: string) {
+        await mkdir(this.context.logUri.fsPath, {recursive: true});
         const logFile = path.join(
             this.context.logUri.fsPath,
             `${prefix}-logs.json`
@@ -39,8 +40,6 @@ export class LoggerManager {
     }
 
     async initLoggers() {
-        await mkdir(this.context.logUri.fsPath, {recursive: true});
-
         const outputChannel = window.createOutputChannel("Databricks Logs");
         outputChannel.clear();
 

--- a/packages/databricks-vscode/src/logger/LoggerManager.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.ts
@@ -11,8 +11,7 @@ const {NamedLogger, ExposedLoggers} = logging;
 export class LoggerManager {
     constructor(readonly context: ExtensionContext) {}
 
-    private async getLogFile(prefix: string) {
-        await mkdir(this.context.logUri.fsPath, {recursive: true});
+    async getLogFile(prefix: string) {
         const logFile = path.join(
             this.context.logUri.fsPath,
             `${prefix}-logs.json`
@@ -40,6 +39,8 @@ export class LoggerManager {
     }
 
     async initLoggers() {
+        await mkdir(this.context.logUri.fsPath, {recursive: true});
+
         const outputChannel = window.createOutputChannel("Databricks Logs");
         outputChannel.clear();
 
@@ -66,9 +67,7 @@ export class LoggerManager {
             true
         );
 
-        /** 
-        This logger collects all the logs in the extension.
-        */
+        // This logger collects all the logs in the extension.
         NamedLogger.getOrCreate(
             "Extension",
             {
@@ -87,29 +86,6 @@ export class LoggerManager {
             },
             true
         );
-
-        const cliLogFile = await this.getLogFile("databricks-cli");
-        /** 
-        This logger collects all the output from databricks CLI.
-        */
-        NamedLogger.getOrCreate(
-            "DatabricksCLI",
-            {
-                factory: (name) => {
-                    return loggers.add(name, {
-                        transports: [
-                            getOutputConsoleTransport(outputChannel, {
-                                level: "error",
-                            }),
-                            this.getFileTransport(cliLogFile, {
-                                level: "debug",
-                            }),
-                        ],
-                    });
-                },
-            },
-            true
-        );
     }
 
     openLogFolder() {
@@ -120,6 +96,5 @@ export class LoggerManager {
 /* eslint-disable @typescript-eslint/naming-convention */
 export enum Loggers {
     Extension = "Extension",
-    CLI = "DatabricksCLI",
 }
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -37,20 +37,6 @@ export const workspaceConfigs = {
                 .get<boolean>("clusters.onlyShowAccessibleClusters") ?? false
         );
     },
-    get cliVerboseMode() {
-        const legacyVerboseMode =
-            workspace
-                .getConfiguration("databricks")
-                .get<boolean>("bricks.verboseMode") ?? false;
-
-        const verboseMode =
-            workspace
-                .getConfiguration("databricks")
-                .get<boolean>("cli.verboseMode") ?? false;
-
-        return verboseMode || legacyVerboseMode;
-    },
-
     get syncDestinationType() {
         return (
             workspace


### PR DESCRIPTION
## Changes
The CLI can write its logs to a file and we don't have to manage this on the extension side. 

- The format of the logs is a bit different now
- In the verbose mode we were writing debug logs to the terminal task in the VSCode (as they were coming to the stderr). Right now such logs are only in the log file, and output has just the stdout (as CLI keeps stderr empty when you ask it to log to a file)
- The verbose mode option is gone. The output in the sync terminal is clean and always based on stdout, and the verbose logs are always written into a file


## Tests
Updated existing tests

