### PR TITLE
Deploy and run resource

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -244,6 +244,19 @@
                 "title": "Deploy bundle",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet",
                 "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.deployAndRun",
+                "icon": "$(debug-start)",
+                "title": "Deploy the bundle and run the resource",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.cancelAllRuns",
+                "title": "Cancel all runs",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet",
+                "category": "Databricks"
             }
         ],
         "viewsContainers": {
@@ -388,6 +401,11 @@
                 {
                     "command": "databricks.cluster.start",
                     "when": "view == configurationView && viewItem == databricks.configuration.cluster.terminated",
+                    "group": "inline@0"
+                },
+                {
+                    "command": "databricks.bundle.deployAndRun",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.*.runnable.*$/",
                     "group": "inline@0"
                 }
             ],

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -257,6 +257,13 @@
                 "title": "Cancel all runs",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet",
                 "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.cancelRun",
+                "title": "Cancel run",
+                "icon": "$(debug-stop)",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet",
+                "category": "Databricks"
             }
         ],
         "viewsContainers": {
@@ -406,6 +413,11 @@
                 {
                     "command": "databricks.bundle.deployAndRun",
                     "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.*.runnable.*$/",
+                    "group": "inline@0"
+                },
+                {
+                    "command": "databricks.bundle.cancelRun",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.*.running.*$/",
                     "group": "inline@0"
                 }
             ],

--- a/packages/databricks-vscode/src/bundle/BundleCommands.ts
+++ b/packages/databricks-vscode/src/bundle/BundleCommands.ts
@@ -1,6 +1,22 @@
 import {Disposable, window} from "vscode";
 import {BundleRemoteStateModel} from "./models/BundleRemoteStateModel";
 import {onError} from "../utils/onErrorDecorator";
