### PR TITLE
Fix regression where switching targets, with the same host, does not trigger a model refresh

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -138,11 +138,15 @@ export class ConnectionManager implements Disposable {
                     this.updateClusterManager,
                     this
                 ),
-                // Don't listen to target change for logging in. Explictly listen for changes in the keys we care about.
+                // Don't just listen to target change for logging in. Also explictly listen for changes in the keys we care about.
                 // We don't have to listen to changes in authProfile as it's set by the login method and we don't respect other
                 // user changes.
                 // TODO: start listening to changes in authParams
                 this.configModel.onDidChangeKey("host")(
+                    this.loginWithSavedAuth,
+                    this
+                ),
+                this.configModel.onDidChangeTarget(
                     this.loginWithSavedAuth,
                     this
                 )

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -224,6 +224,8 @@ export class ConfigModel implements Disposable {
             this.onDidChangeTargetEmitter.fire();
         });
 
+        await this.setAuthProvider(undefined);
+
         this.vscodeWhenContext.isTargetSet(this._target !== undefined);
     }
 


### PR DESCRIPTION
## Changes
Switching targets (with the same host) was not triggering model refresh. This fixes the issue. 

## Tests
<!-- How is this tested? -->

