### PR TITLE
Bring back `login` public API

### DIFF
--- a/packages/databricks-vscode-types/index.ts
+++ b/packages/databricks-vscode-types/index.ts
@@ -12,6 +12,7 @@ export interface PublicApi {
     connectionManager: {
         onDidChangeState: Event<ConnectionState>;
 
+        login(interactive?: boolean, force?: boolean): Promise<void>;
         waitForConnect(): Promise<void>;
 
         get state(): ConnectionState;

--- a/packages/databricks-vscode/src/locking/Barrier.ts
+++ b/packages/databricks-vscode/src/locking/Barrier.ts
@@ -1,0 +1,9 @@
+export class Barrier {
+    public promise: Promise<void>;
+    public resolve: () => void = () => {};
+    constructor() {
+        this.promise = new Promise((resolve) => {
+            this.resolve = resolve;
+        });
+    }
+}

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -23,7 +23,11 @@ export enum Events {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 export type AutoLoginSource = "init" | "hostChange" | "targetChange";
-export type ManualLoginSource = "authTypeSwitch" | "authTypeLogin" | "command";
+export type ManualLoginSource =
+    | "authTypeSwitch"
+    | "authTypeLogin"
+    | "command"
+    | "api";
 export type BundleRunResourceType = "pipelines" | "jobs";
 
 /** Documentation about all of the properties and metrics of the event. */


### PR DESCRIPTION
Tested on databricks driver for the SQLTools extension. Databricks Power Tools extension doesn't work even with 1.3 version. With this v2 API it has the same "Connection is not valid!" issue as in 1.3.


