### PR TITLE
Run `bundle summary` with `--force-pull`

### DIFF
--- a/packages/databricks-vscode/scripts/package-vsix.sh
+++ b/packages/databricks-vscode/scripts/package-vsix.sh
@@ -52,11 +52,10 @@ rm -rf bin
 ./scripts/fetch-databricks-cli.sh $CLI_ARCH
 yarn ts-node ./scripts/setArchInPackage.ts $VSXI_ARCH -f package.json --cliArch $CLI_ARCH -V $VSXI_ARCH -c $(git rev-parse --short HEAD)
 
-# Temporary disable terraform bundling, as we've noticed a bug with projects that use older version of the terraform provider
 # Don't bundle terraform for win32-arm64 as they don't support it yet: https://github.com/hashicorp/terraform/issues/32719
-# if [ $ARCH != "win32-arm64" ]; then
-#   yarn ts-node ./scripts/setupCLIDependencies.ts --cli ./.build/databricks --binDir ./bin --package ./package.json --arch $CLI_ARCH
-# fi
+if [ $ARCH != "win32-arm64" ]; then
+  yarn ts-node ./scripts/setupCLIDependencies.ts --cli ./.build/databricks --binDir ./bin --package ./package.json --arch $CLI_ARCH
+fi
 
 yarn run prettier package.json --write
 TAG="release-v$(cat package.json | jq -r .version)" yarn run package -t $VSXI_ARCH

--- a/packages/databricks-vscode/scripts/package-vsix.sh
+++ b/packages/databricks-vscode/scripts/package-vsix.sh
@@ -52,10 +52,11 @@ rm -rf bin
 ./scripts/fetch-databricks-cli.sh $CLI_ARCH
 yarn ts-node ./scripts/setArchInPackage.ts $VSXI_ARCH -f package.json --cliArch $CLI_ARCH -V $VSXI_ARCH -c $(git rev-parse --short HEAD)
 
+# Temporary disable terraform bundling, as we've noticed a bug with projects that use older version of the terraform provider
 # Don't bundle terraform for win32-arm64 as they don't support it yet: https://github.com/hashicorp/terraform/issues/32719
-if [ $ARCH != "win32-arm64" ]; then
-  yarn ts-node ./scripts/setupCLIDependencies.ts --cli ./.build/databricks --binDir ./bin --package ./package.json --arch $CLI_ARCH
-fi
+# if [ $ARCH != "win32-arm64" ]; then
+#   yarn ts-node ./scripts/setupCLIDependencies.ts --cli ./.build/databricks --binDir ./bin --package ./package.json --arch $CLI_ARCH
+# fi
 
 yarn run prettier package.json --write
 TAG="release-v$(cat package.json | jq -r .version)" yarn run package -t $VSXI_ARCH

--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -44,11 +44,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
     public target: string | undefined;
     public authProvider: AuthProvider | undefined;
     protected mutex = new Mutex();
-    private refreshInterval: NodeJS.Timeout | undefined;
     private logger = logging.NamedLogger.getOrCreate(Loggers.Bundle);
-
-    // Forces the CLI to regenerate local terraform state and pull the remote state
-    private skipCliCache = true;
 
     constructor(
         private readonly cli: CliWrapper,
@@ -126,7 +122,6 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
             this.target,
             this.authProvider,
             this.workspaceFolder,
-            this.skipCliCache,
             this.workspaceConfigs.databrickscfgLocation,
             this.logger
         );
@@ -134,7 +129,6 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
         if (output === "" || output === undefined) {
             return {};
         }
-        this.skipCliCache = false;
         return JSON.parse(output);
     }
 
@@ -149,14 +143,10 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
     }
 
     public resetCache(): void {
-        this.skipCliCache = true;
         this.stateCache.set({});
     }
 
     dispose() {
         super.dispose();
-        if (this.refreshInterval !== undefined) {
-            clearInterval(this.refreshInterval);
-        }
     }
 }

--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -47,6 +47,9 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
     private refreshInterval: NodeJS.Timeout | undefined;
     private logger = logging.NamedLogger.getOrCreate(Loggers.Bundle);
 
+    // Forces the CLI to regenerate local terraform state and pull the remote state
+    private skipCliCache = true;
+
     constructor(
         private readonly cli: CliWrapper,
         private readonly workspaceFolder: Uri,
@@ -123,6 +126,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
             this.target,
             this.authProvider,
             this.workspaceFolder,
+            this.skipCliCache,
             this.workspaceConfigs.databrickscfgLocation,
             this.logger
         );
@@ -130,6 +134,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
         if (output === "" || output === undefined) {
             return {};
         }
+        this.skipCliCache = false;
         return JSON.parse(output);
     }
 
@@ -144,6 +149,7 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
     }
 
     public resetCache(): void {
+        this.skipCliCache = true;
         this.stateCache.set({});
     }
 

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -343,7 +343,7 @@ export class CliWrapper {
             // Forces the CLI to regenerate local terraform state and pull the remote state.
             // Regenerating terraform state is useful when we want to ensure that the provider version
             // used in the local state matches the bundled version we supply with the extension.
-            "--force-pull",
+            // "--force-pull",
         ];
 
         logger?.info(

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -331,14 +331,20 @@ export class CliWrapper {
         target: string,
         authProvider: AuthProvider,
         workspaceFolder: Uri,
-        skipCache: boolean,
         configfilePath?: string,
         logger?: logging.NamedLogger
     ) {
-        const cmd = [this.cliPath, "bundle", "summary", "--target", target];
-        if (skipCache) {
-            cmd.push("--force-pull");
-        }
+        const cmd = [
+            this.cliPath,
+            "bundle",
+            "summary",
+            "--target",
+            target,
+            // Forces the CLI to regenerate local terraform state and pull the remote state.
+            // Regenerating terraform state is useful when we want to ensure that the provider version
+            // used in the local state matches the bundled version we supply with the extension.
+            "--force-pull",
+        ];
 
         logger?.info(
             `Refreshing bundle configuration for target ${target}...`,

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -343,7 +343,7 @@ export class CliWrapper {
             // Forces the CLI to regenerate local terraform state and pull the remote state.
             // Regenerating terraform state is useful when we want to ensure that the provider version
             // used in the local state matches the bundled version we supply with the extension.
-            // "--force-pull",
+            "--force-pull",
         ];
 
         logger?.info(

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -331,10 +331,14 @@ export class CliWrapper {
         target: string,
         authProvider: AuthProvider,
         workspaceFolder: Uri,
+        skipCache: boolean,
         configfilePath?: string,
         logger?: logging.NamedLogger
     ) {
         const cmd = [this.cliPath, "bundle", "summary", "--target", target];
+        if (skipCache) {
+            cmd.push("--force-pull");
+        }
 
         logger?.info(
             `Refreshing bundle configuration for target ${target}...`,


### PR DESCRIPTION
Fixes a problem with projects that use older version of the databricks provider (than the one with ship the extension with).

With the updated logic we always regenerating internal terraform state when we execute `summary` command, which sets the correct provider version for the terraform