### PR TITLE
Remove team-reviewers field from the "update CLI" action

### DIFF
--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -35,5 +35,4 @@ jobs:
           committer: GitHub <noreply@github.com>
           branch: update-cli-v${{ github.event.inputs.version }}
           title: 'Update Databricks CLI to v${{ github.event.inputs.version }}'
-          team-reviewers: eng-dev-ecosystem
           draft: false


### PR DESCRIPTION
It requires too many permissions


