### PR TITLE
Fixes to initialisation UI

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -313,22 +313,22 @@
         "viewsWelcome": [
             {
                 "view": "configurationView",
-                "contents": "Add Databricks configuration to the current project:\n[Initialize Project](command:databricks.bundle.startManualMigration)",
-                "when": "workspaceFolderCount > 0 && databricks.context.initialized && databricks.context.pendingManualMigration"
-            },
-            {
-                "view": "configurationView",
-                "contents": "There are multiple Databricks projects in the workspace, please chose which one to open:\n[Open Existing Project](command:databricks.bundle.openSubProject)",
+                "contents": "There are multiple Databricks projects in the workspace:\n[Open existing Databricks Project](command:databricks.bundle.openSubProject)",
                 "when": "workspaceFolderCount > 0 && databricks.context.initialized && databricks.context.subProjectsAvailable"
             },
             {
                 "view": "configurationView",
-                "contents": "Create a new Databricks project?\n[Create a new Databricks Project](command:databricks.bundle.initNewProject)",
-                "when": "workspaceFolderCount > 0 && databricks.context.initialized && !databricks.context.pendingManualMigration"
+                "contents": "[Create a new Databricks Project](command:databricks.bundle.initNewProject)",
+                "when": "workspaceFolderCount > 0 && databricks.context.initialized"
             },
             {
                 "view": "configurationView",
-                "contents": "[Show Quickstart](command:databricks.quickstart.open)\nTo learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html).",
+                "contents": "Migrate current workspace to a Databricks Project: \n[Migrate to Databricks Project](command:databricks.bundle.startManualMigration)",
+                "when": "workspaceFolderCount > 0 && databricks.context.initialized && databricks.context.pendingManualMigration"
+            },
+            {
+                "view": "configurationView",
+                "contents": "To learn more about how to use Databricks with VS Code [read our docs](https://docs.databricks.com/dev-tools/vscode-ext.html) or [Quickstart guide](command:databricks.quickstart.open)",
                 "when": "databricks.context.initialized"
             },
             {
@@ -338,7 +338,7 @@
             },
             {
                 "view": "configurationView",
-                "contents": "The workspace is empty.\n[Initialize New Project](command:databricks.bundle.initNewProject)",
+                "contents": "The workspace is empty.\n[Create a new Databricks Project](command:databricks.bundle.initNewProject)",
                 "when": "workspaceFolderCount == 0"
             }
         ],

--- a/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundlePreValidateModel.ts
@@ -63,9 +63,9 @@ export class BundlePreValidateModel extends BaseModelWithStateCache<BundlePreVal
         });
     }
 
-    public async setTarget(target: string | undefined) {
+    public setTarget(target: string | undefined) {
         this.target = target;
-        await this.stateCache.refresh();
+        this.resetCache();
     }
 
     protected readStateFromTarget(
@@ -93,7 +93,6 @@ export class BundlePreValidateModel extends BaseModelWithStateCache<BundlePreVal
         return targetObject;
     }
 
-    @Mutex.synchronise("mutex")
     protected async readState() {
         if (this.target === undefined) {
             return {};
@@ -137,6 +136,10 @@ export class BundlePreValidateModel extends BaseModelWithStateCache<BundlePreVal
         }
 
         return [...filesWithConfig, ...filesWithTarget][0];
+    }
+
+    public resetCache(): void {
+        this.stateCache.set({});
     }
 
     public dispose() {

--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -94,23 +94,20 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
         );
     }
 
