### PR TITLE
Explicitly clear terminal environment variables before injecting new ones

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -88,9 +88,10 @@ export async function activate(
 
     // Add the databricks binary to the PATH environment variable in terminals
     context.environmentVariableCollection.clear();
-    context.environmentVariableCollection.append(
+    context.environmentVariableCollection.persistent = false;
+    context.environmentVariableCollection.prepend(
         "PATH",
-        `${path.delimiter}${context.asAbsolutePath("./bin")}`
+        `${context.asAbsolutePath("./bin")}${path.delimiter}`
     );
 
     const loggerManager = new LoggerManager(context);


### PR DESCRIPTION
## Changes
* Environment variables are not getting refreshed by just issuing the `environmentVariableCollection.replace` command. We now explicitly clear the terminal env (`environmentVariableCollection.clear`) before injecting new variables.
* Also synchronised writing env file and exporting to terminal. Env file is written first and we export to terminal only on successful writes. 

fixes https://github.com/databricks/databricks-vscode/issues/980

## Tests
* manual
