### PR TITLE
Cache list profiles output based on last modified time of .databrickscfg

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -12,7 +12,7 @@ import {
     RemoteUri,
     LocalUri,
 } from "../sync/SyncDestination";
-import {LoginWizard, listProfiles} from "./LoginWizard";
+import {LoginWizard, getProfilesForHost} from "./LoginWizard";
 import {ClusterManager} from "../cluster/ClusterManager";
 import {DatabricksWorkspace} from "./DatabricksWorkspace";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
@@ -246,9 +246,8 @@ export class ConnectionManager implements Disposable {
         }
 
         // Try to load a unique profile that matches the host
-        const profiles = (await listProfiles(this.cli)).filter(
-            (p) => p.host?.toString() === host.toString()
-        );
+        const profiles = await getProfilesForHost(host, this.cli);
+
         if (profiles.length !== 1) {
             return;
         }

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -11,7 +11,7 @@ import {
     MultiStepInput,
     ValidationMessageType,
 } from "../ui/MultiStepInputWizard";
-import {CliWrapper, ConfigEntry} from "../cli/CliWrapper";
+import {CliWrapper, ProfileDetails} from "../cli/CliWrapper";
 import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 import {
     AuthProvider,
@@ -46,7 +46,7 @@ interface State {
 export class LoginWizard {
     private state = {} as Partial<State>;
     private readonly title = "Configure Databricks Workspace";
-    private _profiles: Array<ConfigEntry> = [];
+    private _profiles: Array<ProfileDetails> = [];
     async getProfiles() {
         if (this._profiles.length === 0) {
             this._profiles = await listProfiles(this.cliWrapper);
@@ -435,7 +435,7 @@ export async function listProfiles(cliWrapper: CliWrapper) {
         async () => {
             const profiles = (
                 await cliWrapper.listProfiles(
-                    workspaceConfigs.databrickscfgLocation
+                    FileUtils.getDatabricksConfigFilePath().fsPath
                 )
             ).filter((profile) => {
                 try {
@@ -448,6 +448,12 @@ export async function listProfiles(cliWrapper: CliWrapper) {
 
             return profiles;
         }
+    );
+}
+
+export async function getProfilesForHost(host: URL, cliWrapper: CliWrapper) {
+    return (await listProfiles(cliWrapper)).filter(
+        (profile) => profile.host?.toString() === host.toString()
     );
 }
 

--- a/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
@@ -3,6 +3,8 @@ import {ConnectionManager} from "../ConnectionManager";
 import {BaseComponent} from "./BaseComponent";
 import {ConfigurationTreeItem} from "./types";
 import {ThemeIcon, ThemeColor} from "vscode";
+import {getProfilesForHost} from "../LoginWizard";
+import {CliWrapper} from "../../cli/CliWrapper";
 
 export const AUTH_TYPE_SWITCH_ID = "AUTH-TYPE";
 export const AUTH_TYPE_LOGIN_ID = "LOGIN";
@@ -14,7 +16,8 @@ function getContextValue(key: string) {
 export class AuthTypeComponent extends BaseComponent {
     constructor(
         private readonly connectionManager: ConnectionManager,
-        private readonly configModel: ConfigModel
+        private readonly configModel: ConfigModel,
+        private readonly cli: CliWrapper
     ) {
         super();
         this.disposables.push(
@@ -28,6 +31,10 @@ export class AuthTypeComponent extends BaseComponent {
     }
 
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
+        if (this.configModel.target === undefined) {
+            return [];
+        }
+
         const authProvider =
             this.connectionManager.databricksWorkspace?.authProvider;
 
@@ -41,7 +48,17 @@ export class AuthTypeComponent extends BaseComponent {
         }
 
         if (authProvider === undefined) {
-            const label = "Login to Databricks";
+            const host = await this.configModel.get("host");
+            if (host === undefined) {
+                return [];
+            }
+
+            const profiles = await getProfilesForHost(host, this.cli);
+            let label = "Login to Databricks";
+            if (profiles.length > 1) {
+                label =
+                    "Multiple login profiles available. Click to select a profile.";
+            }
             return [
                 {
                     label: {label},

--- a/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
@@ -15,6 +15,7 @@ import {AuthTypeComponent} from "./AuthTypeComponent";
 import {ClusterComponent} from "./ClusterComponent";
 import {SyncDestinationComponent} from "./SyncDestinationComponent";
 import {BundleProjectManager} from "../../bundle/BundleProjectManager";
+import {CliWrapper} from "../../cli/CliWrapper";
 
 /**
  * Data provider for the cluster tree view
@@ -32,14 +33,19 @@ export class ConfigurationDataProvider
     private disposables: Array<Disposable> = [];
     private components: Array<BaseComponent> = [
         new BundleTargetComponent(this.configModel),
-        new AuthTypeComponent(this.connectionManager, this.configModel),
+        new AuthTypeComponent(
+            this.connectionManager,
+            this.configModel,
+            this.cli
+        ),
         new ClusterComponent(this.connectionManager, this.configModel),
         new SyncDestinationComponent(this.connectionManager, this.configModel),
     ];
     constructor(
         private readonly connectionManager: ConnectionManager,
         private readonly bundleProjectManager: BundleProjectManager,
-        private readonly configModel: ConfigModel
+        private readonly configModel: ConfigModel,
+        private readonly cli: CliWrapper
     ) {
         this.disposables.push(
             this.bundleProjectManager.onDidChangeStatus(async () => {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -415,7 +415,8 @@ export async function activate(
     const configurationDataProvider = new ConfigurationDataProvider(
         connectionManager,
         bundleProjectManager,
-        configModel
+        configModel,
+        cli
     );
 
     const connectionCommands = new ConnectionCommands(

--- a/packages/databricks-vscode/src/utils/fileUtils.ts
+++ b/packages/databricks-vscode/src/utils/fileUtils.ts
@@ -50,7 +50,7 @@ export function getHomedir() {
     return process.env.HOME ?? homedir();
 }
 
-export async function openDatabricksConfigFile() {
+export function getDatabricksConfigFilePath() {
     const homeDir = getHomedir();
     let filePath =
         workspaceConfigs.databrickscfgLocation ??
@@ -59,7 +59,11 @@ export async function openDatabricksConfigFile() {
     if (filePath.startsWith("~/")) {
         filePath = path.join(homeDir, filePath.slice(2));
     }
-    const uri = Uri.file(path.normalize(filePath));
+    return Uri.file(path.normalize(filePath));
+}
+
+export async function openDatabricksConfigFile() {
+    const uri = getDatabricksConfigFilePath();
     try {
         await workspace.fs.stat(uri);
     } catch (e) {


### PR DESCRIPTION
## Changes
* Also show  'Multiple login profiles available. Click to select a profile.' instead of "login to Databricks" when multiple profiles are available.
* Hide the login button when no target is selected.

## Tests
<!-- How is this tested? -->

