### PR TITLE
Remove bundle source

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -200,7 +200,7 @@ export class ConnectionCommands implements Disposable {
     }
 
     async selectTarget() {
-        const targets = await this.configModel.bundlePreValidateModel.targets;
+        const targets = await this.configModel.targets;
         const currentTarget = this.configModel.target;
         if (targets === undefined) {
             return;

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -171,9 +171,8 @@ export class ConnectionManager implements Disposable {
         }
 
         // Try to load a profile user had previously selected for this target
-        const savedProfile = (
-            await this.configModel.overrideableConfigModel.load()
-        ).authProfile;
+        const savedProfile = (await this.configModel.get("overrides"))
+            ?.authProfile;
         if (savedProfile !== undefined) {
             const authProvider = new ProfileAuthProvider(host, savedProfile);
             if (await authProvider.check()) {
@@ -183,8 +182,8 @@ export class ConnectionManager implements Disposable {
 
         // Try to load any parameters that are hard coded in the bundle
         const bundleAuthParams =
-            await this.configModel.bundlePreValidateModel.load();
-        if (bundleAuthParams.authParams !== undefined) {
+            await this.configModel.get("preValidateConfig");
+        if (bundleAuthParams?.authParams !== undefined) {
             throw new Error("Bundle auth params not implemented");
         }
 

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -42,6 +42,7 @@ type ConfigState = Pick<
     OverrideableConfigState & {
         preValidateConfig?: BundlePreValidateState;
         validateConfig?: BundleValidateState;
+        overrides?: OverrideableConfigState;
     };
 
 function selectTopLevelKeys(
@@ -90,6 +91,7 @@ export class ConfigModel implements Disposable {
             ...overrides,
             preValidateConfig: bundlePreValidateConfig,
             validateConfig: bundleValidateConfig,
+            overrides,
         };
     }
 
@@ -109,9 +111,9 @@ export class ConfigModel implements Disposable {
     private _authProvider: AuthProvider | undefined;
 
     constructor(
-        public readonly bundleValidateModel: BundleValidateModel,
-        public readonly overrideableConfigModel: OverrideableConfigModel,
-        public readonly bundlePreValidateModel: BundlePreValidateModel,
+        private readonly bundleValidateModel: BundleValidateModel,
+        private readonly overrideableConfigModel: OverrideableConfigModel,
+        private readonly bundlePreValidateModel: BundlePreValidateModel,
         private readonly vscodeWhenContext: CustomWhenContext,
         private readonly stateStorage: StateStorage
     ) {
@@ -139,6 +141,9 @@ export class ConfigModel implements Disposable {
         await this.readTarget();
     }
 
+    get targets() {
+        return this.bundlePreValidateModel.targets;
+    }
     /**
      * Try to read target from bundle config.
      * If not found, try to read from state storage.

--- a/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
@@ -55,8 +55,8 @@ export class AuthTypeComponent extends BaseComponent {
         }
 
         const config =
-            (await this.configModel.getS("authProfile")) ??
-            (await this.configModel.getS("authParams"));
+            (await this.configModel.get("authProfile")) ??
+            (await this.configModel.get("authParams"));
         if (config === undefined) {
             // This case can never happen. This is just to make ts happy.
             return [];
@@ -72,7 +72,6 @@ export class AuthTypeComponent extends BaseComponent {
                 description: authProvider.describe(),
                 contextValue: getContextValue(authProvider.authType),
                 id: TREE_ICON_ID,
-                source: config.source,
             },
         ];
     }

--- a/packages/databricks-vscode/src/configuration/ui/ClusterComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ClusterComponent.ts
@@ -85,9 +85,9 @@ export class ClusterComponent extends BaseComponent {
 
     @onError({popup: true})
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
-        const config = await this.configModel.getS("clusterId");
+        const config = await this.configModel.get("clusterId");
 
-        if (config?.config === undefined) {
+        if (config === undefined) {
             // Cluster is not set in bundle and override
             // We are logged in -> Select cluster prompt
             const label = "Select a cluster";
@@ -124,7 +124,6 @@ export class ClusterComponent extends BaseComponent {
                 collapsibleState: TreeItemCollapsibleState.Expanded,
                 contextValue: contextValue,
                 iconPath: icon,
-                source: config.source,
                 id: TREE_ICON_ID,
             },
         ];

--- a/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
@@ -4,8 +4,6 @@ import {
     EventEmitter,
     TreeDataProvider,
     TreeItem,
-    ThemeIcon,
-    ThemeColor,
 } from "vscode";
 
 import {ConnectionManager} from "../ConnectionManager";
@@ -79,47 +77,8 @@ export class ConfigurationDataProvider
                 break;
         }
 
-        const configSourceTooltip = {
-            bundle: "This configuration is loaded from a Databricks Asset Bundle.",
-            override: "This configuration is a workspace only override.",
-        };
-
         return (
             await Promise.all(this.components.map((c) => c.getChildren(parent)))
-        )
-            .map((items) => {
-                // Add config source item to expanded view, if the parent config is not a default
-                if (
-                    parent?.source === undefined ||
-                    parent.source === "default" ||
-                    items.length === 0
-                ) {
-                    return items;
-                }
-
-                const tooltip = configSourceTooltip[parent.source];
-                return [
-                    {
-                        label: "Source",
-                        description: parent.source,
-                        iconPath: new ThemeIcon("info", new ThemeColor("info")),
-                        tooltip,
-                    },
-                    ...items,
-                ];
-            })
-            .flat()
-            .map((item) => {
-                // Add config source tooltip to the config root item, if the  config is not a default
-                // and parent is undefined.
-                if (item.source === undefined || item.source === "default") {
-                    return item;
-                }
-                const tooltip = configSourceTooltip[item.source];
-                return {
-                    ...item,
-                    tooltip,
-                };
-            });
+        ).flat();
     }
 }

--- a/packages/databricks-vscode/src/configuration/ui/types.ts
+++ b/packages/databricks-vscode/src/configuration/ui/types.ts
@@ -1,7 +1,5 @@
 import {TreeItem} from "vscode";
-import {ConfigSource} from "../models/ConfigModel";
 
 export interface ConfigurationTreeItem extends TreeItem {
-    source?: ConfigSource;
     url?: string;
 }


### PR DESCRIPTION
## Changes
* Remove config source tag. It  was being used only for clusterId any and we can figure that out by diffing with the `validatedConfig`.
* Expose `validateConfig` and `preValidateConfig` from the config model.
* Hide configModel submodels.
## Tests
<!-- How is this tested? -->

