### PR TITLE
Use raw app insights keys for the telemetry reporter

### DIFF
--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -1,9 +1,9 @@
 import {AuthType} from "@databricks/databricks-sdk";
-/** The production application insights configuration string for Databricks. */
-export const PROD_APP_INSIGHTS_CONFIGURATION_STRING =
+/** The production application insights instrumentation key for Databricks. */
+export const PROD_APP_INSIGHTS_CONFIGURATION_KEY =
     "ebe191c5-f06b-4189-b68c-34fb5fbdb3f0";
-/** The application insights configuration string used while developing on the VS Code extension */
-export const DEV_APP_INSIGHTS_CONFIGURATION_STRING =
+/** The application insights instrumentation key used while developing on the VS Code extension */
+export const DEV_APP_INSIGHTS_CONFIGURATION_KEY =
     "257d1561-5005-4a76-a3a8-7955df129e86";
 
 /** The list of all events which can be monitored. */

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -1,10 +1,10 @@
 import {AuthType} from "@databricks/databricks-sdk";
 /** The production application insights configuration string for Databricks. */
 export const PROD_APP_INSIGHTS_CONFIGURATION_STRING =
-    "InstrumentationKey=ebe191c5-f06b-4189-b68c-34fb5fbdb3f0;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";
+    "ebe191c5-f06b-4189-b68c-34fb5fbdb3f0";
 /** The application insights configuration string used while developing on the VS Code extension */
 export const DEV_APP_INSIGHTS_CONFIGURATION_STRING =
-    "InstrumentationKey=257d1561-5005-4a76-a3a8-7955df129e86;IngestionEndpoint=https://eastus2-3.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/";
+    "257d1561-5005-4a76-a3a8-7955df129e86";
 
 /** The list of all events which can be monitored. */
 /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/databricks-vscode/src/telemetry/index.ts
+++ b/packages/databricks-vscode/src/telemetry/index.ts
@@ -2,13 +2,13 @@ import TelemetryReporter from "@vscode/extension-telemetry";
 import {DatabricksWorkspace} from "../configuration/DatabricksWorkspace";
 import {isDevExtension} from "../utils/developmentUtils";
 import {
-    DEV_APP_INSIGHTS_CONFIGURATION_STRING,
+    DEV_APP_INSIGHTS_CONFIGURATION_KEY,
     EventProperties,
     EventTypes,
     ExtraMetadata,
     Metadata,
     MetadataTypes,
-    PROD_APP_INSIGHTS_CONFIGURATION_STRING,
+    PROD_APP_INSIGHTS_CONFIGURATION_KEY,
 } from "./constants";
 import crypto from "crypto";
 import bcrypt from "bcryptjs";
@@ -90,9 +90,9 @@ export function getContextMetadata(): ExtraMetadata[Metadata.CONTEXT] {
 
 function getTelemetryKey(): string {
     if (isDevExtension()) {
-        return DEV_APP_INSIGHTS_CONFIGURATION_STRING;
+        return DEV_APP_INSIGHTS_CONFIGURATION_KEY;
     }
-    return PROD_APP_INSIGHTS_CONFIGURATION_STRING;
+    return PROD_APP_INSIGHTS_CONFIGURATION_KEY;
 }
 
 function getTelemetryReporter(): TelemetryReporter | undefined {


### PR DESCRIPTION
Our telemetry setup doesn't work with vscode-extension-telemetry 0.9.0+, after they updated their internal app insights reporter dependency.

Debugging the issue showed that app insights reporter silently fails with 400 errors, saying that instrumentation key params are incorrect.

The usage docs explicitly mention to use "Instrumentation Key" while creating the reporter instance, not the "Connection String" which we were using in our setup. After changing it to they keys I can confirm that the events finally come through (in staging azure "deco-vscode" app insights)q

