### PR TITLE
Inject databricks globals into python debugger

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -360,7 +360,14 @@
                     "group": "inline@0"
                 }
             ],
-            "editor/title/run": [
+            "editor/title": [
+                {
+                    "submenu": "databricks.run",
+                    "group": "navigation@0",
+                    "when": "resourceLangId == python || resourceLangId == scala || resourceLangId == r || resourceLangId == sql || resourceExtname == .ipynb"
+                }
+            ],
+            "databricks.run": [
                 {
                     "command": "databricks.run.runEditorContents",
                     "when": "resourceLangId == python",
@@ -414,6 +421,14 @@
                 "id": "databricks.cluster.filter",
                 "label": "Filter clusters ...",
                 "icon": "$(filter)"
+            },
+            {
+                "id": "databricks.run",
+                "label": "Run on Databricks",
+                "icon": {
+                    "dark": "resources/dark/logo.svg",
+                    "light": "resources/light/logo.svg"
+                }
             }
         ],
         "taskDefinitions": [

--- a/packages/databricks-vscode/resources/python/local-runner.py
+++ b/packages/databricks-vscode/resources/python/local-runner.py
@@ -1,0 +1,10 @@
+import os
+from databricks.connect import DatabricksSession
+
+source_file = os.environ.get("DATABRICKS_SOURCE_FILE", "")
+
+spark = DatabricksSession.builder.getOrCreate()
+
+from runpy import run_path
+
+run_path(source_file, run_name="__main__", init_globals={"spark": spark})


### PR DESCRIPTION
## Changes
* Consolidate databricks run modes into a separate menu. 
![image](https://github.com/databricks/databricks-vscode/assets/88345179/5b1779ac-e016-4ab3-9b27-9d1e3d53235f)

* Inject globals when running with debugger or running the file locally.

## Tests
<!-- How is this tested? -->

