### PR TITLE
Fix deeplinks format to work across all clouds

### DIFF
--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
@@ -22,7 +22,7 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
             return undefined;
         }
 
-        return `${host.toString()}jobs/${this.data.id}`;
+        return `${host.toString()}#job/${this.data.id}`;
     }
 
     constructor(

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskRunStatusTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskRunStatusTreeNode.ts
@@ -24,7 +24,7 @@ export class TaskRunStatusTreeNode implements BundleResourceExplorerTreeNode {
             return undefined;
         }
 
-        return `${host.toString()}jobs/${this.jobId}/runs/${
+        return `${host.toString()}#job/${this.jobId}/run/${
             this.runDetails.run_id
         }`;
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
@@ -33,7 +33,9 @@ export class TaskTreeNode implements BundleResourceExplorerTreeNode {
             return undefined;
         }
 
-        return `${host.toString()}jobs/${this.jobId}/tasks/${this.taskKey}`;
+        return `${host.toString()}#job/${this.jobId}/tasks/task/${
+            this.taskKey
+        }`;
     }
     constructor(
         private readonly context: ExtensionContext,


### PR DESCRIPTION
Tested on native databricks, azure, gcp, and aws. 

Pipeline links seem to work fine too, as they already use "hash" links

