### PR TITLE
Use deco PAT token in the update-cli-action

### DIFF
--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DECO_GITHUB_TOKEN }}
           commit-message: Update Databricks CLI to v${{ github.event.inputs.version }}
           body: Update Databricks CLI to v${{ github.event.inputs.version }}
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
Using default token leads to the auto-generated PRs not triggering any workflows. Github recommends using separate PATs for this use-case. We've already exported new secret to the repo, this PR is about using it in the action


