### PR TITLE
Add currently selected python environment to path for wheel builds

### DIFF
--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -9,6 +9,7 @@ import lodash from "lodash";
 import {WorkspaceConfigs} from "../../vscode-objs/WorkspaceConfigs";
 import {logging} from "@databricks/databricks-sdk";
 import {Loggers} from "../../logger";
+import {MsPythonExtensionWrapper} from "../../language/MsPythonExtensionWrapper";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type BundleResourceModifiedStatus = "created" | "deleted" | "updated";
@@ -49,6 +50,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
     constructor(
         private readonly cli: CliWrapper,
         private readonly workspaceFolder: Uri,
+        private readonly pythonExtension: MsPythonExtensionWrapper,
         private readonly workspaceConfigs: WorkspaceConfigs
     ) {
         super();
@@ -72,6 +74,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
             this.target,
             this.authProvider,
             this.workspaceFolder,
+            this.pythonExtension,
             this.workspaceConfigs.databrickscfgLocation,
             this.logger
         );

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -415,7 +415,8 @@ export class CliWrapper {
 
         // Add python executable to PATH
         const executable = await pythonExtension.getPythonExecutable();
-        let shellPath = process.env.PATH;
+        const cliEnvVars = EnvVarGenerators.getEnvVarsForCli(configfilePath);
+        let shellPath = cliEnvVars.PATH;
         if (executable) {
             shellPath = `${path.dirname(executable)}${path.delimiter}${
                 process.env.PATH
@@ -424,7 +425,7 @@ export class CliWrapper {
         const p = spawn(cmd[0], cmd.slice(1), {
             cwd: workspaceFolder.fsPath,
             env: {
-                ...EnvVarGenerators.getEnvVarsForCli(configfilePath),
+                ...cliEnvVars,
                 ...EnvVarGenerators.getProxyEnvVars(),
                 ...authProvider.toEnv(),
                 ...this.getLogginEnvVars(),

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -418,9 +418,9 @@ export class CliWrapper {
         const cliEnvVars = EnvVarGenerators.getEnvVarsForCli(configfilePath);
         let shellPath = cliEnvVars.PATH;
         if (executable) {
-            shellPath = `${path.dirname(executable)}${path.delimiter}${
-                shellPath
-            }`;
+            shellPath = `${path.dirname(executable)}${
+                path.delimiter
+            }${shellPath}`;
         }
         const p = spawn(cmd[0], cmd.slice(1), {
             cwd: workspaceFolder.fsPath,

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -419,7 +419,7 @@ export class CliWrapper {
         let shellPath = cliEnvVars.PATH;
         if (executable) {
             shellPath = `${path.dirname(executable)}${path.delimiter}${
-                process.env.PATH
+                shellPath
             }`;
         }
         const p = spawn(cmd[0], cmd.slice(1), {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -232,6 +232,7 @@ export async function activate(
     const bundleRemoteStateModel = new BundleRemoteStateModel(
         cli,
         workspaceUri,
+        pythonExtensionWrapper,
         workspaceConfigs
     );
     const configModel = new ConfigModel(


### PR DESCRIPTION
## Changes
* Deploying jobs with wheels fails because we are not propagating the selected virtual env to bundle commands. 
* This PR fixes that by adding the path to virtual environment python binary to `PATH` env var for bundle deploy. 

## Tests
<!-- How is this tested? -->

