### PR TITLE
Show a more actionable error message when deployment fails

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -35,6 +35,14 @@ export interface ConfigEntry {
 }
 
 export type SyncType = "full" | "incremental";
+export class ProcessError extends Error {
+    constructor(
+        message: string,
+        public code: number | null
+    ) {
+        super(message);
+    }
+}
 
 async function waitForProcess(
     p: ChildProcessWithoutNullStreams,
@@ -63,7 +71,7 @@ async function waitForProcess(
             if (code === 0) {
                 resolve(output.join(""));
             } else {
-                reject(stderr.join(""));
+                reject(new ProcessError(stderr.join("\n"), code));
             }
         });
         p.on("error", reject);

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -84,9 +84,18 @@ export class BundleCommands implements Disposable {
         await this.refreshRemoteState();
     }
 
-    @onError({popup: {prefix: "Error deploying the bundle."}})
     async deployCommand() {
-        await this.deploy();
+        try {
+            await this.deploy();
+        } catch (e) {
+            const choice = await window.showErrorMessage(
+                "Databricks: Error deploying resource.",
+                "Show Logs"
+            );
+            if (choice === "Show Logs") {
+                this.outputChannel.show();
+            }
+        }
     }
 
     @onError({popup: {prefix: "Error running resource."}})


### PR DESCRIPTION
## Changes
* We were not catching bundle deployment errors because the process was throwing string errors and we don't capture errors which are not instance of `Error` class in onError. 
* Now, we show that the deployment has failed and ask the user to if they want to see the logs. 

## Tests
<!-- How is this tested? -->

