### PR TITLE
Return config source from `ConfigModel`

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConfigOverrideReaderWriter.ts
+++ b/packages/databricks-vscode/src/configuration/ConfigOverrideReaderWriter.ts
@@ -1,10 +1,10 @@
 import {EventEmitter} from "vscode";
 import {Mutex} from "../locking";
 import {StateStorage} from "../vscode-objs/StateStorage";
-import {OverrideableConfigs, ConfigReaderWriter} from "./types";
+import {OverrideableConfig, ConfigReaderWriter} from "./types";
 
 export class ConfigOverrideReaderWriter
-    implements ConfigReaderWriter<keyof OverrideableConfigs>
+    implements ConfigReaderWriter<keyof OverrideableConfig>
 {
     private writeMutex = new Mutex();
     private onDidChangeEmitter = new EventEmitter<void>();
@@ -20,10 +20,10 @@ export class ConfigOverrideReaderWriter
      * @returns status of the write
      */
     @Mutex.synchronise("writeMutex")
-    async write<T extends keyof OverrideableConfigs>(
+    async write<T extends keyof OverrideableConfig>(
         key: T,
         target: string,
-        value?: OverrideableConfigs[T]
+        value?: OverrideableConfig[T]
     ) {
         const data = this.storage.get("databricks.bundle.overrides");
         if (data[target] === undefined) {
@@ -49,10 +49,10 @@ export class ConfigOverrideReaderWriter
         return this.storage.get("databricks.bundle.overrides")[target];
     }
 
-    async read<T extends keyof OverrideableConfigs>(
+    async read<T extends keyof OverrideableConfig>(
         key: T,
         target: string
-    ): Promise<OverrideableConfigs[T] | undefined> {
+    ): Promise<OverrideableConfig[T] | undefined> {
         return this.storage.get("databricks.bundle.overrides")[target]?.[key];
     }
 }

--- a/packages/databricks-vscode/src/configuration/types.ts
+++ b/packages/databricks-vscode/src/configuration/types.ts
@@ -9,6 +9,10 @@ export type DatabricksConfigs = {
     workspaceFsPath?: string;
 };
 
+export type DatabricksConfigSource = {
+    [key in keyof DatabricksConfigs]: "bundle" | "override";
+};
+
 export const OVERRIDEABLE_CONFIGS = [
     "clusterId",
     "authParams",
@@ -33,6 +37,10 @@ export type BundleConfigs = Pick<
     DatabricksConfigs,
     (typeof BUNDLE_CONFIGS)[number]
 >;
+
+export const DATABRICKS_CONFIGS = Array.from(
+    new Set([...OVERRIDEABLE_CONFIGS, ...BUNDLE_CONFIGS])
+);
 
 export function isOverrideableConfig(
     key: any

--- a/packages/databricks-vscode/src/configuration/types.ts
+++ b/packages/databricks-vscode/src/configuration/types.ts
@@ -1,4 +1,4 @@
-export type DatabricksConfigs = {
+export type DatabricksConfig = {
     host?: string;
 
     // reconcile with actual mode and auth type enums from bundle
@@ -10,21 +10,21 @@ export type DatabricksConfigs = {
 };
 
 export type DatabricksConfigSource = {
-    [key in keyof DatabricksConfigs]: "bundle" | "override";
+    [key in keyof DatabricksConfig]: "bundle" | "override";
 };
 
-export const OVERRIDEABLE_CONFIGS = [
+export const OVERRIDEABLE_CONFIG_KEYS = [
     "clusterId",
     "authParams",
     "workspaceFsPath",
 ] as const;
 
-export type OverrideableConfigs = Pick<
-    DatabricksConfigs,
-    (typeof OVERRIDEABLE_CONFIGS)[number]
+export type OverrideableConfig = Pick<
+    DatabricksConfig,
+    (typeof OVERRIDEABLE_CONFIG_KEYS)[number]
 >;
 
-export const BUNDLE_CONFIGS = [
+export const BUNDLE_CONFIG_KEYS = [
     "clusterId",
     "authParams",
     "workspaceFsPath",
@@ -33,26 +33,26 @@ export const BUNDLE_CONFIGS = [
 ] as const;
 
 /** These are configs which can be loaded from the bundle */
-export type BundleConfigs = Pick<
-    DatabricksConfigs,
-    (typeof BUNDLE_CONFIGS)[number]
+export type BundleConfig = Pick<
+    DatabricksConfig,
+    (typeof BUNDLE_CONFIG_KEYS)[number]
 >;
 
-export const DATABRICKS_CONFIGS = Array.from(
-    new Set([...OVERRIDEABLE_CONFIGS, ...BUNDLE_CONFIGS])
+export const DATABRICKS_CONFIG_KEYS = Array.from(
+    new Set([...OVERRIDEABLE_CONFIG_KEYS, ...BUNDLE_CONFIG_KEYS])
 );
 
-export function isOverrideableConfig(
+export function isOverrideableConfigKey(
     key: any
-): key is keyof OverrideableConfigs {
-    return OVERRIDEABLE_CONFIGS.includes(key);
+): key is keyof OverrideableConfig {
+    return OVERRIDEABLE_CONFIG_KEYS.includes(key);
 }
 
-export function isBundleConfig(key: any): key is keyof BundleConfigs {
-    return BUNDLE_CONFIGS.includes(key);
+export function isBundleConfigKey(key: any): key is keyof BundleConfig {
+    return BUNDLE_CONFIG_KEYS.includes(key);
 }
 
-export interface ConfigReaderWriter<T extends keyof DatabricksConfigs> {
-    read(key: T, target: string): Promise<DatabricksConfigs[T] | undefined>;
-    write(key: T, target: string, value?: DatabricksConfigs[T]): Promise<void>;
+export interface ConfigReaderWriter<T extends keyof DatabricksConfig> {
+    read(key: T, target: string): Promise<DatabricksConfig[T] | undefined>;
+    write(key: T, target: string, value?: DatabricksConfig[T]): Promise<void>;
 }

--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
@@ -1,6 +1,6 @@
 import {randomUUID} from "crypto";
 import {ExtensionContext} from "vscode";
-import {OverrideableConfigs} from "../configuration/types";
+import {OverrideableConfig} from "../configuration/types";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 type KeyInfo<V> = {
@@ -18,7 +18,7 @@ function withType<V>() {
 
 const Keys = {
     "databricks.bundle.overrides": withType<{
-        [k: string]: OverrideableConfigs;
+        [k: string]: OverrideableConfig;
     }>()({
         location: "workspace",
         defaultValue: {},


### PR DESCRIPTION
## Changes
* We need config source to display the overrides clearly in the UI. This PR allows config source to be passed through `ConfigModel`.
## Tests
Manual
