### PR TITLE
Trigger target change on prevalidate changes, so that auth resolution happens again

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -204,9 +204,8 @@ export class ConnectionManager implements Disposable {
         }
 
         // Try to load any parameters that are hard coded in the bundle
-        const bundleAuthParams = await this.configModel.get(
-            "preValidateConfig"
-        );
+        const bundleAuthParams =
+            await this.configModel.get("preValidateConfig");
         if (bundleAuthParams?.authParams !== undefined) {
             throw new Error("Bundle auth params not implemented");
         }

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -204,8 +204,9 @@ export class ConnectionManager implements Disposable {
         }
 
         // Try to load any parameters that are hard coded in the bundle
-        const bundleAuthParams =
-            await this.configModel.get("preValidateConfig");
+        const bundleAuthParams = await this.configModel.get(
+            "preValidateConfig"
+        );
         if (bundleAuthParams?.authParams !== undefined) {
             throw new Error("Bundle auth params not implemented");
         }

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -131,6 +131,9 @@ export class ConfigModel implements Disposable {
             }),
             this.bundlePreValidateModel.onDidChange(async () => {
                 await this.readTarget();
+                // We fire the target change emitter because auth info might have changed,
+                // which we handle exactly the same way as a target change.
+                this.onDidChangeTargetEmitter.fire();
                 //refresh cache to trigger onDidChange event
                 await this.configCache.refresh();
             }),


### PR DESCRIPTION
## Changes
Auth resolution does not happen again when pre validate configs change (host, mode etc). We want to treat changes to prevalidate config as target changes, so that complete auth resolution happens again. 

## Tests
<!-- How is this tested? -->