-    @Mutex.synchronise("mutex")
-    public async setTarget(target: string | undefined) {
+    public setTarget(target: string | undefined) {
         if (this.target === target) {
             return;
         }
         this.target = target;
+        this.resetCache();
         this.authProvider = undefined;
-        await this.stateCache.refresh();
     }
 
-    @Mutex.synchronise("mutex")
-    public async setAuthProvider(authProvider: AuthProvider | undefined) {
+    public setAuthProvider(authProvider: AuthProvider | undefined) {
         if (
             !lodash.isEqual(this.authProvider?.toJSON(), authProvider?.toJSON())
         ) {
             this.authProvider = authProvider;
-            await this.stateCache.refresh();
         }
     }
 
@@ -141,6 +138,10 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
         return key.split(".").reduce((prev: any, k) => {
             return prev[k];
         }, resources);
+    }
+
+    public resetCache(): void {
+        this.stateCache.set({});
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
@@ -17,8 +17,8 @@ export type BundleValidateState = {
 } & BundleTarget;
 
 export class BundleValidateModel extends BaseModelWithStateCache<BundleValidateState> {
-    private target: string | undefined;
-    private authProvider: AuthProvider | undefined;
+    public target: string | undefined;
+    public authProvider: AuthProvider | undefined;
     protected mutex = new Mutex();
     protected logger = logging.NamedLogger.getOrCreate(Loggers.Bundle);
 

--- a/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
@@ -40,23 +40,20 @@ export class BundleValidateModel extends BaseModelWithStateCache<BundleValidateS
         );
     }
 
-    @Mutex.synchronise("mutex")
-    public async setTarget(target: string | undefined) {
+    public setTarget(target: string | undefined) {
         if (this.target === target) {
             return;
         }
         this.target = target;
+        this.resetCache();
         this.authProvider = undefined;
-        await this.stateCache.refresh();
     }
 
-    @Mutex.synchronise("mutex")
-    public async setAuthProvider(authProvider: AuthProvider | undefined) {
+    public setAuthProvider(authProvider: AuthProvider | undefined) {
         if (
             !lodash.isEqual(this.authProvider?.toJSON(), authProvider?.toJSON())
         ) {
             this.authProvider = authProvider;
-            await this.stateCache.refresh();
         }
     }
 
@@ -80,6 +77,10 @@ export class BundleValidateModel extends BaseModelWithStateCache<BundleValidateS
             remoteRootPath: validateOutput?.workspace?.file_path,
             ...validateOutput,
         };
+    }
+
+    public resetCache(): void {
+        this.stateCache.set({});
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -42,6 +42,20 @@ export class ProcessError extends Error {
     ) {
         super(message);
     }
+
+    showErrorMessage(prefix?: string) {
+        window
+            .showErrorMessage(
+                (prefix?.trimEnd().concat(" ") ?? "") +
+                    `Error executing Databricks CLI command.`,
+                "Show Logs"
+            )
+            .then((choice) => {
+                if (choice === "Show Logs") {
+                    commands.executeCommand("databricks.bundle.showLogs");
+                }
+            });
+    }
 }
 
 async function waitForProcess(

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -15,9 +15,10 @@ import {ConfigModel} from "./models/ConfigModel";
 import {saveNewProfile} from "./LoginWizard";
 import {PersonalAccessTokenAuthProvider} from "./auth/AuthProvider";
 import {normalizeHost} from "../utils/urlUtils";
-import {CliWrapper} from "../cli/CliWrapper";
+import {CliWrapper, ProcessError} from "../cli/CliWrapper";
 import {AUTH_TYPE_SWITCH_ID, AUTH_TYPE_LOGIN_ID} from "./ui/AuthTypeComponent";
 import {ManualLoginSource} from "../telemetry/constants";
+import {onError} from "../utils/onErrorDecorator";
 
 function formatQuickPickClusterSize(sizeInMB: number): string {
     if (sizeInMB > 1024) {
@@ -204,6 +205,7 @@ export class ConnectionCommands implements Disposable {
         };
     }
 
+    @onError({popup: {prefix: "Error selecting target."}})
     async selectTarget() {
         const targets = await this.configModel.targets;
         const currentTarget = this.configModel.target;
@@ -226,7 +228,14 @@ export class ConnectionCommands implements Disposable {
         if (selectedTarget === undefined) {
             return;
         }
-        this.configModel.setTarget(selectedTarget.label);
+        try {
+            await this.configModel.setTarget(selectedTarget.label);
+        } catch (e) {
+            if (e instanceof ProcessError) {
+                e.showErrorMessage("Error selecting target");
+            }
+            throw e;
+        }
     }
 
     dispose() {

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -293,7 +293,6 @@ export class ConnectionManager implements Disposable {
                     `Can't connect to the workspace: "${e.message}"."`
                 );
             }
-            await this.logout();
         }
     }
 
@@ -309,11 +308,15 @@ export class ConnectionManager implements Disposable {
             "authProfile",
             authProvider.toJSON().profile as string | undefined
         );
-        await this.configModel.setAuthProvider(authProvider);
+
         await this.updateSyncDestinationMapper();
         await this.updateClusterManager();
         await this._metadataService.setApiClient(this.apiClient);
-        this.updateState("CONNECTED");
+        try {
+            await this.configModel.setAuthProvider(authProvider);
+        } finally {
+            this.updateState("CONNECTED");
+        }
     }
 
     @Mutex.synchronise("loginLogoutMutex")

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -5,8 +5,8 @@ import {
     AuthType as SdkAuthType,
 } from "@databricks/databricks-sdk";
 import {Cluster} from "../sdk-extensions";
-import {EventEmitter, Uri, window, Disposable, commands} from "vscode";
-import {CliWrapper, ProcessError} from "../cli/CliWrapper";
+import {EventEmitter, Uri, window, Disposable} from "vscode";
+import {CliWrapper} from "../cli/CliWrapper";
 import {
     SyncDestinationMapper,
     RemoteUri,
@@ -275,20 +275,7 @@ export class ConnectionManager implements Disposable {
                 `Can't connect to the workspace`,
                 e
             );
-            if (e instanceof ProcessError) {
-                window
-                    .showErrorMessage(
-                        `Can't connect to the workspace. Error executing Databricks CLI command.`,
-                        "Show Logs"
-                    )
-                    .then((choice) => {
-                        if (choice === "Show Logs") {
-                            commands.executeCommand(
-                                "databricks.bundle.showLogs"
-                            );
-                        }
-                    });
-            } else if (e instanceof Error) {
+            if (e instanceof Error) {
                 window.showErrorMessage(
                     `Can't connect to the workspace: "${e.message}"."`
                 );

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -12,7 +12,7 @@ import {
     RemoteUri,
     LocalUri,
 } from "../sync/SyncDestination";
-import {LoginWizard, listProfiles} from "./LoginWizard";
+import {LoginWizard, getProfilesForHost} from "./LoginWizard";
 import {ClusterManager} from "../cluster/ClusterManager";
 import {DatabricksWorkspace} from "./DatabricksWorkspace";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
@@ -246,9 +246,7 @@ export class ConnectionManager implements Disposable {
         }
 
         // Try to load a unique profile that matches the host
-        const profiles = (await listProfiles(this.cli)).filter(
-            (p) => p.host?.toString() === host.toString()
-        );
+        const profiles = await getProfilesForHost(host, this.cli);
         if (profiles.length !== 1) {
             return;
         }

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -440,7 +440,7 @@ export async function listProfiles(cliWrapper: CliWrapper) {
         async () => {
             const profiles = (
                 await cliWrapper.listProfiles(
-                    workspaceConfigs.databrickscfgLocation
+                    FileUtils.getDatabricksConfigFilePath().fsPath
                 )
             ).filter((profile) => {
                 try {
@@ -453,6 +453,12 @@ export async function listProfiles(cliWrapper: CliWrapper) {
 
             return profiles;
         }
+    );
+}
+
+export async function getProfilesForHost(host: URL, cliWrapper: CliWrapper) {
+    return (await listProfiles(cliWrapper)).filter(
+        (profile) => profile.host?.toString() === host.toString()
     );
 }
 

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -188,7 +188,7 @@ export class ProfileAuthProvider extends AuthProvider {
 
     constructor(
         host: URL,
-        private readonly profile: string,
+        readonly profile: string,
         private readonly cli: CliWrapper,
         checked = false
     ) {

--- a/packages/databricks-vscode/src/configuration/models/BaseModelWithStateCache.ts
+++ b/packages/databricks-vscode/src/configuration/models/BaseModelWithStateCache.ts
@@ -48,6 +48,11 @@ export abstract class BaseModelWithStateCache<StateType extends object>
         }>;
     }
 
+    public refresh() {
+        this.stateCache.refresh();
+    }
+
+    public abstract resetCache(): void;
     dispose() {
         this.disposables.forEach((i) => i.dispose());
     }

--- a/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
@@ -60,10 +60,9 @@ export class OverrideableConfigModel extends BaseModelWithStateCache<Overrideabl
         super();
     }
 
-    @Mutex.synchronise("mutex")
-    public async setTarget(target: string | undefined) {
+    public setTarget(target: string | undefined) {
         this.target = target;
-        await this.stateCache.refresh();
+        this.resetCache();
     }
 
     protected async readState() {
@@ -125,6 +124,10 @@ export class OverrideableConfigModel extends BaseModelWithStateCache<Overrideabl
         data[key] = value;
         await mkdir(path.dirname(storageFile.fsPath), {recursive: true});
         await writeFile(storageFile.fsPath, JSON.stringify(data, null, 2));
+    }
+
+    public resetCache(): void {
+        this.stateCache.set({});
     }
 
     public dispose() {

--- a/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
@@ -61,7 +61,7 @@ export class AuthTypeComponent extends BaseComponent {
             }
             return [
                 {
-                    label: {label},
+                    label: {label, highlights: [[0, label.length]]},
                     iconPath: new ThemeIcon(
                         "account",
                         new ThemeColor("notificationsErrorIcon.foreground")

--- a/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/AuthTypeComponent.ts
@@ -3,6 +3,8 @@ import {ConnectionManager} from "../ConnectionManager";
 import {BaseComponent} from "./BaseComponent";
 import {ConfigurationTreeItem} from "./types";
 import {ThemeIcon, ThemeColor} from "vscode";
+import {getProfilesForHost} from "../LoginWizard";
+import {CliWrapper} from "../../cli/CliWrapper";
 
 export const AUTH_TYPE_SWITCH_ID = "AUTH-TYPE";
 export const AUTH_TYPE_LOGIN_ID = "LOGIN";
@@ -14,7 +16,8 @@ function getContextValue(key: string) {
 export class AuthTypeComponent extends BaseComponent {
     constructor(
         private readonly connectionManager: ConnectionManager,
-        private readonly configModel: ConfigModel
+        private readonly configModel: ConfigModel,
+        private readonly cli: CliWrapper
     ) {
         super();
         this.disposables.push(
@@ -28,6 +31,10 @@ export class AuthTypeComponent extends BaseComponent {
     }
 
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
+        if (this.configModel.target === undefined) {
+            return [];
+        }
+
         const authProvider =
             this.connectionManager.databricksWorkspace?.authProvider;
 
@@ -41,7 +48,17 @@ export class AuthTypeComponent extends BaseComponent {
         }
 
         if (authProvider === undefined) {
-            const label = "Login to Databricks";
+            const host = await this.configModel.get("host");
+            if (host === undefined) {
+                return [];
+            }
+
+            const profiles = await getProfilesForHost(host, this.cli);
+            let label = "Login to Databricks";
+            if (profiles.length > 1) {
+                label =
+                    "Multiple login profiles available. Click to select a profile.";
+            }
             return [
                 {
                     label: {label},

--- a/packages/databricks-vscode/src/configuration/ui/ClusterComponent.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ClusterComponent.ts
@@ -105,6 +105,10 @@ export class ClusterComponent extends BaseComponent {
                         new ThemeColor("notificationsErrorIcon.foreground")
                     ),
                     id: TREE_ICON_ID,
+                    command: {
+                        title: "Select a cluster",
+                        command: "databricks.connection.attachClusterQuickPick",
+                    },
                 },
             ];
         }

--- a/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
@@ -15,6 +15,7 @@ import {AuthTypeComponent} from "./AuthTypeComponent";
 import {ClusterComponent} from "./ClusterComponent";
 import {SyncDestinationComponent} from "./SyncDestinationComponent";
 import {BundleProjectManager} from "../../bundle/BundleProjectManager";
+import {CliWrapper} from "../../cli/CliWrapper";
 
 /**
  * Data provider for the cluster tree view
@@ -32,14 +33,19 @@ export class ConfigurationDataProvider
     private disposables: Array<Disposable> = [];
     private components: Array<BaseComponent> = [
         new BundleTargetComponent(this.configModel),
-        new AuthTypeComponent(this.connectionManager, this.configModel),
+        new AuthTypeComponent(
+            this.connectionManager,
+            this.configModel,
+            this.cli
+        ),
         new ClusterComponent(this.connectionManager, this.configModel),
         new SyncDestinationComponent(this.connectionManager, this.configModel),
     ];
     constructor(
         private readonly connectionManager: ConnectionManager,
         private readonly bundleProjectManager: BundleProjectManager,
-        private readonly configModel: ConfigModel
+        private readonly configModel: ConfigModel,
+        private readonly cli: CliWrapper
     ) {
         this.disposables.push(
             this.bundleProjectManager.onDidChangeStatus(async () => {

--- a/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/configuration/ui/ConfigurationDataProvider.ts
@@ -16,7 +16,8 @@ import {ClusterComponent} from "./ClusterComponent";
 import {SyncDestinationComponent} from "./SyncDestinationComponent";
 import {BundleProjectManager} from "../../bundle/BundleProjectManager";
 import {CliWrapper} from "../../cli/CliWrapper";
-
+import {logging} from "@databricks/databricks-sdk";
+import {Loggers} from "../../logger";
 /**
  * Data provider for the cluster tree view
  */
@@ -76,7 +77,15 @@ export class ConfigurationDataProvider
         if (!isInBundleProject) {
             return [];
         }
-        const children = this.components.map((c) => c.getChildren(parent));
+        const children = this.components.map((c) =>
+            c.getChildren(parent).catch((e) => {
+                logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                    `Error getting children for ${c.constructor.name}`,
+                    e
+                );
+                return [];
+            })
+        );
         return (await Promise.all(children)).flat();
     }
 }

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -448,7 +448,8 @@ export async function activate(
     const configurationDataProvider = new ConfigurationDataProvider(
         connectionManager,
         bundleProjectManager,
-        configModel
+        configModel,
+        cli
     );
 
     const connectionCommands = new ConnectionCommands(

--- a/packages/databricks-vscode/src/test/e2e/auth.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/auth.e2e.ts
@@ -57,16 +57,6 @@ describe("Configure Databricks Extension", async function () {
             }
         });
         assert(welcomeButtons, "Welcome buttons don't exist");
-        const initTitle = await welcomeButtons[0].getTitle();
-        const quickStartTitle = await welcomeButtons[1].getTitle();
-        assert(
-            initTitle.toLowerCase().includes("initialize"),
-            "'initialize` button doesn't exist"
-        );
-        assert(
-            quickStartTitle.toLowerCase().includes("quickstart"),
-            "'quickstart' button doesn't exist"
-        );
     });
 
     it("should automatically login after detecting bundle configuration", async () => {

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -9,7 +9,7 @@ import {PipelineTreeNode} from "./PipelineTreeNode";
 import {JobTreeNode} from "./JobTreeNode";
 import {CustomWhenContext} from "../../vscode-objs/CustomWhenContext";
 import {Events, Telemetry} from "../../telemetry";
-
+import * as lodash from "lodash";
 export const RUNNABLE_BUNDLE_RESOURCES = [
     "pipelines",
     "jobs",
@@ -35,7 +35,17 @@ export class BundleCommands implements Disposable {
     ) {
         this.disposables.push(
             this.bundleValidateModel.onDidChange(async () => {
-                await this.refreshRemoteState();
+                // Only refresh if both the validate model and the remote state model are using the same target and auth provider
+                if (
+                    this.bundleRemoteStateModel.target ===
+                        this.bundleValidateModel.target &&
+                    lodash.isEqual(
+                        this.bundleRemoteStateModel.authProvider,
+                        this.bundleValidateModel.authProvider
+                    )
+                ) {
+                    await this.refreshRemoteState();
+                }
             })
         );
     }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -1,4 +1,4 @@
-import {Disposable, ProgressLocation, window, commands} from "vscode";
+import {Disposable, ProgressLocation, window} from "vscode";
 import {BundleRemoteStateModel} from "../../bundle/models/BundleRemoteStateModel";
 import {onError} from "../../utils/onErrorDecorator";
 import {BundleResourceExplorerTreeNode} from "./types";
@@ -10,6 +10,7 @@ import {JobTreeNode} from "./JobTreeNode";
 import {CustomWhenContext} from "../../vscode-objs/CustomWhenContext";
 import {Events, Telemetry} from "../../telemetry";
 import * as lodash from "lodash";
+import {ProcessError} from "../../cli/CliWrapper";
 export const RUNNABLE_BUNDLE_RESOURCES = [
     "pipelines",
     "jobs",
@@ -65,13 +66,11 @@ export class BundleCommands implements Disposable {
             if (!(e instanceof Error)) {
                 throw e;
             }
-            window
-                .showErrorMessage("Error refreshing bundle state.", "Show Logs")
-                .then((choice) => {
-                    if (choice === "Show Logs") {
-                        commands.executeCommand("databricks.bundle.showLogs");
-                    }
-                });
+
+            if (e instanceof ProcessError) {
+                e.showErrorMessage("Error refreshing remote state.");
+            }
+
             throw e;
         }
     }
@@ -99,13 +98,9 @@ export class BundleCommands implements Disposable {
             if (!(e instanceof Error)) {
                 throw e;
             }
-            window
-                .showErrorMessage("Error deploying resource.", "Show Logs")
-                .then((choice) => {
-                    if (choice === "Show Logs") {
-                        commands.executeCommand("databricks.bundle.showLogs");
-                    }
-                });
+            if (e instanceof ProcessError) {
+                e.showErrorMessage("Error deploying bundle.");
+            }
             throw e;
         } finally {
             this.whenContext.setDeploymentState("idle");

--- a/packages/databricks-vscode/src/utils/EventWithErrorHandler.ts
+++ b/packages/databricks-vscode/src/utils/EventWithErrorHandler.ts
@@ -12,7 +12,6 @@ export class EventEmitterWithErrorHandler<T> {
         const fn = (
             listener: (e: T) => Promise<unknown>,
             opts: {
-                thisArgs?: any;
                 disposables?: Disposable[];
                 onError?: OnErrorProps;
             } = {}
@@ -21,7 +20,7 @@ export class EventEmitterWithErrorHandler<T> {
 
             return this._event(
                 withOnErrorHandler(listener, opts.onError),
-                opts.thisArgs,
+                undefined,
                 opts.disposables
             );
         };

--- a/packages/databricks-vscode/src/utils/fileUtils.ts
+++ b/packages/databricks-vscode/src/utils/fileUtils.ts
@@ -50,7 +50,7 @@ export function getHomedir() {
     return process.env.HOME ?? homedir();
 }
 
-export async function openDatabricksConfigFile() {
+export function getDatabricksConfigFilePath() {
     const homeDir = getHomedir();
     let filePath =
         workspaceConfigs.databrickscfgLocation ??
@@ -59,7 +59,11 @@ export async function openDatabricksConfigFile() {
     if (filePath.startsWith("~/")) {
         filePath = path.join(homeDir, filePath.slice(2));
     }
-    const uri = Uri.file(path.normalize(filePath));
+    return Uri.file(path.normalize(filePath));
+}
+
+export async function openDatabricksConfigFile() {
+    const uri = getDatabricksConfigFilePath();
     try {
         await workspace.fs.stat(uri);
     } catch (e) {

--- a/packages/databricks-vscode/src/utils/urlUtils.ts
+++ b/packages/databricks-vscode/src/utils/urlUtils.ts
@@ -7,6 +7,13 @@ export async function openExternal(url: string) {
     await env.openExternal(Uri.parse(addHttpsIfNoProtocol(url), true));
 }
 
+export class UrlError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "UrlError";
+    }
+}
+
 export function normalizeHost(host: string): URL {
     let url: URL;
 
@@ -16,10 +23,10 @@ export function normalizeHost(host: string): URL {
     try {
         url = new URL(host);
     } catch (e) {
-        throw new Error("Invalid host name");
+        throw new UrlError("Invalid host name");
     }
     if (url.protocol !== "https:") {
-        throw new Error("Invalid protocol");
+        throw new UrlError("Invalid protocol");
     }
 
     return new URL(`https://${url.hostname}`);


### PR DESCRIPTION
## Changes
### Welcome view changes
* Always show button to create a databricks project.
* Don't automatically migrate from old project.json if there are subprojects present. 
* Reword welcome view buttons and text
<img width="528" alt="image" src="https://github.com/databricks/databricks-vscode/assets/88345179/f8624887-6cdc-4ad7-97eb-c46ad9b8b42e">

### Login Changes
* Don't logout if refreshing one of the models fails. This means users can see the error, fix it and have their fixes automatically be picked up and tried out. 
* Show "Multiple login profiles available. Click to select a profile." when multiple profiles found in .databrickscfg.

## Tests
<!-- How is this tested? -->

