### PR TITLE
Ignore stderr for validate and summary commands

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -288,13 +288,11 @@ export class CliWrapper {
                 },
                 shell: true,
             });
-            const output = stdout + stderr;
-
             logger?.info("Finished reading local bundle configuration.", {
                 bundleOpName: "validate",
             });
-            logger?.debug(output);
-            return output;
+            logger?.debug(stdout + stderr);
+            return stdout;
         } catch (e: any) {
             logger?.error(
                 `Failed to read local bundle configuration. ${e.message ?? ""}`,
@@ -335,13 +333,11 @@ export class CliWrapper {
                 },
                 shell: true,
             });
-
-            const output = stdout + stderr;
             logger?.info("Bundle configuration refreshed.", {
                 bundleOpName: "summarize",
             });
-            logger?.debug(output);
-            return output;
+            logger?.debug(stdout + stderr);
+            return stdout;
         } catch (e: any) {
             logger?.error(
                 `Failed to refresh bundle configuration. ${e.message ?? ""}`,


### PR DESCRIPTION
We still log stderr, but don't pass it down to the callers, as it will mess up json parsing.

If the command fails with non zero status we also fail, but the presence of stderr is not an indicator of failure in this case.

