### PR TITLE
Store `lastInstalledExtensionVersion` in the global storage so we only show `what's new` once

### DIFF
--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
@@ -70,7 +70,7 @@ const Keys = {
     }),
 
     "databricks.lastInstalledExtensionVersion": withType<string>()({
-        location: "workspace",
+        location: "global",
         defaultValue: "0.0.0",
     }),
 };


### PR DESCRIPTION
## Changes
* We were storing `lastInstalledExtensionVersion` in workspace state storage, which is causing the extension to show the `what's new` popup for every workspace once. We should store it in the global storage instead. 

**Note**: Users will see a 1 time popup after this update before the versions are updated in the global location correctly.

## Tests
* manually
