### PR TITLE
Fix CLI output parsing

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -52,7 +52,7 @@ def logErrorAndContinue(f):
 def load_env_from_leaf(path: str) -> bool:
     curdir = path if os.path.isdir(path) else os.path.dirname(path)
     env_file_path = os.path.join(curdir, ".databricks", ".databricks.env")
-    if os.path.exists(os.path.dirname(env_file_path)):
+    if os.path.exists(env_file_path):
         with open(env_file_path, "r") as f:
             for line in f.readlines():
                 key, value = line.strip().split("=", 1)

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -61,7 +61,7 @@ export class ProcessError extends Error {
     }
 }
 
-async function waitForProcess(
+export async function waitForProcess(
     p: ChildProcessWithoutNullStreams,
     onStdOut?: (data: string) => void,
     onStdError?: (data: string) => void
@@ -87,13 +87,13 @@ async function waitForProcess(
             if (code === 0) {
                 resolve();
             } else {
-                reject(new ProcessError(stderr.join("\n"), code));
+                reject(new ProcessError(stderr.join(""), code));
             }
         });
         p.on("error", (e) => new ProcessError(e.message, null));
     });
 
-    return {stdout: stdout.join("\n"), stderr: stderr.join("\n")};
+    return {stdout: stdout.join(""), stderr: stderr.join("")};
 }
 
 async function runBundleCommand(


### PR DESCRIPTION
Main change: `bundle summary` and `bundle validate` were failing for dabs project with many resources. CLI process outputs json in multiple chunks if it's too big, and we were joining them with `\n` control char, breaking json parsing. Confirmed that the output is still properly separated into new lines for non json output (since new lines are embedded in the process output in that case).

Second fix is porting this PR to the bundle-integ branch: https://github.com/databricks/databricks-vscode/pull/1266
