### PR TITLE
Update login wizard and show cancel button for running resources

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -343,6 +343,7 @@
                 },
                 {
                     "command": "databricks.bundle.initNewProject",
+                    "group": "navigation@1",
                     "when": "view == configurationView"
                 },
                 {

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -146,7 +146,7 @@ export class ConfigModel implements Disposable {
         );
     }
 
-    @onError({popup: {prefix: "Failed to initialize configs."}})
+    @onError({popup: true})
     public async init() {
         await this.readTarget();
         this.bundleRemoteStateModel.init();
@@ -177,7 +177,18 @@ export class ConfigModel implements Disposable {
             }
             savedTarget = await this.bundlePreValidateModel.defaultTarget;
         });
-        await this.setTarget(savedTarget);
+
+        try {
+            await this.setTarget(savedTarget);
+        } catch (e: any) {
+            let message: string = String(e);
+            if (e instanceof Error) {
+                message = e.message;
+            }
+            throw new Error(
+                `Failed to initialize target ${savedTarget}: ${message}`
+            );
+        }
     }
 
     public get target() {

--- a/packages/databricks-vscode/src/locking/CachedValue.ts
+++ b/packages/databricks-vscode/src/locking/CachedValue.ts
@@ -38,13 +38,24 @@ export class CachedValue<T> implements Disposable {
                     newValue = {} as T;
                 }
 
+                const customizer: lodash.IsEqualCustomizer = (value, other) => {
+                    if (value instanceof URL && other instanceof URL) {
+                        return value.toString() === other.toString();
+                    }
+                    return undefined;
+                };
+
                 for (const key of Object.keys({
                     ...oldValue,
                     ...newValue,
                 } as any) as (keyof T)[]) {
                     if (
                         oldValue === null ||
-                        !lodash.isEqual(oldValue?.[key], newValue?.[key])
+                        !lodash.isEqualWith(
+                            oldValue?.[key],
+                            newValue?.[key],
+                            customizer
+                        )
                     ) {
                         this.onDidChangeKeyEmitters.get(key)?.fire();
                     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/DecorationProvider.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/DecorationProvider.ts
@@ -51,7 +51,7 @@ export class TreeItemDecorationProvider implements FileDecorationProvider {
 export function asDecorationResourceUri(id: string, data: FileDecoration) {
     return Uri.from({
         scheme: SCHEME,
-        authority: id,
+        path: id,
         query: JSON.stringify(data),
     });
 }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
@@ -1,4 +1,4 @@
-import {TreeItemCollapsibleState, ExtensionContext} from "vscode";
+import {ExtensionContext} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {
     BundleResourceExplorerResource,
@@ -50,14 +50,16 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
                 hasUrl: this.url !== undefined,
                 cancellable: isRunning,
                 nodeType: this.type,
+                modifiedStatus: this.data.modified_status,
             }),
             resourceUri: DecorationUtils.getModifiedStatusDecoration(
-                this.resourceKey,
+                this.data.name ?? this.resourceKey,
                 this.data.modified_status
             ),
-            collapsibleState: isRunning
-                ? TreeItemCollapsibleState.Collapsed
-                : TreeItemCollapsibleState.Expanded,
+            collapsibleState: DecorationUtils.getCollapsibleState(
+                isRunning,
+                this.data.modified_status
+            ),
         };
     }
 

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
@@ -48,6 +48,7 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
                 resourceType: this.type,
                 running: isRunning,
                 hasUrl: this.url !== undefined,
+                cancellable: isRunning,
                 nodeType: this.type,
             }),
             resourceUri: DecorationUtils.getModifiedStatusDecoration(

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
@@ -46,6 +46,7 @@ export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
                 resourceType: this.type,
                 running: isRunning,
                 hasUrl: this.url !== undefined,
+                cancellable: isRunning,
                 nodeType: this.type,
             }),
             resourceUri: DecorationUtils.getModifiedStatusDecoration(

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
@@ -1,4 +1,3 @@
-import {TreeItemCollapsibleState} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {
     BundleResourceExplorerResource,
@@ -48,14 +47,16 @@ export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
                 hasUrl: this.url !== undefined,
                 cancellable: isRunning,
                 nodeType: this.type,
+                modifiedStatus: this.data.modified_status,
             }),
             resourceUri: DecorationUtils.getModifiedStatusDecoration(
-                this.resourceKey,
+                this.data.name ?? this.resourceKey,
                 this.data.modified_status
             ),
-            collapsibleState: isRunning
-                ? TreeItemCollapsibleState.Expanded
-                : TreeItemCollapsibleState.Collapsed,
+            collapsibleState: DecorationUtils.getCollapsibleState(
+                isRunning,
+                this.data.modified_status
+            ),
         };
     }
 

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/ContextUtils.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/ContextUtils.ts
@@ -1,3 +1,4 @@
+import {BundleResourceModifiedStatus} from "../../../bundle/models/BundleRemoteStateModel";
 import {RUNNABLE_BUNDLE_RESOURCES} from "../BundleCommands";
 import {
     BundleResourceExplorerResourceKey,
@@ -10,6 +11,7 @@ type BundleTreeItemContext = {
     running?: boolean;
     cancellable?: boolean;
     hasUrl?: boolean;
+    modifiedStatus?: BundleResourceModifiedStatus;
 };
 
 export function getContextString(context: BundleTreeItemContext) {
@@ -21,7 +23,8 @@ export function getContextString(context: BundleTreeItemContext) {
             (RUNNABLE_BUNDLE_RESOURCES as string[]).includes(
                 context.resourceType
             ) &&
-            !context.running
+            !context.running &&
+            context.modifiedStatus !== "deleted"
         ) {
             parts.push("runnable");
         }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/DecorationUtils.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/DecorationUtils.ts
@@ -1,6 +1,6 @@
 import {BundleResourceModifiedStatus} from "../../../bundle/models/BundleRemoteStateModel";
 import {asDecorationResourceUri} from "../DecorationProvider";
-import {ThemeColor} from "vscode";
+import {ThemeColor, TreeItemCollapsibleState} from "vscode";
 
 export function getModifiedStatusDecoration(
     id: string,
@@ -30,4 +30,19 @@ export function getModifiedStatusDecoration(
                 tooltip: "Updated after deploy",
             });
     }
+}
+
+export function getCollapsibleState(
+    isRunning: boolean,
+    modifiedStatus?: BundleResourceModifiedStatus
+): TreeItemCollapsibleState {
+    if (modifiedStatus === "deleted") {
+        return TreeItemCollapsibleState.None;
+    }
+
+    if (isRunning) {
+        return TreeItemCollapsibleState.Collapsed;
+    }
+
+    return TreeItemCollapsibleState.Expanded;
 }


### PR DESCRIPTION
* Login wizard
  * In host selection menu, don't show same host multiple times if there are multiple profiles. Only show it once with all the profiles listed in the description.
  * Show existing profiles first in menu for creating/selecting auth type.
 
* Dabs Explorer
  * Show the name of resource in the tooltip for created/deleted resources
  * Show the cancel button for running resources (removed due to a previous PR).

* Actually show the project init icon in the configuration view header
* The URL object is not compared properly by lodash. This meant, we were a host change event whenever anything unrelated in the bundle changed. Which lead to reconnection on every edit to the bundle. Also fix this.
  