### PR TITLE
Add bundle project manager

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -233,7 +233,7 @@
             },
             {
                 "command": "databricks.bundle.initNewProject",
-                "title": "Initialize new Databricks project",
+                "title": "Initialize new project",
                 "enablement": "databricks.context.activated",
                 "category": "Databricks"
             }

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -57,9 +57,9 @@
                 "enablement": "databricks.context.activated && databricks.context.loggedIn"
             },
             {
-                "command": "databricks.connection.configureWorkspace",
+                "command": "databricks.connection.configureLogin",
                 "icon": "$(gear)",
-                "title": "Configure workspace",
+                "title": "Sign in to Databricks workspace",
                 "enablement": "databricks.context.activated",
                 "category": "Databricks"
             },
@@ -278,7 +278,7 @@
             },
             {
                 "view": "configurationView",
-                "contents": "Configure your Databricks workspace:\n[Configure Databricks](command:databricks.connection.configureWorkspace)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
+                "contents": "Sign in to your Databricks workspace:\n[Sign in to Databricks](command:databricks.connection.configureLogin)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
                 "when": "workspaceFolderCount > 0 && !databricks.context.loggedIn"
             },
             {
@@ -290,7 +290,7 @@
         "menus": {
             "view/title": [
                 {
-                    "command": "databricks.connection.configureWorkspace",
+                    "command": "databricks.connection.configureLogin",
                     "when": "view == configurationView",
                     "group": "navigation@3"
                 },
@@ -347,7 +347,7 @@
                     "group": "inline@2"
                 },
                 {
-                    "command": "databricks.connection.configureWorkspace",
+                    "command": "databricks.connection.configureLogin",
                     "when": "view == configurationView && viewItem =~ /^databricks.configuration.authType.*$/",
                     "group": "inline@2"
                 },

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -230,6 +230,12 @@
                 "title": "Select a Databricks Asset Bundle target.",
                 "enablement": "databricks.context.activated",
                 "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.initNewProject",
+                "title": "Initialize new Databricks project",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
             }
         ],
         "viewsContainers": {
@@ -291,6 +297,10 @@
                 },
                 {
                     "command": "databricks.quickstart.open",
+                    "when": "view == configurationView"
+                },
+                {
+                    "command": "databricks.bundle.initNewProject",
                     "when": "view == configurationView"
                 },
                 {

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -273,13 +273,8 @@
             },
             {
                 "view": "configurationView",
-                "contents": "Current workspace has no Databricks configuration at the root level, do you want to initialize a new Databricks project?\n[Initialize New Project](command:databricks.bundle.initNewProject)\n",
-                "when": "workspaceFolderCount > 0 && databricks.context.loggedIn"
-            },
-            {
-                "view": "configurationView",
-                "contents": "Sign in to your Databricks workspace:\n[Sign in to Databricks](command:databricks.connection.configureLogin)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
-                "when": "workspaceFolderCount > 0 && !databricks.context.loggedIn"
+                "contents": "Current workspace has no Databricks configuration at the root level, do you want to initialize a new Databricks project?\n[Initialize New Project](command:databricks.bundle.initNewProject)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
+                "when": "workspaceFolderCount > 0"
             },
             {
                 "view": "configurationView",

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -268,8 +268,18 @@
         "viewsWelcome": [
             {
                 "view": "configurationView",
-                "contents": "In order to connect to a cluster you first have to configure your Databricks workspace:\n[Configure Databricks](command:databricks.connection.configureWorkspace)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
-                "when": "workspaceFolderCount > 0"
+                "contents": "There are multiple Databricks projects in the workspace, please chose which one to open:\n[Open Existing Project](command:databricks.bundle.openSubProject)\n",
+                "when": "workspaceFolderCount > 0 && databricks.context.subProjectsAvailable"
+            },
+            {
+                "view": "configurationView",
+                "contents": "Current workspace has no Databricks configuration at the root level, do you want to initialize a new Databricks project?\n[Initialize New Project](command:databricks.bundle.initNewProject)\n",
+                "when": "workspaceFolderCount > 0 && databricks.context.loggedIn"
+            },
+            {
+                "view": "configurationView",
+                "contents": "Configure your Databricks workspace:\n[Configure Databricks](command:databricks.connection.configureWorkspace)\n[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
+                "when": "workspaceFolderCount > 0 && !databricks.context.loggedIn"
             },
             {
                 "view": "configurationView",

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -56,22 +56,30 @@ export class BundleFileSet {
         return Uri.file(rootFile[0]);
     }
 
-    async getSubProjects(root?: Uri): Promise<{relative: Uri; absolute: Uri}[]> {
+    async getSubProjects(
+        root?: Uri
+    ): Promise<{relative: Uri; absolute: Uri}[]> {
         const subProjectRoots = await glob.glob(
-            toGlobPath(this.getAbsolutePath(this.subProjectFilePattern, root).fsPath),
+            toGlobPath(
+                this.getAbsolutePath(this.subProjectFilePattern, root).fsPath
+            ),
             {nocase: process.platform === "win32"}
         );
-        const normalizedRoot = path.normalize(root?.fsPath ?? this.workspaceRoot.fsPath);
-        return subProjectRoots.map((rootFile) => {
-            const dirname = path.dirname(path.normalize(rootFile));
-            const absolute = Uri.file(dirname);
-            const relative = Uri.file(
-                absolute.fsPath.replace(this.workspaceRoot.fsPath, "")
-            );
-            return {absolute, relative};
-        }).filter(({absolute}) => {
-            return absolute.fsPath !== normalizedRoot;
-        });
+        const normalizedRoot = path.normalize(
+            root?.fsPath ?? this.workspaceRoot.fsPath
+        );
+        return subProjectRoots
+            .map((rootFile) => {
+                const dirname = path.dirname(path.normalize(rootFile));
+                const absolute = Uri.file(dirname);
+                const relative = Uri.file(
+                    absolute.fsPath.replace(this.workspaceRoot.fsPath, "")
+                );
+                return {absolute, relative};
+            })
+            .filter(({absolute}) => {
+                return absolute.fsPath !== normalizedRoot;
+            });
     }
 
     async getIncludedFilesGlob() {

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -61,13 +61,16 @@ export class BundleFileSet {
             toGlobPath(this.getAbsolutePath(this.subProjectFilePattern, root).fsPath),
             {nocase: process.platform === "win32"}
         );
+        const normalizedRoot = path.normalize(root?.fsPath ?? this.workspaceRoot.fsPath);
         return subProjectRoots.map((rootFile) => {
-            const dirname = path.dirname(rootFile);
+            const dirname = path.dirname(path.normalize(rootFile));
             const absolute = Uri.file(dirname);
             const relative = Uri.file(
                 absolute.fsPath.replace(this.workspaceRoot.fsPath, "")
             );
             return {absolute, relative};
+        }).filter(({absolute}) => {
+            return absolute.fsPath !== normalizedRoot;
         });
     }
 

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -38,11 +38,11 @@ export class BundleFileSet {
 
     constructor(private readonly workspaceRoot: Uri) {}
 
-    getAbsolutePath(path: string | Uri) {
+    getAbsolutePath(path: string | Uri, root?: Uri) {
         if (typeof path === "string") {
-            return Uri.joinPath(this.workspaceRoot, path);
+            return Uri.joinPath(root ?? this.workspaceRoot, path);
         }
-        return Uri.joinPath(this.workspaceRoot, path.fsPath);
+        return Uri.joinPath(root ?? this.workspaceRoot, path.fsPath);
     }
 
     async getRootFile() {
@@ -56,9 +56,9 @@ export class BundleFileSet {
         return Uri.file(rootFile[0]);
     }
 
-    async getSubProjects(): Promise<{relative: Uri; absolute: Uri}[]> {
+    async getSubProjects(root?: Uri): Promise<{relative: Uri; absolute: Uri}[]> {
         const subProjectRoots = await glob.glob(
-            toGlobPath(this.getAbsolutePath(this.subProjectFilePattern).fsPath),
+            toGlobPath(this.getAbsolutePath(this.subProjectFilePattern, root).fsPath),
             {nocase: process.platform === "win32"}
         );
         return subProjectRoots.map((rootFile) => {

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -73,7 +73,7 @@ export class BundleFileSet {
                 const dirname = path.dirname(path.normalize(rootFile));
                 const absolute = Uri.file(dirname);
                 const relative = Uri.file(
-                    absolute.fsPath.replace(this.workspaceRoot.fsPath, "")
+                    absolute.fsPath.replace(normalizedRoot, "")
                 );
                 return {absolute, relative};
             })

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -61,10 +61,9 @@ export class BundleFileSet {
             toGlobPath(this.getAbsolutePath(this.subProjectFilePattern).fsPath),
             {nocase: process.platform === "win32"}
         );
-        const delimiter = process.platform === "win32" ? "\\" : "/";
         return subProjectRoots.map((rootFile) => {
-            const partsWithoutFileName = rootFile.split(delimiter).slice(0, -1);
-            const absolute = Uri.file(partsWithoutFileName.join(delimiter));
+            const dirname = path.dirname(rootFile);
+            const absolute = Uri.file(dirname);
             const relative = Uri.file(
                 absolute.fsPath.replace(this.workspaceRoot.fsPath, "")
             );

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -16,6 +16,7 @@ import {CachedValue} from "../locking/CachedValue";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
 import {CliWrapper} from "../cli/CliWrapper";
 import {LoginWizard} from "../configuration/LoginWizard";
+import {Mutex} from "../locking";
 
 export class BundleProjectManager {
     private logger = logging.NamedLogger.getOrCreate(Loggers.Extension);
@@ -35,13 +36,17 @@ export class BundleProjectManager {
 
     private _subProjects = new CachedValue<{absolute: Uri; relative: Uri}[]>(
         async () => {
-            const subProjects = await this.bundleFileSet.getSubProjects();
-            this.customWhenContext.setSubProjectsAvailable(
-                subProjects?.length > 0
+            const projects = await this.bundleFileSet.getSubProjects();
+            this.logger.debug(
+                `Detected ${projects.length} sub folders with bundle projects`
             );
-            return subProjects;
+            this.customWhenContext.setSubProjectsAvailable(projects.length > 0);
+            return projects;
         }
     );
+
+    private projectServicesReady = false;
+    private projectServiceMutex = new Mutex();
 
     constructor(
         private cli: CliWrapper,
@@ -50,41 +55,79 @@ export class BundleProjectManager {
         private configModel: ConfigModel,
         private bundleFileSet: BundleFileSet,
         private workspaceUri: Uri
-    ) {}
+    ) {
+        this.disposables.push(
+            this.bundleFileSet.bundleDataCache.onDidChange(async () => {
+                try {
+                    await this._isBundleProject.refresh();
+                } catch (error) {
+                    this.logger.error(
+                        "Failed to refresh isBundleProject var",
+                        error
+                    );
+                }
+            }),
+            this._isBundleProject.onDidChange(async () => {
+                try {
+                    await this.configureBundleProject();
+                } catch (error) {
+                    this.logger.error(
+                        "Failed to configure bundle project after isBundleProject change",
+                        error
+                    );
+                }
+            })
+        );
+    }
 
     public async isBundleProject(): Promise<boolean> {
         return await this._isBundleProject.value;
     }
 
     public async configureWorkspace(): Promise<void> {
-        if (await this.isBundleProject()) {
-            this.logger.debug("Detected an existing bundle project");
-            return this.initExistingProject();
-        }
+        // We listen to _isBundleProject changes and call configureBundleProject
+        await this._isBundleProject.refresh();
+
+        // The cached value updates subProjectsAvailabe context.
+        // We have a configurationView that shows "open project" button if the context value is true.
+        await this._subProjects.refresh();
+
         const isLegacyProject = await this._isLegacyProject.value;
         if (isLegacyProject) {
             this.logger.debug(
                 "Detected a legacy project.json, starting automatic migration"
             );
             await this.migrateProjectJsonToBundle();
-            await this._isBundleProject.refresh();
-            return this.initExistingProject();
-        }
-        const subProjects = await this._subProjects.value;
-        if (subProjects.length > 0) {
-            this.logger.debug(
-                "Detected multiple sub folders with bundle projects"
-            );
-        } else {
-            this.logger.debug(
-                "No bundle or legacy configs detected, waiting for the user to configure auth manually"
-            );
         }
     }
 
-    private async initExistingProject() {
+    private async configureBundleProject() {
+        if (await this.isBundleProject()) {
+            this.logger.debug(
+                "Detected an existing bundle project, initializing project services"
+            );
+            return this.initProjectServices();
+        } else {
+            this.logger.debug(
+                "No bundle config detected, disposing project services"
+            );
+            await this.disposeProjectServices();
+        }
+    }
+
+    @Mutex.synchronise("projectServiceMutex")
+    private async initProjectServices() {
+        if (this.projectServicesReady) {
+            this.logger.debug("Project services have already been initialized");
+            return;
+        }
         await this.configModel.init();
         await this.connectionManager.init();
+        this.projectServicesReady = true;
+    }
+
+    private async disposeProjectServices() {
+        // TODO
     }
 
     public async openSubProjects() {
@@ -95,7 +138,9 @@ export class BundleProjectManager {
         return this.promptToOpenSubProjects(projects);
     }
 
-    private async promptToOpenSubProjects(projects: {absolute: Uri, relative: Uri}[]) {
+    private async promptToOpenSubProjects(
+        projects: {absolute: Uri; relative: Uri}[]
+    ) {
         type OpenProjectItem = QuickPickItem & {uri?: Uri};
         const items: OpenProjectItem[] = projects.map((project) => {
             return {
@@ -136,16 +181,34 @@ export class BundleProjectManager {
             return;
         }
         await this.bundleInitInTerminal(parentFolder, authProvider.toEnv());
+        this.logger.debug(
+            "Finished bundle init wizard, detecting projects to initialize or open"
+        );
         await this._isBundleProject.refresh();
         const projects = await this.bundleFileSet.getSubProjects(parentFolder);
         if (projects.length > 0) {
+            this.logger.debug(
+                `Detected ${projects.length} sub projects after the init wizard, prompting to open one`
+            );
             await this.promptToOpenSubProjects(projects);
         } else {
-            // notify that we don't know what to open
+            this.logger.debug(
+                `No projects detect after the init wizard, showing notification to open a folder manually`
+            );
+            const choice = await window.showInformationMessage(
+                `We haven't detected any Databricks projects in "${parentFolder.fsPath}". If you initialized your project somewhere else, please open the folder manually.`,
+                "Open Folder"
+            );
+            if (choice === "Open Folder") {
+                await commands.executeCommand("vscode.openFolder");
+            }
         }
     }
 
-    private async bundleInitInTerminal(parentFolder: Uri, env: Record<string, string>) {
+    private async bundleInitInTerminal(
+        parentFolder: Uri,
+        env: Record<string, string>
+    ) {
         const terminal = window.createTerminal({
             name: "Databricks Project Init",
             isTransient: true,
@@ -159,10 +222,14 @@ export class BundleProjectManager {
             this.cli.escapePathArgument(parentFolder.fsPath),
         ];
         const finalPrompt = `echo "Press any key to close the terminal and continue ..."; read; exit`;
-        terminal.sendText(`${this.cli.cliPath} ${args.join(" ")}; ${finalPrompt}`);
+        terminal.sendText(
+            `${this.cli.cliPath} ${args.join(" ")}; ${finalPrompt}`
+        );
         return new Promise<void>((resolve) => {
             const closeEvent = window.onDidCloseTerminal(async (t) => {
-                if (t !== terminal) return;
+                if (t !== terminal) {
+                    return;
+                }
                 closeEvent.dispose();
                 resolve();
             });

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -86,7 +86,9 @@ export class BundleProjectManager {
 
     public async configureWorkspace(): Promise<void> {
         // We listen to _isBundleProject changes and call configureBundleProject
-        await this._isBundleProject.refresh();
+        if (await this.isBundleProject()) {
+            return;
+        }
 
         // The cached value updates subProjectsAvailabe context.
         // We have a configurationView that shows "open project" button if the context value is true.

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -46,7 +46,7 @@ export class BundleProjectManager {
     );
 
     private projectServicesReady = false;
-    private projectServiceMutex = new Mutex();
+    private projectServicesMutex = new Mutex();
 
     constructor(
         private cli: CliWrapper,
@@ -115,7 +115,7 @@ export class BundleProjectManager {
         }
     }
 
-    @Mutex.synchronise("projectServiceMutex")
+    @Mutex.synchronise("projectServicesMutex")
     private async initProjectServices() {
         if (this.projectServicesReady) {
             this.logger.debug("Project services have already been initialized");

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -1,0 +1,143 @@
+import {
+    QuickPickItem,
+    QuickPickItemKind,
+    Disposable,
+    Uri,
+    window,
+    commands,
+} from "vscode";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+import {BundleFileSet} from "./BundleFileSet";
+import {logging} from "@databricks/databricks-sdk";
+import {Loggers} from "../logger";
+import {CachedValue} from "../locking/CachedValue";
+import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
+
+export class BundleProjectManager {
+    private logger = logging.NamedLogger.getOrCreate(Loggers.Extension);
+    private disposables: Disposable[] = [];
+
+    private _isBundleProject = new CachedValue<boolean>(async () => {
+        const rootBundleFile = await this.bundleFileSet.getRootFile();
+        return rootBundleFile !== undefined;
+    });
+
+    public onDidChangeStatus = this._isBundleProject.onDidChange;
+
+    private _isLegacyProject = new CachedValue<boolean>(async () => {
+        // TODO
+        return false;
+    });
+
+    private _subProjects = new CachedValue<{absolute: Uri; relative: Uri}[]>(
+        async () => {
+            const subProjects = await this.bundleFileSet.getSubProjects();
+            this.customWhenContext.setSubProjectsAvailable(
+                subProjects?.length > 0
+            );
+            return subProjects;
+        }
+    );
+
+    constructor(
+        private customWhenContext: CustomWhenContext,
+        private connectionManager: ConnectionManager,
+        private configModel: ConfigModel,
+        private bundleFileSet: BundleFileSet,
+        private workspaceUri: Uri
+    ) {}
+
+    public async isBundleProject(): Promise<boolean> {
+        return await this._isBundleProject.value;
+    }
+
+    public async configureWorkspace(): Promise<void> {
+        if (await this.isBundleProject()) {
+            this.logger.debug("Detected an existing bundle project");
+            return this.initExistingProject();
+        }
+        const isLegacyProject = await this._isLegacyProject.value;
+        if (isLegacyProject) {
+            this.logger.debug(
+                "Detected a legacy project.json, starting automatic migration"
+            );
+            await this.migrateProjectJsonToBundle();
+            await this._isBundleProject.refresh();
+            return this.initExistingProject();
+        }
+        const subProjects = await this._subProjects.value;
+        if (subProjects.length > 0) {
+            this.logger.debug(
+                "Detected multiple sub folders with bundle projects, prompting to open one"
+            );
+        } else {
+            this.logger.debug(
+                "No bundle or legacy configs detected, waiting for the user to configure auth manually"
+            );
+        }
+    }
+
+    private async initExistingProject() {
+        await this.configModel.init();
+        await this.connectionManager.init();
+    }
+
+    public async promptToOpenSubProjects() {
+        const projects = await this._subProjects.value;
+        if (projects.length === 0) {
+            return;
+        }
+        type OpenProjectItem = QuickPickItem & {uri?: Uri};
+        const items: OpenProjectItem[] = projects.map((project) => {
+            return {
+                uri: project.absolute,
+                label: project.relative.fsPath,
+                detail: project.absolute.fsPath,
+            };
+        });
+        items.push(
+            {label: "", kind: QuickPickItemKind.Separator},
+            {label: "Choose another folder"}
+        );
+        const options = {
+            title: "We've detected several Databricks projects, select the one you want to open",
+        };
+        const item = await window.showQuickPick<OpenProjectItem>(
+            items,
+            options
+        );
+        if (!item) {
+            return;
+        }
+        await commands.executeCommand("vscode.openFolder", item.uri);
+    }
+
+    private async migrateProjectJsonToBundle() {
+        // TODO
+    }
+
+    public async initNewProject() {
+        const parentFolder = await this.promptForParentFolder();
+        if (!parentFolder) {
+            this.logger.debug("No parent folder provided");
+            return;
+        }
+        // TODO
+    }
+
+    private async promptForParentFolder(): Promise<Uri | undefined> {
+        const parentPath = await window.showInputBox({
+            title: "Provide a path to a folder where you would want your new project to be",
+            value: this.workspaceUri.fsPath,
+        });
+        if (!parentPath) {
+            return undefined;
+        }
+        return Uri.file(parentPath);
+    }
+
+    dispose() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -156,7 +156,7 @@ export class BundleProjectManager {
             {label: "Choose another folder"}
         );
         const options = {
-            title: "We've detected several Databricks projects, select the one you want to open",
+            title: "Select the project you want to open",
         };
         const item = await window.showQuickPick<OpenProjectItem>(
             items,
@@ -173,8 +173,12 @@ export class BundleProjectManager {
     }
 
     public async initNewProject() {
-        const authProvider = await LoginWizard.run(this.cli, this.configModel);
+        let authProvider = this.connectionManager.databricksWorkspace?.authProvider;
+        if (!authProvider) {
+            authProvider = await LoginWizard.run(this.cli, this.configModel);
+        }
         if (!authProvider || !(await authProvider.check())) {
+            this.logger.debug("No valid auth providers, can't proceed with bundle init wizard");
             return;
         }
         const parentFolder = await this.promptForParentFolder();
@@ -195,7 +199,7 @@ export class BundleProjectManager {
             await this.promptToOpenSubProjects(projects);
         } else {
             this.logger.debug(
-                `No projects detect after the init wizard, showing notification to open a folder manually`
+                `No projects detected after the init wizard, showing notification to open a folder manually`
             );
             const choice = await window.showInformationMessage(
                 `We haven't detected any Databricks projects in "${parentFolder.fsPath}". If you initialized your project somewhere else, please open the folder manually.`,

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -75,6 +75,11 @@ export class BundleProjectManager {
                         "Failed to configure bundle project after isBundleProject change",
                         error
                     );
+                    const message =
+                        (error as Error)?.message ?? "Unknown Error";
+                    window.showErrorMessage(
+                        `Failed to configure Databricks project: ${message}`
+                    );
                 }
             })
         );

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -262,7 +262,7 @@ export class BundleProjectManager {
         return {
             cancelled: item === undefined,
             approved: item?.approved ?? false,
-        }
+        };
     }
 
     private async bundleInitInTerminal(

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -173,12 +173,15 @@ export class BundleProjectManager {
     }
 
     public async initNewProject() {
-        let authProvider = this.connectionManager.databricksWorkspace?.authProvider;
+        let authProvider =
+            this.connectionManager.databricksWorkspace?.authProvider;
         if (!authProvider) {
             authProvider = await LoginWizard.run(this.cli, this.configModel);
         }
         if (!authProvider || !(await authProvider.check())) {
-            this.logger.debug("No valid auth providers, can't proceed with bundle init wizard");
+            this.logger.debug(
+                "No valid auth providers, can't proceed with bundle init wizard"
+            );
             return;
         }
         const parentFolder = await this.promptForParentFolder();

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -57,7 +57,7 @@ describe(__filename, () => {
         mocks.push(configsSpy);
         when(configsSpy.loggingEnabled).thenReturn(true);
         const cli = createCliWrapper(logFilePath);
-        await execFile(cli.cliPath, ["version", ...cli.loggingArguments]);
+        await execFile(cli.cliPath, ["version", ...cli.getLoggingArguments()]);
         const file = await readFile(logFilePath);
         // Just checking if the file is not empty to avoid depending on internal CLI log patterns
         assert.ok(file.toString().length > 0);

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -45,19 +45,29 @@ export class CliWrapper {
         return this.extensionContext.asAbsolutePath("./bin/databricks");
     }
 
-    getLoggingArguments(escape?: boolean): string[] {
+    getLoggingArguments(): string[] {
         if (!workspaceConfigs.loggingEnabled) {
             return [];
         }
-        const logFilePath = this.logFilePath ?? "stderr";
         return [
             "--log-level",
             "debug",
             "--log-file",
-            escape ? this.escapePathArgument(logFilePath) : logFilePath,
+            this.logFilePath ?? "stderr",
             "--log-format",
             "json",
         ];
+    }
+
+    getLogginEnvVars(): Record<string, string> {
+        if (!workspaceConfigs.loggingEnabled) {
+            return {};
+        }
+        return {
+            DATABRICKS_LOG_LEVEL: "debug",
+            DATABRICKS_LOG_FILE: this.logFilePath ?? "stderr",
+            DATABRICKS_LOG_FORMAT: "json",
+        }
     }
 
     escapePathArgument(arg: string): string {

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -45,18 +45,23 @@ export class CliWrapper {
         return this.extensionContext.asAbsolutePath("./bin/databricks");
     }
 
-    get loggingArguments(): string[] {
+    getLoggingArguments(escape?: boolean): string[] {
         if (!workspaceConfigs.loggingEnabled) {
             return [];
         }
+        const logFilePath = this.logFilePath ?? "stderr";
         return [
             "--log-level",
             "debug",
             "--log-file",
-            this.logFilePath ?? "stderr",
+            escape ? this.escapePathArgument(logFilePath) : logFilePath,
             "--log-format",
             "json",
         ];
+    }
+
+    escapePathArgument(arg: string): string {
+        return `"${arg.replaceAll('"', '\\"')}"`;
     }
 
     /**
@@ -73,7 +78,7 @@ export class CliWrapper {
             "--watch",
             "--output",
             "json",
-            ...this.loggingArguments,
+            ...this.getLoggingArguments(),
         ];
         if (syncType === "full") {
             args.push("--full");
@@ -88,7 +93,7 @@ export class CliWrapper {
                 "auth",
                 "profiles",
                 "--skip-validate",
-                ...this.loggingArguments,
+                ...this.getLoggingArguments(),
             ],
         };
     }

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -64,10 +64,12 @@ export class CliWrapper {
             return {};
         }
         return {
+            /* eslint-disable @typescript-eslint/naming-convention */
             DATABRICKS_LOG_LEVEL: "debug",
             DATABRICKS_LOG_FILE: this.logFilePath ?? "stderr",
             DATABRICKS_LOG_FORMAT: "json",
-        }
+            /* eslint-enable @typescript-eslint/naming-convention */
+        };
     }
 
     escapePathArgument(arg: string): string {

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -66,7 +66,7 @@ export class ConnectionCommands implements Disposable {
         this.connectionManager.logout();
     }
 
-    async configureWorkspaceCommand() {
+    async configureLoginCommand() {
         await this.connectionManager.configureLogin();
     }
 

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -246,14 +246,10 @@ export class ConnectionManager implements Disposable {
 
                 await this.updateSyncDestinationMapper();
                 await this.updateClusterManager();
-                // Target may not exist when we login in the workspace without any bundle configuration
-                // (e.g. for the sake of bundle initialization wizard)
-                if (this.configModel.target) {
-                    await this.configModel.set(
-                        "authProfile",
-                        authProvider.toJSON().profile as string | undefined
-                    );
-                }
+                await this.configModel.set(
+                    "authProfile",
+                    authProvider.toJSON().profile as string | undefined
+                );
                 await this.configModel.setAuthProvider(authProvider);
                 await this._metadataService.setApiClient(this.apiClient);
                 this.updateState("CONNECTED");

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -121,7 +121,6 @@ export class ConnectionManager implements Disposable {
     }
 
     public async init() {
-        await this.configModel.init();
         await this.loginWithSavedAuth();
 
         this.disposables.push(
@@ -247,10 +246,14 @@ export class ConnectionManager implements Disposable {
 
                 await this.updateSyncDestinationMapper();
                 await this.updateClusterManager();
-                await this.configModel.set(
-                    "authProfile",
-                    authProvider.toJSON().profile as string | undefined
-                );
+                // Target may not exist when we login in the workspace without any bundle configuration
+                // (e.g. for the sake of bundle initialization wizard)
+                if (this.configModel.target) {
+                    await this.configModel.set(
+                        "authProfile",
+                        authProvider.toJSON().profile as string | undefined
+                    );
+                }
                 await this.configModel.setAuthProvider(authProvider);
                 this.updateState("CONNECTED");
             });

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -255,6 +255,7 @@ export class ConnectionManager implements Disposable {
                     );
                 }
                 await this.configModel.setAuthProvider(authProvider);
+                await this._metadataService.setApiClient(this.apiClient);
                 this.updateState("CONNECTED");
             });
         } catch (e) {

--- a/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
@@ -47,8 +47,8 @@ export class AuthTypeComponent extends BaseComponent {
                     contextValue: getContextValue("none"),
                     id: TREE_ICON_ID,
                     command: {
-                        title: "Login to Databricks",
-                        command: "databricks.connection.configureWorkspace",
+                        title: "Sign in to Databricks",
+                        command: "databricks.connection.configureLogin",
                     },
                 },
             ];

--- a/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
@@ -73,11 +73,6 @@ export class ConfigurationDataProvider
     async getChildren(
         parent?: ConfigurationTreeItem | undefined
     ): Promise<Array<ConfigurationTreeItem>> {
-        if (this.connectionManager.state === "DISCONNECTED") {
-            return [];
-        } else if (this.connectionManager.state === "CONNECTING") {
-            await this.connectionManager.waitForConnect();
-        }
         const isInBundleProject =
             await this.bundleProjectManager.isBundleProject();
         if (!isInBundleProject) {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -440,8 +440,8 @@ export async function activate(
             connectionCommands
         ),
         telemetry.registerCommand(
-            "databricks.connection.configureWorkspace",
-            connectionCommands.configureWorkspaceCommand,
+            "databricks.connection.configureLogin",
+            connectionCommands.configureLoginCommand,
             connectionCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -227,6 +227,7 @@ export async function activate(
     context.subscriptions.push(metadataService);
 
     const bundleProjectManager = new BundleProjectManager(
+        cli,
         customWhenContext,
         connectionManager,
         configModel,
@@ -237,7 +238,7 @@ export async function activate(
         bundleProjectManager,
         telemetry.registerCommand(
             "databricks.bundle.openSubProject",
-            bundleProjectManager.promptToOpenSubProjects,
+            bundleProjectManager.openSubProjects,
             bundleProjectManager
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -644,6 +644,10 @@ export async function activate(
     );
 
     bundleProjectManager.configureWorkspace().catch((e) => {
+        logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+            "Failed to configure workspace",
+            e
+        );
         window.showErrorMessage(e);
     });
 

--- a/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
+++ b/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
@@ -27,6 +27,14 @@ export class CustomWhenContext {
         );
     }
 
+    setSubProjectsAvailable(value: boolean) {
+        commands.executeCommand(
+            "setContext",
+            "databricks.context.subProjectsAvailable",
+            value
+        );
+    }
+
     updateShowClusterView() {
         commands.executeCommand(
             "setContext",


### PR DESCRIPTION
"Bundle project manager" is being initialised before configModel or connectionManager.
If necessary, it does automatic migration from the legacy projects to the bundles (will be implemented in the follow-up).
If it detects multiple bundle projects and offers to choose which one to open. If it detects a bundle config in the root of the workspace it kicks off configModel and connectionManager.
If it detects no bundle config in the root, it offers to create a project (spawning the Databricks CLI in the terminal)

I've played around with displaying notifications for things like "hey, chose one project to open", or "there's no config in your workspace, would you like to init a new project?", but they don't flow well with existing quick-pick/input wizards and are pretty easy to miss. Currently I'm using welcome views to show such information:

The default view is still the same:
![Screenshot 2024-01-22 at 10 11 20](https://github.com/databricks/databricks-vscode/assets/148094031/b185b327-5e91-4fed-8609-93724c9532c8)

If we don't detect bundle config in the root, but there are subfolders with bundles, we show an additional text and a button:
![Screenshot 2024-01-22 at 10 11 58](https://github.com/databricks/databricks-vscode/assets/148094031/e90184ea-3e74-44b1-b0ba-f90720c7c72f)

It's still possible to login in this state, after which we will also show "init" button:

![Screenshot 2024-01-22 at 10 13 27](https://github.com/databricks/databricks-vscode/assets/148094031/9b43a3b6-ac62-47cc-93db-1dd1285023c2)

If there are no sub-projects, then we just show login button alone in the view:
![Screenshot 2024-01-22 at 10 14 54](https://github.com/databricks/databricks-vscode/assets/148094031/68f4a84f-4974-4ba3-9d96-45f7113668c2)


 

