### PR TITLE
Add new action to update cli version

### DIFF
--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -36,4 +36,4 @@ jobs:
           branch: update-cli-v${{ github.event.inputs.version }}
           title: 'Update Databricks CLI to v${{ github.event.inputs.version }}'
           team-reviewers: eng-dev-ecosystem
-          draft: true
+          draft: false

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -1,0 +1,39 @@
+name: update-cli-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
+
+jobs:
+  update-cli-version:
+    runs-on: ubuntu-latest
+
+    strategy:
+        matrix:
+            node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install JQ
+        run: sudo apt-get install jq
+
+      - name: Update CLI version
+        run: jq '.cli.version = "{{ github.event.inputs.version }}"' packages/databricks-vscode/package.json --indent 4 > tmp.json && mv tmp.json packages/databricks-vscode/package.json
+
+      - name: Create a pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update Databricks CLI to v${{ github.event.inputs.version }}
+          body: Update Databricks CLI to v${{ github.event.inputs.version }}
+          committer: GitHub <noreply@github.com>
+          branch: update-cli-v${{ github.event.inputs.version }}
+          title: 'Update Databricks CLI to v${{ github.event.inputs.version }}'
+          team-reviewers: eng-dev-ecosystem
+          draft: true


### PR DESCRIPTION
It will be triggered automatically after we add a dispatch logic to the CLI repo ([in the release action](https://github.com/databricks/cli/blob/main/.github/workflows/release.yml#L36)).

The approach is the same as we've introduced for automatic PRs to the setup-cli repo: https://github.com/databricks/setup-cli/pull/48

