### PR TITLE
All `AuthProviders` must implement a non silent `check`.

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -142,7 +142,7 @@ export class ConnectionManager {
                 }
             }
 
-            if (!(await projectConfigFile.authProvider.check(true))) {
+            if (!(await projectConfigFile.authProvider.check())) {
                 throw new Error(
                     `Can't login with ${projectConfigFile.authProvider.describe()}.`
                 );
@@ -277,7 +277,7 @@ export class ConnectionManager {
                 return;
             }
 
-            if (!(await config.authProvider.check(false))) {
+            if (!(await config.authProvider.check())) {
                 return;
             }
 

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -46,7 +46,7 @@ export class AzureCliCheck implements Disposable {
         this.disposables = [];
     }
 
-    public async check(silent = false): Promise<boolean> {
+    public async check(): Promise<boolean> {
         this.tenantId = this.authProvider.tenantId;
 
         let loginAttempts = 0;
@@ -156,11 +156,12 @@ export class AzureCliCheck implements Disposable {
                 message = e.message;
             }
 
+            NamedLogger.getOrCreate(Loggers.Extension).error(message, e);
             window.showErrorMessage(message);
             return false;
         }
 
-        if (result && !silent) {
+        if (result) {
             window.showInformationMessage(
                 "Databricks: Successfully logged in with Azure CLI"
             );

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -2,10 +2,12 @@ import {
     ExecUtils,
     ProductVersion,
     WorkspaceClient,
+    logging,
 } from "@databricks/databricks-sdk";
 import {Disposable, window} from "vscode";
 import {DatabricksCliAuthProvider} from "./AuthProvider";
 import {orchestrate, OrchestrationLoopError, Step} from "./orchestrate";
+import {Loggers} from "../../logger";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const extensionVersion = require("../../../package.json")
@@ -23,7 +25,7 @@ export class DatabricksCliCheck implements Disposable {
         this.disposables = [];
     }
 
-    async check(silent: boolean): Promise<boolean> {
+    async check(): Promise<boolean> {
         const steps: Record<StepName, Step<boolean, StepName>> = {
             tryLogin: async () => {
                 if (await this.tryLogin()) {
@@ -55,12 +57,15 @@ export class DatabricksCliCheck implements Disposable {
             } else {
                 message = e.message;
             }
-
+            logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                message,
+                e
+            );
             window.showErrorMessage(message);
             return false;
         }
 
-        if (result && !silent) {
+        if (result) {
             window.showInformationMessage(
                 "Databricks: Successfully logged in with Databricks CLI"
             );

--- a/packages/databricks-vscode/src/configuration/auth/orchestrate.ts
+++ b/packages/databricks-vscode/src/configuration/auth/orchestrate.ts
@@ -42,7 +42,7 @@ export async function orchestrate<S, KEYS extends string>(
             throw new OrchestrationLoopError();
         }
         const result: StepResult<S, KEYS> = await steps[step]();
-        logger?.info(`Azire CLI check: ${step}`, result);
+        logger?.info(`Auth check: ${step}`, result);
 
         if (result.type === "error") {
             throw result.error;


### PR DESCRIPTION
## Changes
* Moving forward, we want to avoid having silent checks to make reasoning about auth easier. This PR makes it so that all AuthProviders must implement the `check` method.
* Each check method must handle it's own Retry Loop, error handling and display. Since now checks are always interactive, we do not want calling code to manage the interactions. 

## Tests
* manual
