### PR TITLE
Use packaged CLI if a cli path is not specified in .databrickscfg profile

### DIFF
--- a/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
+++ b/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
@@ -42,7 +42,7 @@ export class JobRunStatus extends BundleRunStatus {
             throw new Error("No run id found");
         }
 
-        const client = this.authProvider.getWorkspaceClient();
+        const client = await this.authProvider.getWorkspaceClient();
         try {
             this.runState = "running";
             await (
@@ -70,7 +70,7 @@ export class JobRunStatus extends BundleRunStatus {
             return;
         }
 
-        const client = this.authProvider.getWorkspaceClient();
+        const client = await this.authProvider.getWorkspaceClient();
         await (
             await client.jobs.cancelRun({run_id: parseInt(this.runId)})
         ).wait();

--- a/packages/databricks-vscode/src/bundle/run/PipelineRunStatus.ts
+++ b/packages/databricks-vscode/src/bundle/run/PipelineRunStatus.ts
@@ -49,7 +49,7 @@ export class PipelineRunStatus extends BundleRunStatus {
             throw new Error("No update id");
         }
 
-        const client = this.authProvider.getWorkspaceClient();
+        const client = await this.authProvider.getWorkspaceClient();
         this.runState = "running";
 
         this.interval = setInterval(async () => {
@@ -99,7 +99,7 @@ export class PipelineRunStatus extends BundleRunStatus {
             return;
         }
 
-        const client = this.authProvider.getWorkspaceClient();
+        const client = await this.authProvider.getWorkspaceClient();
         const update = await client.pipelines.getUpdate({
             pipeline_id: this.pipelineId,
             update_id: this.runId,

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -95,7 +95,11 @@ export class ConnectionCommands implements Disposable {
             throw new Error("Must login first");
         }
         const hostUrl = normalizeHost(host);
-        const provider = new PersonalAccessTokenAuthProvider(hostUrl, token);
+        const provider = new PersonalAccessTokenAuthProvider(
+            hostUrl,
+            token,
+            this.cli
+        );
         await saveNewProfile(name, provider, this.cli);
     }
 

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -300,11 +300,11 @@ export class ConnectionManager implements Disposable {
     @Mutex.synchronise("loginLogoutMutex")
     private async _connect(authProvider: AuthProvider) {
         this.updateState("CONNECTING");
+        this._workspaceClient = await authProvider.getWorkspaceClient();
         this._databricksWorkspace = await DatabricksWorkspace.load(
-            authProvider.getWorkspaceClient(),
+            this._workspaceClient,
             authProvider
         );
-        this._workspaceClient = authProvider.getWorkspaceClient();
         await this.configModel.set(
             "authProfile",
             authProvider.toJSON().profile as string | undefined

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -304,12 +304,16 @@ export class LoginWizard {
             | PersonalAccessTokenAuthProvider;
         switch (pick.authType) {
             case "azure-cli":
-                authProvider = new AzureCliAuthProvider(this.state.host!);
+                authProvider = new AzureCliAuthProvider(
+                    this.state.host!,
+                    this.cliWrapper
+                );
                 break;
 
             case "databricks-cli":
                 authProvider = new DatabricksCliAuthProvider(
                     this.state.host!,
+                    this.cliWrapper.cliPath,
                     this.cliWrapper
                 );
                 break;
@@ -329,7 +333,8 @@ export class LoginWizard {
                     }
                     authProvider = new PersonalAccessTokenAuthProvider(
                         this.state.host!,
-                        token
+                        token,
+                        this.cliWrapper
                     );
                 }
                 break;

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -30,6 +30,7 @@ export abstract class AuthProvider {
     constructor(
         private readonly _host: URL,
         private readonly _authType: AuthType,
+        private readonly _cli: CliWrapper,
         private checked: boolean = false
     ) {}
 
@@ -49,8 +50,8 @@ export abstract class AuthProvider {
     abstract toEnv(): Record<string, string>;
     abstract toIni(): Record<string, string | undefined> | undefined;
 
-    getWorkspaceClient(): WorkspaceClient {
-        const config = this.getSdkConfig();
+    async getWorkspaceClient(): Promise<WorkspaceClient> {
+        const config = await this.getSdkConfig();
 
         return new WorkspaceClient(config, {
             product: "databricks-vscode",
@@ -97,7 +98,17 @@ export abstract class AuthProvider {
 
         return this.checked;
     }
-    protected abstract getSdkConfig(): Config;
+    async getSdkConfig(): Promise<Config> {
+        const config = this._getSdkConfig();
+        await config.ensureResolved();
+        if (config.databricksCliPath === undefined) {
+            config.databricksCliPath = this._cli.cliPath;
+        }
+
+        return config;
+    }
+
+    protected abstract _getSdkConfig(): Config;
 
     static fromJSON(json: Record<string, any>, cli: CliWrapper): AuthProvider {
         const host =
@@ -121,7 +132,11 @@ export abstract class AuthProvider {
                 );
 
             case "databricks-cli":
-                return new DatabricksCliAuthProvider(host, cli);
+                return new DatabricksCliAuthProvider(
+                    host,
+                    json.databricksPath ?? cli.cliPath,
+                    cli
+                );
 
             case "profile":
                 if (!json.profile) {
@@ -144,12 +159,17 @@ export abstract class AuthProvider {
             case "azure-cli":
                 return new AzureCliAuthProvider(
                     host,
+                    cli,
                     config.azureTenantId,
                     config.azureLoginAppId
                 );
 
             case "databricks-cli":
-                return new DatabricksCliAuthProvider(host, cli);
+                return new DatabricksCliAuthProvider(
+                    host,
+                    config.databricksCliPath ?? cli.cliPath,
+                    cli
+                );
 
             default:
                 if (config.profile) {
@@ -172,7 +192,7 @@ export class ProfileAuthProvider extends AuthProvider {
         private readonly cli: CliWrapper,
         checked = false
     ) {
-        super(host, "profile", checked);
+        super(host, "profile", cli, checked);
     }
 
     describe(): string {
@@ -198,7 +218,7 @@ export class ProfileAuthProvider extends AuthProvider {
         return undefined;
     }
 
-    public static getSdkConfig(profile: string): Config {
+    private static getSdkConfig(profile: string): Config {
         return new Config({
             profile: profile,
             configFile: workspaceConfigs.databrickscfgLocation,
@@ -206,25 +226,25 @@ export class ProfileAuthProvider extends AuthProvider {
         });
     }
 
-    getSdkConfig(): Config {
+    protected _getSdkConfig(): Config {
         return ProfileAuthProvider.getSdkConfig(this.profile);
     }
 
     protected async _check() {
         while (true) {
             try {
-                const sdkConfig = this.getSdkConfig();
-                await sdkConfig.ensureResolved();
+                const sdkConfig = await this.getSdkConfig();
                 const authProvider = AuthProvider.fromSdkConfig(
                     sdkConfig,
                     this.cli
                 );
 
                 if (authProvider instanceof ProfileAuthProvider) {
-                    const workspaceClient = this.getWorkspaceClient();
+                    const workspaceClient = await this.getWorkspaceClient();
                     await workspaceClient.currentUser.me();
                     return true;
                 }
+
                 return await authProvider.check(false, false);
             } catch (e) {
                 let message: string = `Can't login with config profile ${this.profile}`;
@@ -252,9 +272,10 @@ export class ProfileAuthProvider extends AuthProvider {
 export class DatabricksCliAuthProvider extends AuthProvider {
     constructor(
         host: URL,
-        readonly cli: CliWrapper
+        readonly cliPath: string,
+        cli: CliWrapper
     ) {
-        super(host, "databricks-cli");
+        super(host, "databricks-cli", cli);
     }
 
     describe(): string {
@@ -265,15 +286,15 @@ export class DatabricksCliAuthProvider extends AuthProvider {
         return {
             host: this.host.toString(),
             authType: this.authType,
-            databricksPath: this.cli.cliPath,
+            databricksPath: this.cliPath,
         };
     }
 
-    getSdkConfig(): Config {
+    _getSdkConfig(): Config {
         return new Config({
             host: this.host.toString(),
             authType: "databricks-cli",
-            databricksCliPath: this.cli.cliPath,
+            databricksCliPath: this.cliPath,
         });
     }
 
@@ -301,8 +322,8 @@ export class AzureCliAuthProvider extends AuthProvider {
     private _tenantId?: string;
     private _appId?: string;
 
-    constructor(host: URL, tenantId?: string, appId?: string) {
-        super(host, "azure-cli");
+    constructor(host: URL, cli: CliWrapper, tenantId?: string, appId?: string) {
+        super(host, "azure-cli", cli);
 
         this._tenantId = tenantId;
         this._appId = appId;
@@ -329,7 +350,7 @@ export class AzureCliAuthProvider extends AuthProvider {
         };
     }
 
-    getSdkConfig(): Config {
+    _getSdkConfig(): Config {
         return new Config({
             host: this.host.toString(),
             authType: "azure-cli",
@@ -369,9 +390,10 @@ export class AzureCliAuthProvider extends AuthProvider {
 export class PersonalAccessTokenAuthProvider extends AuthProvider {
     constructor(
         host: URL,
-        private readonly token: string
+        private readonly token: string,
+        cli: CliWrapper
     ) {
-        super(host, "pat");
+        super(host, "pat", cli);
     }
 
     describe(): string {
@@ -400,7 +422,7 @@ export class PersonalAccessTokenAuthProvider extends AuthProvider {
     protected async _check(): Promise<boolean> {
         while (true) {
             try {
-                const workspaceClient = this.getWorkspaceClient();
+                const workspaceClient = await this.getWorkspaceClient();
                 await workspaceClient.currentUser.me();
                 return true;
             } catch (e) {
@@ -424,7 +446,7 @@ export class PersonalAccessTokenAuthProvider extends AuthProvider {
             }
         }
     }
-    protected getSdkConfig(): Config {
+    protected _getSdkConfig(): Config {
         return new Config({
             host: this.host.toString(),
             authType: "pat",

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -73,7 +73,7 @@ export class DatabricksCliCheck implements Disposable {
             {
                 host: this.authProvider.host.toString(),
                 authType: "databricks-cli",
-                databricksCliPath: this.authProvider.cli.cliPath,
+                databricksCliPath: this.authProvider.cliPath,
             },
             {
                 product: "databricks-vscode",
@@ -92,7 +92,7 @@ export class DatabricksCliCheck implements Disposable {
 
     private async login(): Promise<void> {
         try {
-            await ExecUtils.execFile(this.authProvider.cli.cliPath, [
+            await ExecUtils.execFile(this.authProvider.cliPath, [
                 "auth",
                 "login",
                 "--host",


### PR DESCRIPTION
For profiles which do not have `databricks_cli_path` specified, we should use the packaged CLI. 

## Changes
* Authproviders always try to resolve the sdk config. If no CLI is found after resolution (after loaders have loaded the profile data from .databrickscfg), we set the path to builtin databricks cli in the config. 
* Also, we now respect the `databricks_cli_path` config from profile. Earlier, we were always defaulting to packaged cli for `DatabricksCliAuthProvider`. 

https://github.com/databricks/databricks-vscode/assets/88345179/79213f70-e85a-42a2-98c9-531e546c0ab6


## Tests
<!-- How is this tested? -->

