### PR TITLE
State message tooltips

### DIFF
--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobRunStatusTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobRunStatusTreeNode.ts
@@ -36,6 +36,7 @@ export class JobRunStatusTreeNode implements BundleResourceExplorerTreeNode {
                     {
                         label: "State Message",
                         description: this.runDetails.state?.state_message,
+                        tooltip: this.runDetails.state?.state_message,
                         contextValue: "state_message",
                     },
                     this

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
@@ -9,7 +9,6 @@ import {
 } from "./types";
 import {ExtensionContext, TreeItemCollapsibleState} from "vscode";
 import {PipelineTreeNode} from "./PipelineTreeNode";
-import {TreeItemTreeNode} from "./TreeItemTreeNode";
 
 function humaniseResourceType(type: BundleResourceExplorerTreeNode["type"]) {
     switch (type) {
@@ -93,10 +92,6 @@ export class ResourceTypeHeaderTreeNode
         );
         if (pipelines.length > 0) {
             roots.push(
-                new TreeItemTreeNode(
-                    {collapsibleState: TreeItemCollapsibleState.None},
-                    undefined
-                ),
                 new ResourceTypeHeaderTreeNode(context, "pipelines", pipelines)
             );
         }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskRunStatusTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskRunStatusTreeNode.ts
@@ -45,6 +45,7 @@ export class TaskRunStatusTreeNode implements BundleResourceExplorerTreeNode {
                     {
                         label: "State Message",
                         description: this.runDetails.state?.state_message,
+                        tooltip: this.runDetails.state?.state_message,
                         contextValue: "state_message",
                     },
                     this


### PR DESCRIPTION
State messages can contain long errors and are frequently truncated.
By default VSCode shows labels as tooltips, which is not useful.

Also removed the empty node between workflows and pipelines.