### PR TITLE
Pass CLI path to all auth providers and login only once during bundle init

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -177,7 +177,7 @@ export class BundleProjectManager {
         try {
             return await ProjectConfigFile.load(
                 this.workspaceUri.fsPath,
-                this.cli.cliPath
+                this.cli
             );
         } catch (error) {
             this.logger.error("Failed to load legacy project config:", error);
@@ -203,7 +203,11 @@ export class BundleProjectManager {
                 "Creating new profile before bundle migration",
                 profileName
             );
-            authProvider = await saveNewProfile(profileName, authProvider);
+            authProvider = await saveNewProfile(
+                profileName,
+                authProvider,
+                this.cli
+            );
         }
         await this.migrateProjectJsonToBundle(
             authProvider as ProfileAuthProvider,

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -217,6 +217,7 @@ nothing = true
         const authProvider = new ProfileAuthProvider(
             new URL("https://test.com"),
             "PROFILE",
+            cli,
             true
         );
         const workspaceFolder = Uri.file("/test/123");

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -15,6 +15,7 @@ import {ConfigModel} from "./models/ConfigModel";
 import {saveNewProfile} from "./LoginWizard";
 import {PersonalAccessTokenAuthProvider} from "./auth/AuthProvider";
 import {normalizeHost} from "../utils/urlUtils";
+import {CliWrapper} from "../cli/CliWrapper";
 
 function formatQuickPickClusterSize(sizeInMB: number): string {
     if (sizeInMB > 1024) {
@@ -54,7 +55,8 @@ export class ConnectionCommands implements Disposable {
         private wsfsCommands: WorkspaceFsCommands,
         private connectionManager: ConnectionManager,
         private readonly clusterModel: ClusterModel,
-        private readonly configModel: ConfigModel
+        private readonly configModel: ConfigModel,
+        private readonly cli: CliWrapper
     ) {}
 
     /**
@@ -86,7 +88,7 @@ export class ConnectionCommands implements Disposable {
         }
         const hostUrl = normalizeHost(host);
         const provider = new PersonalAccessTokenAuthProvider(hostUrl, token);
-        await saveNewProfile(name, provider);
+        await saveNewProfile(name, provider, this.cli);
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -219,7 +219,10 @@ export class ConnectionManager implements Disposable {
         const savedProfile = (await this.configModel.get("overrides"))
             ?.authProfile;
         if (savedProfile !== undefined) {
-            const authProvider = await ProfileAuthProvider.from(savedProfile);
+            const authProvider = await ProfileAuthProvider.from(
+                savedProfile,
+                this.cli
+            );
             if (
                 authProvider.host.toString() === host.toString() &&
                 (await authProvider.check())
@@ -242,7 +245,10 @@ export class ConnectionManager implements Disposable {
         if (profiles.length !== 1) {
             return;
         }
-        const authProvider = await ProfileAuthProvider.from(profiles[0].name);
+        const authProvider = await ProfileAuthProvider.from(
+            profiles[0].name,
+            this.cli
+        );
         if (await authProvider.check()) {
             return authProvider;
         }

--- a/packages/databricks-vscode/src/configuration/DatabricksWorkspace.test.ts
+++ b/packages/databricks-vscode/src/configuration/DatabricksWorkspace.test.ts
@@ -4,6 +4,8 @@ import {Uri} from "vscode";
 import {ProfileAuthProvider} from "./auth/AuthProvider";
 import {DatabricksWorkspace} from "./DatabricksWorkspace";
 import {iam} from "@databricks/databricks-sdk";
+import {instance, mock} from "ts-mockito";
+import {CliWrapper} from "../cli/CliWrapper";
 
 describe(__filename, () => {
     it("create an instance", () => {
@@ -17,7 +19,8 @@ describe(__filename, () => {
         } as const;
         const authProvider = new ProfileAuthProvider(
             new URL("https://fabian.databricks.com"),
-            "DEFAULT"
+            "DEFAULT",
+            instance(mock(CliWrapper))
         );
         const dbWorkspace: DatabricksWorkspace = new DatabricksWorkspace(
             authProvider,

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -243,7 +243,10 @@ export class LoginWizard {
         }
 
         if (pick.profile !== undefined) {
-            const authProvider = await ProfileAuthProvider.from(pick.profile);
+            const authProvider = await ProfileAuthProvider.from(
+                pick.profile,
+                this.cliWrapper
+            );
             const nextStep = await this.checkAuthProvider(authProvider, input);
             if (nextStep) {
                 return nextStep;
@@ -307,7 +310,7 @@ export class LoginWizard {
             case "databricks-cli":
                 authProvider = new DatabricksCliAuthProvider(
                     this.state.host!,
-                    this.cliWrapper.cliPath
+                    this.cliWrapper
                 );
                 break;
 
@@ -343,7 +346,8 @@ export class LoginWizard {
 
         this.state.authProvider = await saveNewProfile(
             profileName,
-            authProvider
+            authProvider,
+            this.cliWrapper
         );
     }
 
@@ -367,7 +371,8 @@ export class LoginWizard {
 
 export async function saveNewProfile(
     profileName: string,
-    authProvider: AuthProvider
+    authProvider: AuthProvider,
+    cli: CliWrapper
 ) {
     const iniData = authProvider.toIni();
     if (!iniData) {
@@ -397,7 +402,7 @@ export async function saveNewProfile(
     // Write the new profile to .databrickscfg
     await appendFile(configFilePath, finalStr);
 
-    return await ProfileAuthProvider.from(profileName, true);
+    return await ProfileAuthProvider.from(profileName, cli, true);
 }
 
 function humaniseSdkAuthType(sdkAuthType: string) {

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -288,7 +288,6 @@ export class DatabricksCliAuthProvider extends AuthProvider {
         return {
             host: this.host.toString(),
             auth_type: "databricks-cli",
-            databricks_cli_path: this.cli.cliPath,
         };
     }
 

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -73,7 +73,7 @@ export class DatabricksCliCheck implements Disposable {
             {
                 host: this.authProvider.host.toString(),
                 authType: "databricks-cli",
-                databricksCliPath: this.authProvider.databricksPath,
+                databricksCliPath: this.authProvider.cli.cliPath,
             },
             {
                 product: "databricks-vscode",
@@ -92,7 +92,7 @@ export class DatabricksCliCheck implements Disposable {
 
     private async login(): Promise<void> {
         try {
-            await ExecUtils.execFile(this.authProvider.databricksPath, [
+            await ExecUtils.execFile(this.authProvider.cli.cliPath, [
                 "auth",
                 "login",
                 "--host",

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -188,7 +188,7 @@ export async function activate(
         workspaceUri
     );
 
-    const overrideableConfigModel = new OverrideableConfigModel(stateStorage);
+    const overrideableConfigModel = new OverrideableConfigModel(workspaceUri);
     const bundlePreValidateModel = new BundlePreValidateModel(
         bundleFileSet,
         bundleFileWatcher
@@ -417,7 +417,8 @@ export async function activate(
         workspaceFsCommands,
         connectionManager,
         clusterModel,
-        configModel
+        configModel,
+        cli
     );
 
     context.subscriptions.push(

--- a/packages/databricks-vscode/src/file-managers/ProjectConfigFile.test.ts
+++ b/packages/databricks-vscode/src/file-managers/ProjectConfigFile.test.ts
@@ -7,6 +7,8 @@ import path from "path";
 import * as os from "os";
 import {ProfileAuthProvider} from "../configuration/auth/AuthProvider";
 import {Uri} from "vscode";
+import {instance, mock, when} from "ts-mockito";
+import {CliWrapper} from "../cli/CliWrapper";
 
 describe(__filename, () => {
     let tempDir: string;
@@ -29,7 +31,12 @@ describe(__filename, () => {
             encoding: "utf-8",
         });
 
-        const actual = (await ProjectConfigFile.load(tempDir, "databricks"))!;
+        const mockCliWrapper = mock(CliWrapper);
+        when(mockCliWrapper.cliPath).thenReturn("databricks");
+        const actual = (await ProjectConfigFile.load(
+            tempDir,
+            instance(mockCliWrapper)
+        ))!;
         assert.equal(actual.host.toString(), config.host);
         assert.ok(actual.authProvider instanceof ProfileAuthProvider);
         assert.equal(actual.authProvider.authType, config.authType);
@@ -73,7 +80,12 @@ token = testToken`,
             tempDir,
             ".databrickscfg"
         );
-        const actual = (await ProjectConfigFile.load(tempDir, "databricks"))!;
+        const mockCliWrapper = mock(CliWrapper);
+        when(mockCliWrapper.cliPath).thenReturn("databricks");
+        const actual = (await ProjectConfigFile.load(
+            tempDir,
+            instance(mockCliWrapper)
+        ))!;
         assert.equal(
             actual.host.toString(),
             "https://000000000000.00.azuredatabricks.net/"

--- a/packages/databricks-vscode/src/file-managers/ProjectConfigFile.ts
+++ b/packages/databricks-vscode/src/file-managers/ProjectConfigFile.ts
@@ -5,6 +5,7 @@ import {
     ProfileAuthProvider,
 } from "../configuration/auth/AuthProvider";
 import {Uri} from "vscode";
+import {CliWrapper} from "../cli/CliWrapper";
 
 export interface ProjectConfig {
     authProvider: AuthProvider;
@@ -45,13 +46,16 @@ export class ProjectConfigFile {
         };
     }
 
-    static async importOldConfig(config: any): Promise<ProfileAuthProvider> {
-        return await ProfileAuthProvider.from(config.profile);
+    static async importOldConfig(
+        config: any,
+        cli: CliWrapper
+    ): Promise<ProfileAuthProvider> {
+        return await ProfileAuthProvider.from(config.profile, cli);
     }
 
     static async load(
         rootPath: string,
-        cliPath: string
+        cli: CliWrapper
     ): Promise<ProjectConfigFile | undefined> {
         const projectConfigFilePath = path.join(
             path.normalize(rootPath),
@@ -75,9 +79,9 @@ export class ProjectConfigFile {
         let authProvider: AuthProvider;
         const config = JSON.parse(rawConfig);
         if (!config.authType && config.profile) {
-            authProvider = await this.importOldConfig(config);
+            authProvider = await this.importOldConfig(config, cli);
         } else {
-            authProvider = AuthProvider.fromJSON(config, cliPath);
+            authProvider = AuthProvider.fromJSON(config, cli);
         }
         return new ProjectConfigFile(
             {
@@ -92,7 +96,7 @@ export class ProjectConfigFile {
                         : undefined,
             },
             rootPath,
-            cliPath
+            cli.cliPath
         );
     }
 


### PR DESCRIPTION
## Changes
* Store overrides in a per target file instead of state store
* Have a root overrides file for cases when we are not sure of the target. 
* Whenever a target is selected, and it does not already have an override file, it will MOVE the root override file to initialise it's own state json file.

## Tests
<!-- How is this tested? -->

