### PR TITLE
Fix env loading in notebooks

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -52,7 +52,7 @@ def logErrorAndContinue(f):
 def load_env_from_leaf(path: str) -> bool:
     curdir = path if os.path.isdir(path) else os.path.dirname(path)
     env_file_path = os.path.join(curdir, ".databricks", ".databricks.env")
-    if os.path.exists(os.path.dirname(env_file_path)):
+    if os.path.exists(env_file_path):
         with open(env_file_path, "r") as f:
             for line in f.readlines():
                 key, value = line.strip().split("=", 1)


### PR DESCRIPTION
In monorepos it's possible to have multiple `.databricks` folders, while our extension will only put .env file in the root of the workspace.

In that case notebook bootstrap code was trying (and failing) to loading `.env` file from the first `.databricks` folder.

This change makes sure we load the `.env` file from the first folder that actually has it.


