### PR TITLE
Make configuration wizard sticky

### DIFF
--- a/packages/databricks-vscode/src/configuration/configureWorkspaceWizard.ts
+++ b/packages/databricks-vscode/src/configuration/configureWorkspaceWizard.ts
@@ -75,6 +75,7 @@ export async function configureWorkspaceWizard(
                 return false;
             },
             items,
+            ignoreFocusOut: true,
         });
 
         state.host = normalizeHost(host);
@@ -158,6 +159,7 @@ export async function configureWorkspaceWizard(
             totalSteps: 2,
             placeholder: "Select authentication method",
             items,
+            ignoreFocusOut: true,
             shouldResume: async () => {
                 return false;
             },

--- a/packages/databricks-vscode/src/ui/wizard.ts
+++ b/packages/databricks-vscode/src/ui/wizard.ts
@@ -43,6 +43,7 @@ interface QuickAutoCompleteParameters {
     buttons?: QuickInputButton[];
     shouldResume: () => Thenable<boolean>;
     items: Array<QuickPickItem>;
+    ignoreFocusOut: boolean;
 }
 
 interface QuickPickParameters<T extends QuickPickItem> {
@@ -54,6 +55,7 @@ interface QuickPickParameters<T extends QuickPickItem> {
     placeholder: string;
     buttons?: QuickInputButton[];
     shouldResume: () => Thenable<boolean>;
+    ignoreFocusOut: boolean;
 }
 
 export class MultiStepInput {
@@ -107,6 +109,7 @@ export class MultiStepInput {
         buttons,
         shouldResume,
         items,
+        ignoreFocusOut,
     }: QuickAutoCompleteParameters): Promise<
         | string
         | (QuickAutoCompleteParameters extends {buttons: (infer I)[]}
@@ -129,6 +132,7 @@ export class MultiStepInput {
                 input.totalSteps = totalSteps;
                 input.placeholder = prompt;
                 input.items = [...items];
+                input.ignoreFocusOut = ignoreFocusOut;
 
                 disposables.push(
                     input.onDidChangeValue(async () => {
@@ -231,6 +235,7 @@ export class MultiStepInput {
         placeholder,
         buttons,
         shouldResume,
+        ignoreFocusOut,
     }: P) {
         const disposables: Disposable[] = [];
         try {
@@ -243,6 +248,7 @@ export class MultiStepInput {
                 input.totalSteps = totalSteps;
                 input.placeholder = placeholder;
                 input.items = items;
+                input.ignoreFocusOut = ignoreFocusOut;
                 if (activeItem) {
                     input.activeItems = [activeItem];
                 }


### PR DESCRIPTION
## Changes
Add `ignoreFocusOut` to both steps of the configuration wizard. They will not disappear when focusing away from them, but can still be closed with an escape button.

## Tests
Manual

