### PR TITLE
Read data from global workspace block in databaricks.yml

### DIFF
--- a/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
@@ -37,11 +37,10 @@ export class BundlePreValidateModel extends BaseModelWithStateCache<BundlePreVal
             const bundle = await this.bundleFileSet.bundleDataCache.value;
             const targets = Object.assign({}, bundle.targets ?? {});
 
-            await Promise.all(
-                Object.keys(targets ?? {}).map(async (key) => {
-                    targets[key] = this.getRawTargetData(bundle, key);
-                })
-            );
+            Object.keys(targets ?? {}).map((key) => {
+                targets[key] = this.getRawTargetData(bundle, key);
+            });
+
             return targets;
         })();
     }

--- a/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
@@ -4,6 +4,7 @@ import {BundleTarget} from "../types";
 import {BaseModelWithStateCache} from "../../configuration/models/BaseModelWithStateCache";
 import {UrlUtils} from "../../utils";
 import {Mutex} from "../../locking";
+import * as lodash from "lodash";
 
 export type BundlePreValidateState = {
     host?: URL;
@@ -73,8 +74,15 @@ export class BundlePreValidateModel extends BaseModelWithStateCache<BundlePreVal
             return {};
         }
 
-        const targetObject = (await this.bundleFileSet.bundleDataCache.value)
-            .targets?.[this.target];
+        const bundle = await this.bundleFileSet.bundleDataCache.value;
+        const targetObject = bundle?.targets?.[this.target];
+        const globalWorkspace = bundle?.workspace;
+        if (targetObject !== undefined) {
+            targetObject.workspace = lodash.merge(
+                targetObject.workspace ?? {},
+                globalWorkspace
+            );
+        }
 
         return this.readStateFromTarget(targetObject) ?? {};
     }


### PR DESCRIPTION
## Changes
* Bundles support loading workspace data (host, sync destination) from a global "workspace" block, which is overriden by value of the optional workspace block in each target block.
* This PR adds support for this behaviour.

## Tests
<!-- How is this tested? -->

