### PR TITLE
Rename some things

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -177,7 +177,7 @@
             {
                 "command": "databricks.utils.openExternal",
                 "title": "Open link externally",
-                "icon": "$(link)",
+                "icon": "$(link-external)",
                 "category": "Databricks"
             },
             {
@@ -294,7 +294,7 @@
                 },
                 {
                     "id": "dabsResourceExplorerView",
-                    "name": "DABs Resource Explorer",
+                    "name": "Bundle Resource Explorer",
                     "visibility": "visible",
                     "when": "databricks.context.bundle.isTargetSet"
                 },

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -85,7 +85,7 @@ export abstract class AuthProvider {
         await window.withProgress(
             {
                 location: ProgressLocation.Notification,
-                title: `Databricks: Trying to login using ${this.describe()}`,
+                title: `Databricks: Logging in using ${this.describe()}`,
             },
             async () => await checkFn()
         );

--- a/packages/databricks-vscode/src/configuration/ui/BundleTargetComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/BundleTargetComponent.ts
@@ -61,13 +61,13 @@ export class BundleTargetComponent extends BaseComponent {
 
         return [
             {
-                label: target,
+                label: "Target",
                 id: TREE_ICON_ID,
                 iconPath: new ThemeIcon(
                     "target",
                     new ThemeColor("debugIcon.startForeground")
                 ),
-                description: humanisedMode,
+                description: target,
                 contextValue: `databricks.configuration.target.${humanisedMode.toLocaleLowerCase()}}`,
                 collapsibleState: TreeItemCollapsibleState.Collapsed,
             },

--- a/packages/databricks-vscode/src/configuration/ui/SyncDestinationComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/SyncDestinationComponent.ts
@@ -1,4 +1,3 @@
-import {posix} from "path/posix";
 import {ConfigModel} from "../models/ConfigModel";
 import {ConnectionManager} from "../ConnectionManager";
 import {BaseComponent} from "./BaseComponent";
@@ -42,10 +41,9 @@ export class SyncDestinationComponent extends BaseComponent {
             : undefined;
     }
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
-        const config = await this.configModel.get("remoteRootPath");
-        if (config === undefined) {
-            // Workspace folder is not set in bundle and override
-            // We are not logged in
+        const workspaceFsPath = await this.configModel.get("remoteRootPath");
+
+        if (workspaceFsPath === undefined) {
             return [];
         }
 
@@ -54,12 +52,15 @@ export class SyncDestinationComponent extends BaseComponent {
 
         return [
             {
-                label: "Sync",
+                label: "Workspace Folder",
                 tooltip: url ? undefined : "Created after deploy",
-                description: posix.basename(posix.dirname(config)),
-                collapsibleState: TreeItemCollapsibleState.Expanded,
+                description: workspaceFsPath,
+                collapsibleState: TreeItemCollapsibleState.None,
                 contextValue: url ? `${contextValue}.has-url` : contextValue,
-                iconPath: new ThemeIcon("sync", new ThemeColor("charts.green")),
+                iconPath: new ThemeIcon(
+                    "folder-active",
+                    new ThemeColor("charts.green")
+                ),
                 resourceUri: url
                     ? undefined
                     : DecorationUtils.getModifiedStatusDecoration(
@@ -78,27 +79,11 @@ export class SyncDestinationComponent extends BaseComponent {
         if (this.connectionManager.state !== "CONNECTED") {
             return [];
         }
+
         if (parent === undefined) {
             return this.getRoot();
         }
-        // If the parent is not intended for this component, return empty array
-        if (parent.id !== TREE_ICON_ID) {
-            return [];
-        }
-        const workspaceFsPath = await this.configModel.get("remoteRootPath");
 
-        if (workspaceFsPath === undefined) {
-            return [];
-        }
-
-        const children: ConfigurationTreeItem[] = [
-            {
-                label: "Workspace Folder",
-                description: workspaceFsPath,
-                collapsibleState: TreeItemCollapsibleState.None,
-            },
-        ];
-
-        return children;
+        return [];
     }
 }

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -75,8 +75,6 @@ export async function activate(
     const stateStorage = new StateStorage(context);
     const packageMetadata = await PackageJsonUtils.getMetadata(context);
 
-    await stateStorage.set("databricks.preview-tnc.accepted", false);
-
     if (
         !stateStorage.get("databricks.preview-tnc.accepted") &&
         !isIntegrationTest()


### PR DESCRIPTION
## Changes
* Use link-external icon <img width="52" alt="image" src="https://github.com/databricks/databricks-vscode/assets/88345179/eda6495f-8bb7-4309-933b-c8ad41a07af9"> instead of link icon for urls
* Change DABs resource explorer to Bundle resource explorer
* Remove nesting of sync destination tree item. Now there is only 1 level directly displaying the full path. 
* Remove intentionally setting tnc flag to false (some leftover debugging code from previous PR). 


## Tests
<!-- How is this tested? -->

