### PR TITLE
Add exception handlers to bootstrap python code

### DIFF
--- a/packages/databricks-vscode/resources/python/bootstrap.py
+++ b/packages/databricks-vscode/resources/python/bootstrap.py
@@ -37,8 +37,12 @@ user_ns = {
 }
 
 # Set log level to "ERROR". See https://kb.databricks.com/notebooks/cmd-c-on-object-id-p0.html
-import logging; logger = spark._jvm.org.apache.log4j;
-logging.getLogger("py4j.java_gateway").setLevel(logging.ERROR)
+try:
+    import logging; logger = spark._jvm.org.apache.log4j;
+    logging.getLogger("py4j.java_gateway").setLevel(logging.ERROR)
+except Exception as e:
+    logging.debug("Failed to set py4j.java_gateway log level to ERROR", exc_info=True)
+    pass
 
 runpy.run_path(python_file, run_name="__main__", init_globals=user_ns)
 None

--- a/packages/databricks-vscode/resources/python/file.workflow-wrapper.py
+++ b/packages/databricks-vscode/resources/python/file.workflow-wrapper.py
@@ -27,9 +27,13 @@ user_ns = {
     "sqlContext": sqlContext,
 }
 
-# Set log level to "ERROR". See https://kb.databricks.com/notebooks/cmd-c-on-object-id-p0.html
-import logging; logger = spark._jvm.org.apache.log4j;
-logging.getLogger("py4j.java_gateway").setLevel(logging.ERROR)
+try:
+    # Set log level to "ERROR". See https://kb.databricks.com/notebooks/cmd-c-on-object-id-p0.html
+    import logging; logger = spark._jvm.org.apache.log4j;
+    logging.getLogger("py4j.java_gateway").setLevel(logging.ERROR)
+except Exception as e:
+    logging.debug("Failed to set py4j.java_gateway log level to ERROR", exc_info=True)
+    pass
 
 runpy.run_path(python_file, run_name="__main__", init_globals=user_ns)
 None


### PR DESCRIPTION
## Changes
* Our bootstrap for python files (running using both workflows and command execution API), is failing because Db connect does not support jvm context and dbconnect is the default spark implementation from dbr 14.x. 
* This PR adds exception handlers to maintain backwards compatibilty.

Fixes #1123 
## Tests
<!-- How is this tested? -->

