### PR TITLE
Fix bundle-init on windows

### DIFF
--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -8,6 +8,7 @@ import {commands, Disposable, Uri, window} from "vscode";
 import {Loggers} from "../../logger";
 import {AzureCliAuthProvider} from "./AuthProvider";
 import {orchestrate, OrchestrationLoopError, Step} from "./orchestrate";
+import {ShellUtils} from "../../utils";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const {NamedLogger} = logging;
@@ -317,7 +318,7 @@ export class AzureCliCheck implements Disposable {
                     this.azBinPath
                 } login --allow-no-subscriptions ${useDeviceCode} ${
                     tenant ? "-t " + tenant : ""
-                }; echo "Press any key to close the terminal and continue ..."; read; exit`
+                }; echo "Press any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`
             );
 
             return await Promise.race<boolean>([

--- a/packages/databricks-vscode/src/utils/index.ts
+++ b/packages/databricks-vscode/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * as FileUtils from "./fileUtils";
 export * as UrlUtils from "./urlUtils";
+export * as ShellUtils from "./shellUtils";
 export * as UtilsCommands from "./UtilsCommands";
 export * as PackageJsonUtils from "./packageJsonUtils";
 export * as EnvVarGenerators from "./envVarGenerators";

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -1,0 +1,8 @@
+import {env} from "vscode";
+
+export function readCmd() {
+    if (env.shell.toLowerCase().includes("powershell")) {
+        return "Read-Host";
+    }
+    return "read";
+}


### PR DESCRIPTION
Supply full environment to the terminal (but still use `strictEnv` to ignore environmentCollection)

Also use cross-platform read function.

