### PR TITLE
Fix build platform detection

### DIFF
--- a/.github/workflows/create-build-artifacts.yml
+++ b/.github/workflows/create-build-artifacts.yml
@@ -25,6 +25,7 @@ jobs:
               working-directory: packages/databricks-vscode
               env:
                   GH_TOKEN: ${{ github.token }}
+                  BUILD_PLATFORM_ARCH: linux_amd64
 
             - uses: actions/upload-artifact@v3
               with:

--- a/packages/databricks-vscode/scripts/package-vsix.sh
+++ b/packages/databricks-vscode/scripts/package-vsix.sh
@@ -42,7 +42,18 @@ esac
 # This CLI is used to request metadata about CLIs terraform dependencies.
 if [ ! -d ./.build ]; then
   mkdir ./.build
-  BUILD_PLATFORM_ARCH="$(uname -s | awk '{print tolower($0)}')_$(uname -m)"
+  case "$(uname -s | awk '{print tolower($0)}')" in
+    "darwin")
+      BUILD_PLATFORM_ARCH="darwin_arm64"
+      ;;
+    "linux")
+      BUILD_PLATFORM_ARCH="linux_amd64"
+      ;;
+    *)
+      echo "Unknown platform: $BUILD_PLATFORM"
+      exit 1
+      ;;
+  esac
   ./scripts/fetch-databricks-cli.sh $BUILD_PLATFORM_ARCH ./.build
 fi
 

--- a/packages/databricks-vscode/scripts/package-vsix.sh
+++ b/packages/databricks-vscode/scripts/package-vsix.sh
@@ -42,18 +42,9 @@ esac
 # This CLI is used to request metadata about CLIs terraform dependencies.
 if [ ! -d ./.build ]; then
   mkdir ./.build
-  case "$(uname -s | awk '{print tolower($0)}')" in
-    "darwin")
-      BUILD_PLATFORM_ARCH="darwin_arm64"
-      ;;
-    "linux")
-      BUILD_PLATFORM_ARCH="linux_amd64"
-      ;;
-    *)
-      echo "Unknown platform: $BUILD_PLATFORM"
-      exit 1
-      ;;
-  esac
+  if [ -z "$BUILD_PLATFORM_ARCH" ]; then
+      BUILD_PLATFORM_ARCH="$(uname -s | awk '{print tolower($0)}')_$(uname -m)"
+  fi
   ./scripts/fetch-databricks-cli.sh $BUILD_PLATFORM_ARCH ./.build
 fi
 


### PR DESCRIPTION
Made a mistake when setting up build_platform env var - it worked on macos, but linux machines produced platform ids incompatible with the CLI releases