### PR TITLE
Hide authentication quickpicks when checking auth provider

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -229,7 +229,11 @@ export class CliWrapper {
     }
 
     public async getBundleSchema(): Promise<string> {
-        const {stdout} = await execFile(this.cliPath, ["bundle", "schema"]);
+        const {stdout} = await execFile(this.cliPath, [
+            "bundle",
+            "schema",
+            ...this.getLoggingArguments(),
+        ]);
         return stdout;
     }
 
@@ -241,7 +245,13 @@ export class CliWrapper {
     ) {
         const {stdout} = await execFile(
             this.cliPath,
-            ["bundle", "validate", "--target", target],
+            [
+                "bundle",
+                "validate",
+                "--target",
+                target,
+                ...this.getLoggingArguments(),
+            ],
             {
                 cwd: workspaceFolder.fsPath,
                 env: {
@@ -321,6 +331,7 @@ export class CliWrapper {
                 outputDirPath,
                 "--config-file",
                 initConfigFilePath,
+                ...this.getLoggingArguments(),
             ],
             {env: this.getBundleInitEnvVars(authProvider)}
         );
@@ -334,7 +345,14 @@ export class CliWrapper {
         onStdOut?: (data: string) => void,
         onStdError?: (data: string) => void
     ) {
-        const cmd = [this.cliPath, "bundle", "deploy", "--target", target];
+        const cmd = [
+            this.cliPath,
+            "bundle",
+            "deploy",
+            "--target",
+            target,
+            ...this.getLoggingArguments(),
+        ];
         if (onStdError) {
             onStdError(`Deploying the bundle for target ${target}...\n`);
             if (this.clusterId) {
@@ -378,7 +396,14 @@ export class CliWrapper {
 
         return {
             cmd: this.cliPath,
-            args: ["bundle", "run", "--target", target, resourceKey],
+            args: [
+                "bundle",
+                "run",
+                "--target",
+                target,
+                resourceKey,
+                ...this.getLoggingArguments(),
+            ],
             options: {
                 cwd: workspaceFolder.fsPath,
                 env,

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -266,7 +266,13 @@ export class CliWrapper {
     ) {
         const {stdout, stderr} = await execFile(
             this.cliPath,
-            ["bundle", "summary", "--target", target],
+            [
+                "bundle",
+                "summary",
+                "--target",
+                target,
+                ...this.getLoggingArguments(),
+            ],
             {
                 cwd: workspaceFolder.fsPath,
                 env: {

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -100,17 +100,23 @@ export class LoginWizard {
 
     private async checkAuthProvider(
         authProvider: AuthProvider,
-        authDescription: string
+        authDescription: string,
+        input: MultiStepInput
     ): Promise<InputStep | undefined> {
+        //Hide the input and let the check show it's own messages and UI.
+        input.hide();
         if (await authProvider.check()) {
             return;
         }
+
         const choice = await window.showErrorMessage(
-            `Authentication using ${authDescription} failed. Select another authentication method?`,
-            "Yes",
-            "No"
+            `Authentication using ${authDescription} failed.`,
+            "Select a different auth method",
+            "Cancel"
         );
-        if (choice === "Yes") {
+        if (choice === "Select a different auth method") {
+            //Show input again with the select auth step.
+            input.show();
             return this.selectAuthMethod.bind(this);
         }
         throw InputFlowAction.cancel;
@@ -230,7 +236,8 @@ export class LoginWizard {
             );
             const checkResult = await this.checkAuthProvider(
                 authProvider,
-                `profile '${pick.profile}'`
+                `profile '${pick.profile}'`,
+                input
             );
             if (checkResult) {
                 return checkResult;
@@ -320,7 +327,8 @@ export class LoginWizard {
 
         const checkResult = await this.checkAuthProvider(
             authProvider,
-            authProvider.describe()
+            authProvider.describe(),
+            input
         );
         if (checkResult) {
             return checkResult;

--- a/packages/databricks-vscode/src/ui/MultiStepInputWizard.ts
+++ b/packages/databricks-vscode/src/ui/MultiStepInputWizard.ts
@@ -87,6 +87,13 @@ export class MultiStepInput {
     private current?: QuickInput;
     private steps: InputStep[] = [];
 
+    public hide() {
+        this.current?.hide();
+    }
+    public show() {
+        this.current?.show();
+    }
+
     private async stepThrough(start: InputStep) {
         let step: InputStep | void = start;
         while (step) {


### PR DESCRIPTION
## Changes
* Earlier, we had a quickpick fixed in the UI while authproviders were checked. Since auth provider checks have their own UI and retry loops, this made it seem like the quickpick UI is frozen until user clicks out of the auth provider popups. 
* Now, we just hide the quickpicks until auth provider loops are completed. 
* Also add logging for cli commands.

## Tests
<!-- How is this tested? -->