+import {
+    TreeNode as BundleResourceExplorerTreeNode,
+    ResourceTreeNode as BundleResourceExplorerResourceTreeNode,
+} from "../ui/bundle-resource-explorer/types";
+import {BundleRunManager} from "./BundleRunManager";
+
+const RUNNABLE_RESOURCES = [
+    "pipelines",
+    "jobs",
+] satisfies BundleResourceExplorerTreeNode["type"][];
+
+function isRunnable(
+    treeNode: BundleResourceExplorerTreeNode
+): treeNode is BundleResourceExplorerResourceTreeNode {
+    return (RUNNABLE_RESOURCES as string[]).includes(treeNode.type);
+}
 
 export class BundleCommands implements Disposable {
     private disposables: Disposable[] = [];
@@ -8,7 +24,19 @@ export class BundleCommands implements Disposable {
         "Databricks Asset Bundles"
     );
 
-    constructor(private bundleRemoteStateModel: BundleRemoteStateModel) {
+    private writeToChannel = (data: string) => {
+        this.outputChannel.append(data);
+    };
+
+    private prepareOutputChannel() {
+        this.outputChannel.show(true);
+        this.outputChannel.appendLine("");
+    }
+
+    constructor(
+        private readonly bundleRemoteStateModel: BundleRemoteStateModel,
+        private readonly bundleRunManager: BundleRunManager
+    ) {
         this.disposables.push(this.outputChannel);
     }
 
@@ -19,21 +47,40 @@ export class BundleCommands implements Disposable {
 
     @onError({popup: {prefix: "Error deploying the bundle."}})
     async deploy() {
-        this.outputChannel.show(true);
-        this.outputChannel.appendLine("");
-
-        const writeToChannel = (data: string) => {
-            this.outputChannel.append(data);
-        };
         await window.withProgress(
             {location: {viewId: "dabsResourceExplorerView"}},
             async () => {
                 await this.bundleRemoteStateModel.deploy(
-                    writeToChannel,
-                    writeToChannel
+                    this.writeToChannel,
+                    this.writeToChannel
                 );
             }
         );
+    }
+
+    @onError({popup: {prefix: "Error running resource."}})
+    async deployAndRun(treeNode: BundleResourceExplorerTreeNode) {
+        if (!isRunnable(treeNode)) {
+            throw new Error(`Cannot run resource of type ${treeNode.type}`);
+        }
+        //TODO: Don't deploy if there is no diff between local and remote state
+        this.prepareOutputChannel();
+        await window.withProgress(
+            {location: {viewId: "dabsResourceExplorerView"}},
+            async () => {
+                await this.bundleRemoteStateModel.deploy(
+                    this.writeToChannel,
+                    this.writeToChannel
+                );
+            }
+        );
+
+        await this.bundleRunManager.run(treeNode.resourceKey);
+    }
+
+    @onError({popup: {prefix: "Error cancelling run."}})
+    async cancelRun() {
+        this.bundleRunManager.cancelAll();
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/bundle/BundleCommands.ts
+++ b/packages/databricks-vscode/src/bundle/BundleCommands.ts
@@ -79,8 +79,12 @@ export class BundleCommands implements Disposable {
     }
 
     @onError({popup: {prefix: "Error cancelling run."}})
-    async cancelRun() {
-        this.bundleRunManager.cancelAll();
+    async cancelRun(treeNode: BundleResourceExplorerTreeNode) {
+        if (!isRunnable(treeNode)) {
+            throw new Error(`Resource of ${treeNode.type} is not runnable`);
+        }
+
+        this.bundleRunManager.cancel(treeNode.resourceKey);
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/bundle/CustomOutputTerminal.ts
+++ b/packages/databricks-vscode/src/bundle/CustomOutputTerminal.ts
@@ -1,0 +1,86 @@
+import {ChildProcess, SpawnOptions, spawn} from "child_process";
+import {Pseudoterminal, Event, EventEmitter} from "vscode";
+
+export class CustomOutputTerminal implements Pseudoterminal {
+    private writeEmitter = new EventEmitter<string>();
+    onDidWrite: Event<string> = this.writeEmitter.event;
+
+    private closeEmitter = new EventEmitter<number | void>();
+    onDidClose: Event<number | void> = this.closeEmitter.event;
+
+    private onDidCloseProcessEmitter = new EventEmitter<number | null>();
+    onDidCloseProcess: Event<number | null> =
+        this.onDidCloseProcessEmitter.event;
+
+    private _process: ChildProcess | undefined;
+    public get process(): ChildProcess | undefined {
+        return this._process;
+    }
+
+    constructor() {}
+
+    open(): void {}
+
+    spawn({
+        cmd,
+        args,
+        options,
+    }: {
+        cmd: string;
+        args: string[];
+        options: SpawnOptions;
+    }): void {
+        this.writeEmitter.fire("\x1b[2J\x1b[H");
+        this._process = spawn(cmd, args, options);
+        if (!this.process) {
+            throw new Error("Can't start process: process is undefined");
+        }
+
+        if (!this.process.stderr) {
+            throw new Error("Can't start process: can't pipe stderr process");
+        }
+
+        if (!this.process.stdout) {
+            throw new Error("Can't start process: can't pipe stdout process");
+        }
+
+        this.process.stdout.on("data", (data) => {
+            let dataStr = data.toString();
+            dataStr = dataStr.replaceAll("\n", "\r\n");
+            if (!dataStr.endsWith("\r\n")) {
+                dataStr = dataStr + "\r\n";
+            }
+            this.writeEmitter.fire(dataStr);
+        });
+
+        this.process.stderr.on("data", (data) => {
+            let dataStr: string = data.toString();
+            dataStr = dataStr.replaceAll("\n", "\r\n");
+            if (!dataStr.endsWith("\r\n")) {
+                dataStr = dataStr + "\r\n";
+            }
+            this.writeEmitter.fire(dataStr);
+        });
+
+        this.process.on("close", (exitCode) => {
+            this.onDidCloseProcessEmitter.fire(exitCode);
+            this._process = undefined;
+        });
+
+        this.process.on("error", (err) => {
+            this.writeEmitter.fire("\x1b[31m" + err.message + "\x1b[0m\r\n");
+            this.writeEmitter.fire(
+                "\x1b[31m" + (err.stack ?? "") + "\x1b[0m\r\n"
+            );
+        });
+    }
+
+    close(): void {
+        if (this.process !== undefined) {
+            this.writeEmitter.fire(
+                "\x1b[31mProcess killed by user input\x1b[0m\r\n"
+            );
+        }
+        this.process?.kill();
+    }
+}

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -1,5 +1,6 @@
 import {
     ChildProcessWithoutNullStreams,
+    SpawnOptionsWithoutStdio,
     execFile as execFileCb,
     spawn,
 } from "child_process";
@@ -13,6 +14,7 @@ import {Context, context} from "@databricks/databricks-sdk/dist/context";
 import {Cloud} from "../utils/constants";
 import {EnvVarGenerators, UrlUtils} from "../utils";
 import {AuthProvider} from "../configuration/auth/AuthProvider";
+import {removeUndefinedKeys} from "../utils/envVarGenerators";
 
 const withLogContext = logging.withLogContext;
 const execFile = promisify(execFileCb);
@@ -244,9 +246,9 @@ export class CliWrapper {
         workspaceFolder: Uri,
         configfilePath?: string
     ) {
-        let {stdout, stderr} = await execFile(
+        const {stdout, stderr} = await execFile(
             this.cliPath,
-            ["bundle", "summarise", "--target", target],
+            ["bundle", "summary", "--target", target],
             {
                 cwd: workspaceFolder.fsPath,
                 env: {
@@ -260,9 +262,6 @@ export class CliWrapper {
             }
         );
 
-        //TODO: remove this hack once cli command is fixed.
-        stdout = stderr;
-        stderr = "";
         if (stderr !== "") {
             throw new Error(stderr);
         }
@@ -300,5 +299,35 @@ export class CliWrapper {
         );
 
         return await waitForProcess(p, onStdOut, onStdError);
+    }
+
+    getBundleRunCommand(
+        target: string,
+        authProvider: AuthProvider,
+        resourceKey: string,
+        workspaceFolder: Uri,
+        configfilePath?: string
+    ): {
+        cmd: string;
+        args: string[];
+        options: SpawnOptionsWithoutStdio;
+    } {
+        const env: Record<string, string> = removeUndefinedKeys({
+            ...EnvVarGenerators.getEnvVarsForCli(configfilePath),
+            ...EnvVarGenerators.getProxyEnvVars(),
+            ...authProvider.toEnv(),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            DATABRICKS_CLUSTER_ID: this.clusterId,
+        });
+
+        return {
+            cmd: this.cliPath,
+            args: ["bundle", "run", "--target", target, resourceKey],
+            options: {
+                cwd: workspaceFolder.fsPath,
+                env,
+                shell: true,
+            },
+        };
     }
 }

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -217,7 +217,6 @@ export class ConfigModel implements Disposable {
         this.vscodeWhenContext.isTargetSet(this._target !== undefined);
     }
 
-    @onError({popup: {prefix: "Failed to set auth provider."}})
     @Mutex.synchronise("configsMutex")
     public async setAuthProvider(authProvider: AuthProvider | undefined) {
         this._authProvider = authProvider;

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -547,10 +547,14 @@ export async function activate(
     );
 
     // Bundle resource explorer
-    const bundleResourceExplorerTreeDataProvider =
-        new BundleResourceExplorerTreeDataProvider(configModel, context);
-
     const bundleRunManager = new BundleRunManager(bundleRemoteStateModel);
+    const bundleResourceExplorerTreeDataProvider =
+        new BundleResourceExplorerTreeDataProvider(
+            configModel,
+            bundleRunManager,
+            context
+        );
+
     const bundleCommands = new BundleCommands(
         bundleRemoteStateModel,
         bundleRunManager
@@ -580,6 +584,11 @@ export async function activate(
         ),
         telemetry.registerCommand(
             "databricks.bundle.cancelAllRuns",
+            bundleCommands.cancelRun,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.bundle.cancelRun",
             bundleCommands.cancelRun,
             bundleCommands
         )

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -60,6 +60,7 @@ import {BundlePreValidateModel} from "./bundle/models/BundlePreValidateModel";
 import {BundleRemoteStateModel} from "./bundle/models/BundleRemoteStateModel";
 import {BundleResourceExplorerTreeDataProvider} from "./ui/bundle-resource-explorer/BundleResourceExplorerTreeDataProvider";
 import {BundleCommands} from "./bundle/BundleCommands";
+import {BundleRunManager} from "./bundle/BundleRunManager";
 
 const customWhenContext = new CustomWhenContext();
 
@@ -548,10 +549,16 @@ export async function activate(
     // Bundle resource explorer
     const bundleResourceExplorerTreeDataProvider =
         new BundleResourceExplorerTreeDataProvider(configModel, context);
-    const bundleCommands = new BundleCommands(bundleRemoteStateModel);
+
+    const bundleRunManager = new BundleRunManager(bundleRemoteStateModel);
+    const bundleCommands = new BundleCommands(
+        bundleRemoteStateModel,
+        bundleRunManager
+    );
     context.subscriptions.push(
         bundleResourceExplorerTreeDataProvider,
         bundleCommands,
+        bundleRunManager,
         window.registerTreeDataProvider(
             "dabsResourceExplorerView",
             bundleResourceExplorerTreeDataProvider
@@ -564,6 +571,16 @@ export async function activate(
         telemetry.registerCommand(
             "databricks.bundle.deploy",
             bundleCommands.deploy,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.bundle.deployAndRun",
+            bundleCommands.deployAndRun,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.bundle.cancelAllRuns",
+            bundleCommands.cancelRun,
             bundleCommands
         )
     );

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleResourceExplorerTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleResourceExplorerTreeDataProvider.ts
@@ -14,6 +14,7 @@ import {onError} from "../../utils/onErrorDecorator";
 import {TasksRenderer} from "./TasksRenderer";
 import {PipelineRenderer} from "./PipelineRenderer";
 import path from "path";
+import {BundleRunManager} from "../../bundle/BundleRunManager";
 
 function humaniseResourceType(type: TreeNode["type"]) {
     switch (type) {
@@ -35,12 +36,13 @@ export class BundleResourceExplorerTreeDataProvider
         this._onDidChangeTreeData.event;
 
     private renderers: Array<Renderer> = [
-        new JobsRenderer(),
-        new PipelineRenderer(),
+        new JobsRenderer(this.bundleRunManager),
+        new PipelineRenderer(this.bundleRunManager),
         new TasksRenderer(this.context),
     ];
     constructor(
         private readonly configModel: ConfigModel,
+        private readonly bundleRunManager: BundleRunManager,
         private readonly context: ExtensionContext
     ) {
         this.disposables.push(
@@ -48,6 +50,9 @@ export class BundleResourceExplorerTreeDataProvider
                 this._onDidChangeTreeData.fire();
             }),
             this.configModel.onDidChangeKey("remoteStateConfig")(() => {
+                this._onDidChangeTreeData.fire();
+            }),
+            this.bundleRunManager.onDidChange(() => {
                 this._onDidChangeTreeData.fire();
             })
         );

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleResourceExplorerTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleResourceExplorerTreeDataProvider.ts
@@ -53,7 +53,7 @@ export class BundleResourceExplorerTreeDataProvider
         );
     }
 
-    @onError({popup: {prefix: "Error rendering DABs Resource Viewer"}})
+    @onError({popup: {prefix: "Error rendering DABs Resource Viewer."}})
     async getTreeItem(
         element: TreeNode
     ): Promise<BundleResourceExplorerTreeItem> {
@@ -146,7 +146,7 @@ export class BundleResourceExplorerTreeDataProvider
             .flat();
     }
 
-    @onError({popup: {prefix: "Error rendering DABs Resource Viewer"}})
+    @onError({popup: {prefix: "Error rendering DABs Resource Viewer."}})
     async getChildren(element?: TreeNode) {
         if (element === undefined) {
             return await this.getRoots();

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobsRenderer.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobsRenderer.ts
@@ -13,7 +13,7 @@ export class JobsRenderer implements Renderer {
 
         return {
             label: element.data.name,
-            contextValue: "job",
+            contextValue: "databricks.bundle.resource-explorer.runnable.job",
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }
@@ -32,6 +32,7 @@ export class JobsRenderer implements Renderer {
                 type: "task",
                 jobId: element.data.id,
                 jobKey: element.resourceKey,
+                resourceKey: `${element.resourceKey}.tasks.${task.task_key}`,
                 parent: element,
                 data: task,
             };
@@ -48,7 +49,7 @@ export class JobsRenderer implements Renderer {
             return {
                 type: this.type,
                 data: jobs[jobKey],
-                resourceKey: jobKey,
+                resourceKey: `jobs.${jobKey}`,
             };
         });
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobsRenderer.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobsRenderer.ts
@@ -1,11 +1,12 @@
 import {TreeItemCollapsibleState} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {BundleResourceExplorerTreeItem, Renderer, TreeNode} from "./types";
+import {BundleRunManager} from "../../bundle/BundleRunManager";
 
 export class JobsRenderer implements Renderer {
     readonly type = "jobs";
 
-    constructor() {}
+    constructor(private readonly bundleRunManager: BundleRunManager) {}
     getTreeItem(element: TreeNode): BundleResourceExplorerTreeItem {
         if (element.type !== this.type) {
             throw new Error("Invalid element type");
@@ -13,7 +14,11 @@ export class JobsRenderer implements Renderer {
 
         return {
             label: element.data.name,
-            contextValue: "databricks.bundle.resource-explorer.runnable.job",
+            contextValue: `databricks.bundle.resource-explorer.${
+                this.bundleRunManager.isRunning(element.resourceKey)
+                    ? "running"
+                    : "runnable"
+            }.job`,
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineRenderer.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineRenderer.ts
@@ -14,7 +14,8 @@ export class PipelineRenderer implements Renderer {
 
         return {
             label: element.data.name,
-            contextValue: this.type,
+            contextValue:
+                "databricks.bundle.resource-explorer.runnable.pipeline",
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }
@@ -62,7 +63,7 @@ export class PipelineRenderer implements Renderer {
             return {
                 type: this.type,
                 data: pipelines[pipelineKey],
-                resourceKey: pipelineKey,
+                resourceKey: `pipelines.${pipelineKey}`,
             };
         });
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineRenderer.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineRenderer.ts
@@ -1,11 +1,12 @@
 import {TreeItemCollapsibleState} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {BundleResourceExplorerTreeItem, Renderer, TreeNode} from "./types";
+import {BundleRunManager} from "../../bundle/BundleRunManager";
 
 export class PipelineRenderer implements Renderer {
     readonly type = "pipelines";
 
-    constructor() {}
+    constructor(private readonly bundleRunManager: BundleRunManager) {}
 
     getTreeItem(element: TreeNode): BundleResourceExplorerTreeItem {
         if (element.type !== this.type) {
@@ -14,8 +15,11 @@ export class PipelineRenderer implements Renderer {
 
         return {
             label: element.data.name,
-            contextValue:
-                "databricks.bundle.resource-explorer.runnable.pipeline",
+            contextValue: `databricks.bundle.resource-explorer.${
+                this.bundleRunManager.isRunning(element.resourceKey)
+                    ? "running"
+                    : "runnable"
+            }.pipeline`,
             collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
@@ -4,23 +4,27 @@ import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 type Resources = Required<BundleRemoteState>["resources"];
 type Job = Required<Resources>["jobs"][string];
 
+export type ResourceTreeNode = {
+    [k in keyof Required<Resources>]: {
+        type: k;
+        /** The key used to refer to the resource in databricks.yml. Also the key used for running the resource*/
+        resourceKey: string;
+        parent?: TreeNode;
+        data: Required<Resources>[k][string];
+    };
+}[keyof Required<Resources>];
+
 export type TreeNode =
-    | {
-          [k in keyof Required<Resources>]: {
-              type: k;
-              /** The key used to refer to the job in databricks.yml. */
-              resourceKey: string;
-              parent?: TreeNode;
-              data: Required<Resources>[k][string];
-          };
-      }[keyof Required<Resources>]
+    | ResourceTreeNode
     | {
           type: "task";
           jobId?: string;
           /** The key used to refer to the job in databricks.yml. This is
            * especially useful for jobs which have not been deployed yet.
            */
-          jobKey?: string;
+          jobKey: string;
+          /** The key used to refer to the resource in databricks.yml. */
+          resourceKey: string;
           parent?: TreeNode;
           data: Required<Job>["tasks"][number];
       }

--- a/packages/databricks-vscode/src/utils/envVarGenerators.ts
+++ b/packages/databricks-vscode/src/utils/envVarGenerators.ts
@@ -141,14 +141,10 @@ export function getEnvVarsForCli(configfilePath?: string) {
 
 export function removeUndefinedKeys<
     T extends Record<string, string | undefined>,
->(envVarMap?: T): T | undefined {
-    if (envVarMap === undefined) {
-        return;
-    }
-
+>(envVarMap: T): Record<string, string> {
     const filteredEntries = Object.entries(envVarMap).filter(
         (entry) => entry[1] !== undefined
     ) as [string, string][];
 
-    return Object.fromEntries<string>(filteredEntries) as T;
+    return Object.fromEntries<string>(filteredEntries);
 }


### PR DESCRIPTION
## Changes
* show deploy and run button in the UI
* Open a new terminal that shows the live run of the deployment. Terminals are keyed by `resource-key` and `target`. This allows us to reuse existing terminals for a new run. 
* 
* Running state is preserved across target changes. 
* The run button changes to cancel button when running. Also show a spinner for the relevant resources. **Note**: The cancel button ONLY kills the cli process. It does not cancel the online run.


## Tests
<!-- How is this tested? -->

