### PR TITLE
Bring back sync functionality

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -327,21 +327,21 @@
                 "command": "databricks.sync.start",
                 "title": "Start synchronization",
                 "category": "Databricks",
-                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet && databricks.context.bundle.isDevTarget",
                 "icon": "$(sync)"
             },
             {
                 "command": "databricks.sync.startFull",
                 "title": "Start synchronization (full sync)",
                 "category": "Databricks",
-                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet && databricks.context.bundle.isDevTarget",
                 "icon": "$(sync)"
             },
             {
                 "command": "databricks.sync.stop",
                 "title": "Stop synchronization",
                 "category": "Databricks",
-                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet && databricks.context.bundle.isDevTarget",
                 "icon": "$(sync-ignored)"
             }
         ],
@@ -562,12 +562,12 @@
                 },
                 {
                     "command": "databricks.sync.start",
-                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-stopped.*$/",
+                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-stopped.*$/ && databricks.context.bundle.isDevTarget",
                     "group": "inline@0"
                 },
                 {
                     "command": "databricks.sync.stop",
-                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-running.*$/",
+                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-running.*$/ && databricks.context.bundle.isDevTarget",
                     "group": "inline@0"
                 }
             ],

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -322,6 +322,27 @@
                 "title": "Force destroy bundle",
                 "category": "Databricks",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle"
+            },
+            {
+                "command": "databricks.sync.start",
+                "title": "Start synchronization",
+                "category": "Databricks",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "icon": "$(sync)"
+            },
+            {
+                "command": "databricks.sync.startFull",
+                "title": "Start synchronization (full sync)",
+                "category": "Databricks",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "icon": "$(sync)"
+            },
+            {
+                "command": "databricks.sync.stop",
+                "title": "Stop synchronization",
+                "category": "Databricks",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && databricks.context.bundle.isTargetSet",
+                "icon": "$(sync-ignored)"
             }
         ],
         "viewsContainers": {
@@ -538,6 +559,16 @@
                     "when": "view == configurationView && viewItem =~ /^databricks.environment.checkEnvironmentDependencies.success$/",
                     "group": "inline@0",
                     "icon": "$(gear)"
+                },
+                {
+                    "command": "databricks.sync.start",
+                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-stopped.*$/",
+                    "group": "inline@0"
+                },
+                {
+                    "command": "databricks.sync.stop",
+                    "when": "view == configurationView && viewItem =~ /^databricks.*sync.*is-running.*$/",
+                    "group": "inline@0"
                 }
             ],
             "editor/title": [

--- a/packages/databricks-vscode/src/cli/DatabricksCliSyncParser.ts
+++ b/packages/databricks-vscode/src/cli/DatabricksCliSyncParser.ts
@@ -1,0 +1,150 @@
+import {logging} from "@databricks/databricks-sdk";
+import {EventEmitter} from "vscode";
+import {Loggers} from "../logger";
+import {SyncState} from "../sync";
+
+type EventBase = {
+    timestamp: string;
+    seq: number;
+    type: string;
+};
+
+type EventChanges = {
+    put: Array<string>;
+    delete: Array<string>;
+};
+
+type EventStart = EventBase &
+    EventChanges & {
+        type: "start";
+    };
+
+type EventComplete = EventBase &
+    EventChanges & {
+        type: "complete";
+    };
+
+type EventProgress = EventBase & {
+    type: "progress";
+
+    action: "put" | "delete";
+    path: string;
+    progress: number;
+};
+
+type Event = EventStart | EventComplete | EventProgress;
+
+export class DatabricksCliSyncParser {
+    private state: SyncState = "STOPPED";
+
+    constructor(
+        private syncStateCallback: (state: SyncState, reason?: string) => void,
+        private writeEmitter: EventEmitter<string>
+    ) {}
+
+    private changeSize(ec: EventChanges): number {
+        let size = 0;
+        if (ec.put) {
+            size += ec.put.length;
+        }
+        if (ec.delete) {
+            size += ec.delete.length;
+        }
+        return size;
+    }
+
+    private processLine(line: string) {
+        const event = JSON.parse(line) as Event;
+        switch (event.type) {
+            case "start": {
+                this.state = "IN_PROGRESS";
+                this.writeEmitter.fire(
+                    "Starting synchronization (" +
+                        this.changeSize(event) +
+                        " files)\r\n"
+                );
+                break;
+            }
+            case "progress": {
+                let action = "";
+                switch (event.action) {
+                    case "put":
+                        action = "Uploaded";
+                        break;
+                    case "delete":
+                        action = "Deleted";
+                        break;
+                }
+                if (event.progress === 1.0) {
+                    this.writeEmitter.fire(action + " " + event.path + "\r\n");
+                }
+                break;
+            }
+            case "complete":
+                this.state = "WATCHING_FOR_CHANGES";
+                this.writeEmitter.fire("Completed synchronization\r\n");
+                break;
+        }
+    }
+
+    public processStderr(data: string) {
+        const logLines = data.split("\n");
+        for (let i = 0; i < logLines.length; i++) {
+            const line = logLines[i].trim();
+            if (line.length === 0) {
+                continue;
+            }
+            this.writeEmitter.fire(line.trim() + "\r\n");
+            if (this.matchForErrors(line)) {
+                return;
+            }
+        }
+    }
+
+    private matchForErrors(line: string) {
+        if (line.match(/^Error: .*Files in Workspace is disabled.*/) !== null) {
+            this.syncStateCallback("FILES_IN_WORKSPACE_DISABLED");
+            return true;
+        }
+
+        if (line.match(/^Error: .*Files in Repos is disabled.*/) !== null) {
+            this.syncStateCallback("FILES_IN_REPOS_DISABLED");
+            return true;
+        }
+
+        const match = line.match(/^Error: (.*)/);
+        if (match !== null) {
+            this.syncStateCallback("ERROR", match[1]);
+            return true;
+        }
+
+        return false;
+    }
+
+    // This function processes the JSON output from databricks sync and parses it
+    // to figure out if a synchronization step is in progress or has completed.
+    public processStdout(data: string) {
+        const logLines = data.split("\n");
+        for (let i = 0; i < logLines.length; i++) {
+            const line = logLines[i].trim();
+            if (line.length === 0) {
+                continue;
+            }
+
+            try {
+                this.processLine(line);
+            } catch (error: any) {
+                logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                    "Error parsing JSON line from databricks sync stdout: " +
+                        error
+                );
+            }
+
+            if (this.matchForErrors(line)) {
+                return;
+            }
+        }
+
+        this.syncStateCallback(this.state);
+    }
+}

--- a/packages/databricks-vscode/src/cli/SyncParser.test.ts
+++ b/packages/databricks-vscode/src/cli/SyncParser.test.ts
@@ -1,0 +1,87 @@
+import "@databricks/databricks-sdk";
+import assert from "assert";
+import {mock, instance, capture, reset} from "ts-mockito";
+import {EventEmitter} from "vscode";
+import {SyncState} from "../sync";
+import {DatabricksCliSyncParser} from "./DatabricksCliSyncParser";
+
+describe("tests for SycnParser", () => {
+    let syncState: SyncState = "STOPPED";
+    let mockedOutput: EventEmitter<string>;
+    let databricksSyncParser: DatabricksCliSyncParser;
+
+    const syncStateCallback = (state: SyncState) => {
+        syncState = state;
+    };
+
+    beforeEach(() => {
+        syncState = "STOPPED";
+        mockedOutput = mock(EventEmitter<string>);
+        databricksSyncParser = new DatabricksCliSyncParser(
+            syncStateCallback,
+            instance(mockedOutput)
+        );
+    });
+
+    it("ignores empty lines", () => {
+        assert.equal(syncState, "STOPPED");
+        databricksSyncParser.processStdout("\n\n");
+        assert.equal(syncState, "STOPPED");
+    });
+
+    it("ignores non-JSON lines", () => {
+        assert.equal(syncState, "STOPPED");
+        databricksSyncParser.processStdout("foo\nbar\n");
+        assert.equal(syncState, "STOPPED");
+    });
+
+    it("transitions from STOPPED -> IN_PROGRESS -> WATCHING_FOR_CHANGES", () => {
+        assert.equal(syncState, "STOPPED");
+        databricksSyncParser.processStdout(`{"type": "start"}`);
+        assert.equal(syncState, "IN_PROGRESS");
+        databricksSyncParser.processStdout(`{"type": "complete"}`);
+        assert.equal(syncState, "WATCHING_FOR_CHANGES");
+    });
+
+    it("writes start events to the terminal", () => {
+        databricksSyncParser.processStdout(
+            `{"type": "start", "put": ["hello"], "delete": ["world"]}`
+        );
+        const arg = capture(mockedOutput.fire).first();
+        assert.match(arg[0], /^Starting synchronization /);
+    });
+
+    it("writes progress events to the terminal", () => {
+        databricksSyncParser.processStdout(
+            `{"type": "progress", "action": "put", "path": "hello", "progress": 0.0}`
+        );
+        databricksSyncParser.processStdout(
+            `{"type": "progress", "action": "put", "path": "hello", "progress": 1.0}`
+        );
+        assert.match(
+            capture(mockedOutput.fire).first()[0],
+            /^Uploaded hello\r\n/
+        );
+        reset(mockedOutput);
+
+        databricksSyncParser.processStdout(
+            `{"type": "progress", "action": "delete", "path": "hello", "progress": 0.0}`
+        );
+        databricksSyncParser.processStdout(
+            `{"type": "progress", "action": "delete", "path": "hello", "progress": 1.0}`
+        );
+        assert.match(
+            capture(mockedOutput.fire).first()[0],
+            /^Deleted hello\r\n/
+        );
+        reset(mockedOutput);
+    });
+
+    it("writes complete events to the terminal", () => {
+        databricksSyncParser.processStdout(
+            `{"type": "complete", "put": ["hello"], "delete": ["world"]}`
+        );
+        const arg = capture(mockedOutput.fire).first();
+        assert.match(arg[0], /^Completed synchronization\r\n/);
+    });
+});

--- a/packages/databricks-vscode/src/cli/SyncTasks.test.ts
+++ b/packages/databricks-vscode/src/cli/SyncTasks.test.ts
@@ -1,0 +1,148 @@
+import "@databricks/databricks-sdk";
+import * as assert from "assert";
+import {instance, mock, when} from "ts-mockito";
+import {Uri} from "vscode";
+import {ProfileAuthProvider} from "../configuration/auth/AuthProvider";
+import type {ConnectionManager} from "../configuration/ConnectionManager";
+import {DatabricksWorkspace} from "../configuration/DatabricksWorkspace";
+import {LocalUri, SyncDestinationMapper} from "../sync/SyncDestination";
+import {PackageMetaData} from "../utils/packageJsonUtils";
+import {LazyCustomSyncTerminal, SyncTask} from "./SyncTasks";
+import type {CliWrapper} from "./CliWrapper";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+
+describe(__filename, () => {
+    let connection: ConnectionManager;
+    let cli: CliWrapper;
+
+    beforeEach(() => {
+        connection = mock<ConnectionManager>();
+        when(connection.metadataServiceUrl).thenReturn("http://localhost:1234");
+        cli = mock<CliWrapper>();
+    });
+
+    it("should create a sync task", () => {
+        const task = new SyncTask(
+            instance(connection),
+            instance(mock<ConfigModel>()),
+            instance(cli),
+            "incremental",
+            {
+                version: "1.0.0",
+            } as PackageMetaData,
+            () => {}
+        );
+
+        assert.equal(task.definition.type, "databricks");
+        assert.equal(task.definition.task, "sync");
+        assert.equal(task.isBackground, true);
+        assert.deepEqual(task.problemMatchers, ["$databricks-sync"]);
+    });
+
+    describe("pseudo terminal", () => {
+        let env: NodeJS.ProcessEnv;
+
+        beforeEach(() => {
+            // Save environment.
+            env = process.env;
+
+            // Create copy so it is safe to mutate it in tests.
+            process.env = {
+                ...env,
+            };
+        });
+
+        afterEach(() => {
+            // Restore original environment.
+            process.env = env;
+        });
+
+        let terminal: LazyCustomSyncTerminal;
+
+        beforeEach(() => {
+            const mockDbWorkspace = mock(DatabricksWorkspace);
+            when(mockDbWorkspace.authProvider).thenReturn(
+                new ProfileAuthProvider(
+                    new URL("https://000000000000.00.azuredatabricks.net/"),
+                    "profile",
+                    instance(cli)
+                )
+            );
+            when(mockDbWorkspace.host).thenReturn(
+                new URL("https://000000000000.00.azuredatabricks.net/")
+            );
+
+            const mockSyncDestination = mock(SyncDestinationMapper);
+            when(mockSyncDestination.localUri).thenReturn(
+                new LocalUri(Uri.file("/path/to/local/workspace"))
+            );
+
+            when(connection.databricksWorkspace).thenReturn(
+                instance(mockDbWorkspace)
+            );
+
+            when(connection.syncDestinationMapper).thenReturn(
+                instance(mockSyncDestination)
+            );
+
+            const mockConfigModel = mock(ConfigModel);
+            when(mockConfigModel.target).thenReturn("dev");
+            terminal = new LazyCustomSyncTerminal(
+                instance(connection),
+                instance(mockConfigModel),
+                instance(cli),
+                "full",
+                {
+                    version: "1.0.0",
+                } as PackageMetaData,
+                () => {}
+            );
+        });
+
+        it("should receive correct environment variables", () => {
+            delete process.env["HTTP_PROXY"];
+            delete process.env["HTTPS_PROXY"];
+
+            assert.deepEqual(terminal.getProcessOptions(), {
+                cwd: Uri.file("/path/to/local/workspace").fsPath,
+                env: {
+                    /* eslint-disable @typescript-eslint/naming-convention */
+                    DATABRICKS_CLI_UPSTREAM: "databricks-vscode",
+                    DATABRICKS_CLI_UPSTREAM_VERSION: "1.0.0",
+                    DATABRICKS_BUNDLE_TARGET: "dev",
+                    DATABRICKS_HOST:
+                        "https://000000000000.00.azuredatabricks.net/",
+                    DATABRICKS_AUTH_TYPE: "metadata-service",
+                    DATABRICKS_METADATA_SERVICE_URL: "http://localhost:1234",
+                    HOME: process.env.HOME,
+                    PATH: process.env.PATH,
+                    /* eslint-enable @typescript-eslint/naming-convention */
+                },
+            });
+        });
+
+        it("should pass through proxy variables if set", () => {
+            process.env.HTTP_PROXY = "http_proxy";
+            process.env.HTTPS_PROXY = "https_proxy";
+
+            assert.deepEqual(terminal.getProcessOptions(), {
+                cwd: Uri.file("/path/to/local/workspace").fsPath,
+                env: {
+                    /* eslint-disable @typescript-eslint/naming-convention */
+                    DATABRICKS_CLI_UPSTREAM: "databricks-vscode",
+                    DATABRICKS_CLI_UPSTREAM_VERSION: "1.0.0",
+                    DATABRICKS_BUNDLE_TARGET: "dev",
+                    DATABRICKS_HOST:
+                        "https://000000000000.00.azuredatabricks.net/",
+                    DATABRICKS_AUTH_TYPE: "metadata-service",
+                    DATABRICKS_METADATA_SERVICE_URL: "http://localhost:1234",
+                    HOME: process.env.HOME,
+                    PATH: process.env.PATH,
+                    HTTP_PROXY: "http_proxy",
+                    HTTPS_PROXY: "https_proxy",
+                    /* eslint-enable @typescript-eslint/naming-convention */
+                },
+            });
+        });
+    });
+});

--- a/packages/databricks-vscode/src/cli/SyncTasks.ts
+++ b/packages/databricks-vscode/src/cli/SyncTasks.ts
@@ -1,0 +1,332 @@
+import {
+    CustomExecution,
+    Pseudoterminal,
+    Task,
+    TaskGroup,
+    TaskRevealKind,
+    TaskScope,
+    window,
+    Event,
+    EventEmitter,
+} from "vscode";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {CliWrapper, Command, SyncType} from "./CliWrapper";
+import {ChildProcess, spawn, SpawnOptions} from "node:child_process";
+import {SyncState} from "../sync/CodeSynchronizer";
+import {DatabricksCliSyncParser} from "./DatabricksCliSyncParser";
+import {logging} from "@databricks/databricks-sdk";
+import {Loggers} from "../logger";
+import {Context, context} from "@databricks/databricks-sdk/dist/context";
+import {PackageMetaData} from "../utils/packageJsonUtils";
+import {RWLock} from "../locking";
+import {EnvVarGenerators} from "../utils";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+
+const {withLogContext} = logging;
+
+export const TASK_SYNC_TYPE = {
+    syncFull: "sync-full",
+    sync: "sync",
+} as const;
+
+type TaskSyncType = (typeof TASK_SYNC_TYPE)[keyof typeof TASK_SYNC_TYPE];
+
+const cliToTaskSyncType = new Map<SyncType, TaskSyncType>([
+    ["full", TASK_SYNC_TYPE.syncFull],
+    ["incremental", TASK_SYNC_TYPE.sync],
+]);
+
+export class SyncTask extends Task {
+    constructor(
+        connection: ConnectionManager,
+        configModel: ConfigModel,
+        cli: CliWrapper,
+        syncType: SyncType,
+        packageMetadata: PackageMetaData,
+        syncStateCallback: (state: SyncState) => void
+    ) {
+        super(
+            {
+                type: "databricks",
+                task: cliToTaskSyncType.get(syncType) ?? "sync",
+            },
+            TaskScope.Workspace,
+            cliToTaskSyncType.get(syncType) ?? "sync",
+            "databricks",
+            new CustomExecution(async (): Promise<Pseudoterminal> => {
+                return new LazyCustomSyncTerminal(
+                    connection,
+                    configModel,
+                    cli,
+                    syncType,
+                    packageMetadata,
+                    syncStateCallback
+                );
+            })
+        );
+
+        this.isBackground = true;
+        this.detail = "$(rocket) Databricks sync";
+        this.problemMatchers = ["$databricks-sync"];
+        this.presentationOptions.echo = true;
+        this.group = TaskGroup.Build;
+        this.presentationOptions.reveal = TaskRevealKind.Always;
+    }
+
+    static killAll() {
+        window.terminals.forEach((terminal) => {
+            if (
+                Object.values(TASK_SYNC_TYPE)
+                    .map((e) => e as string)
+                    .includes(terminal.name)
+            ) {
+                terminal.dispose();
+            }
+        });
+    }
+}
+
+class CustomSyncTerminal implements Pseudoterminal {
+    private writeEmitter = new EventEmitter<string>();
+    onDidWrite: Event<string> = this.writeEmitter.event;
+
+    private closeEmitter = new EventEmitter<void>();
+    onDidClose: Event<void> = this.closeEmitter.event;
+
+    private syncProcess: ChildProcess | undefined;
+    private databricksSyncParser: DatabricksCliSyncParser;
+    private state: SyncState = "STOPPED";
+    private syncStateCallback: (state: SyncState) => void;
+
+    constructor(
+        private cmd: string,
+        private args: string[],
+        private options: SpawnOptions,
+        syncStateCallback: (state: SyncState, reason?: string) => void
+    ) {
+        this.syncStateCallback = (state: SyncState, reason?: string) => {
+            if (
+                /*
+                We do NOT switch from FILES_IN_REPOS_DISABLED/FILES_IN_WORKSPACE_DISABLED
+                to ERROR/STOPPED. This is because sync process will always exit with non zero
+                exit code when Files in Repos/Workspace are disabled AFTER we have dectected it. 
+                
+                We also do NOT switch from STOPPED to ERROR, because the sync process could
+                exit with non zero exit code when force killed (eg. when killed from UI). This can
+                lead to a error state AFTER stopped state has been set.
+                */
+                ([
+                    "FILES_IN_REPOS_DISABLED",
+                    "FILES_IN_WORKSPACE_DISABLED",
+                ].includes(this.state) &&
+                    ["ERROR", "STOPPED"].includes(state)) ||
+                (this.state === "STOPPED" &&
+                    state === "ERROR" &&
+                    reason === undefined) ||
+                this.state === state
+            ) {
+                return;
+            }
+            this.state = state;
+            syncStateCallback(this.state, reason);
+        };
+        this.databricksSyncParser = new DatabricksCliSyncParser(
+            this.syncStateCallback,
+            this.writeEmitter
+        );
+    }
+
+    open(): void {
+        this.syncStateCallback("IN_PROGRESS");
+        try {
+            this.startSyncProcess();
+        } catch (e) {
+            window.showErrorMessage((e as Error).message);
+        }
+    }
+
+    close(): void {
+        this.syncProcess?.kill();
+        this.syncStateCallback("STOPPED");
+    }
+
+    private startSyncProcess() {
+        this.syncProcess = spawn(this.cmd, this.args, {
+            ...this.options,
+        });
+
+        // Log the sync command being run, its args and any env overrides done by
+        // vscode
+        this.writeEmitter.fire(
+            "[VSCODE] databricks cli path: " + this.cmd.toString()
+        );
+        this.writeEmitter.fire("\n\r");
+        this.writeEmitter.fire(
+            "[VSCODE] sync command args: " + this.args.toLocaleString()
+        );
+        this.writeEmitter.fire("\n\r");
+        this.writeEmitter.fire(
+            "--------------------------------------------------------"
+        );
+        this.writeEmitter.fire("\n\r");
+
+        if (!this.syncProcess) {
+            throw new Error(
+                "Can't start sync: sync process initialization failed"
+            );
+        }
+
+        if (!this.syncProcess.stderr) {
+            throw new Error(
+                "Can't start sync: can't pipe stderr of the sync process"
+            );
+        }
+
+        if (!this.syncProcess.stdout) {
+            throw new Error(
+                "Can't start sync: can't pipe stdout of the sync process"
+            );
+        }
+
+        //When sync fails (due to any reason including Files in Repos/Workspace being disabled),
+        //the sync process could emit "close" before all "data" messages have been done processing.
+        //This can lead to a unknown ERROR state for sync, when in reality the state is actually
+        //known (it is FILES_IN_REPOS_DISABLED/FILES_IN_WORKSPACE_DISABLED). We use a reader-writer
+        //lock to make sure all "data" events have been processd before progressing with "close".
+        const rwLock = new RWLock();
+        this.syncProcess.stderr.on("data", async (data) => {
+            await rwLock.readerEntry();
+            this.databricksSyncParser.processStderr(data.toString());
+            await rwLock.readerExit();
+        });
+
+        this.syncProcess.stdout.on("data", async (data) => {
+            await rwLock.readerEntry();
+            this.databricksSyncParser.processStdout(data.toString());
+            await rwLock.readerExit();
+        });
+
+        this.syncProcess.on("close", async (code) => {
+            await rwLock.writerEntry();
+            if (code !== 0) {
+                this.syncStateCallback("ERROR");
+                // terminate the vscode terminal task
+                this.closeEmitter.fire();
+            }
+            await rwLock.writerExit();
+        });
+    }
+}
+
+/**
+ * Wrapper around the CustomSyncTerminal class that lazily evaluates the process
+ * and args properties. This is necessary because the process and args properties
+ * are not known up front and can only be computed dynamically at runtime.
+ *
+ * A Custom implmentation of the terminal is needed to run databricks sync as a CustomExecution
+ * vscode task, which allows us to parse the stdout/stderr databricks sync logs and compute
+ * sync completeness state based on the output logs
+ */
+export class LazyCustomSyncTerminal extends CustomSyncTerminal {
+    private command?: Command;
+
+    constructor(
+        private connection: ConnectionManager,
+        private configModel: ConfigModel,
+        private cli: CliWrapper,
+        private syncType: SyncType,
+        private packageMetadata: PackageMetaData,
+        syncStateCallback: (state: SyncState) => void
+    ) {
+        super("", [], {}, syncStateCallback);
+
+        const ctx: Context = new Context({
+            rootClassName: "LazyCustomSyncTerminal",
+            rootFnName: "constructor",
+        });
+
+        // hacky way to override properties with getters
+        Object.defineProperties(this, {
+            cmd: {
+                get: () => {
+                    return this.getSyncCommand(ctx).command;
+                },
+            },
+            args: {
+                get: () => {
+                    return this.getSyncCommand(ctx).args;
+                },
+            },
+            options: {
+                get: () => {
+                    return this.getProcessOptions(ctx);
+                },
+            },
+        });
+    }
+
+    @withLogContext(Loggers.Extension)
+    showErrorAndKillThis(msg: string, @context ctx?: Context) {
+        ctx?.logger?.error(msg);
+        window.showErrorMessage(msg);
+        SyncTask.killAll();
+        return new Error(msg);
+    }
+
+    @withLogContext(Loggers.Extension)
+    getProcessOptions(@context ctx?: Context): SpawnOptions {
+        const workspacePath =
+            this.connection.syncDestinationMapper?.localUri.path;
+        if (!workspacePath) {
+            throw this.showErrorAndKillThis(
+                "Can't start sync: No workspace opened!",
+                ctx
+            );
+        }
+
+        const dbWorkspace = this.connection.databricksWorkspace;
+        if (!dbWorkspace) {
+            throw this.showErrorAndKillThis(
+                "Can't start sync: Databricks connection not configured!",
+                ctx
+            );
+        }
+
+        return {
+            cwd: workspacePath,
+            env: {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DATABRICKS_CLI_UPSTREAM: "databricks-vscode",
+                DATABRICKS_CLI_UPSTREAM_VERSION: this.packageMetadata.version,
+                HOME: process.env.HOME,
+                PATH: process.env.PATH,
+                ...EnvVarGenerators.removeUndefinedKeys(
+                    EnvVarGenerators.getCommonDatabricksEnvVars(
+                        this.connection,
+                        this.configModel
+                    )
+                ),
+                /* eslint-enable @typescript-eslint/naming-convention */
+            },
+        } as SpawnOptions;
+    }
+
+    @withLogContext(Loggers.Extension)
+    getSyncCommand(@context ctx?: Context): Command {
+        if (this.command) {
+            return this.command;
+        }
+        const syncDestination = this.connection.syncDestinationMapper;
+
+        if (!syncDestination) {
+            throw this.showErrorAndKillThis(
+                "Can't start sync: Databricks synchronization destination not configured!",
+                ctx
+            );
+        }
+
+        this.command = this.cli.getSyncCommand(syncDestination, this.syncType);
+
+        return this.command;
+    }
+}

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -147,6 +147,11 @@ export class ConfigModel implements Disposable {
             ),
             this.bundleRemoteStateModel.onDidChange(async () => {
                 await this.configCache.refresh();
+            }),
+            this.onDidChangeKey("mode")(async () => {
+                this.vscodeWhenContext.isDevTarget(
+                    (await this.configCache.value).mode === "development"
+                );
             })
         );
     }
@@ -154,13 +159,6 @@ export class ConfigModel implements Disposable {
     @onError({popup: true})
     public async init() {
         await this.readTarget();
-        this.disposables.push(
-            this.onDidChangeKey("mode")(async () => {
-                this.vscodeWhenContext.isDevTarget(
-                    (await this.configCache.value).mode === "development"
-                );
-            })
-        );
     }
 
     get targets() {

--- a/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/ConfigModel.ts
@@ -154,6 +154,13 @@ export class ConfigModel implements Disposable {
     @onError({popup: true})
     public async init() {
         await this.readTarget();
+        this.disposables.push(
+            this.onDidChangeKey("mode")(async () => {
+                this.vscodeWhenContext.isDevTarget(
+                    (await this.configCache.value).mode === "development"
+                );
+            })
+        );
     }
 
     get targets() {

--- a/packages/databricks-vscode/src/sync/CodeSynchronizer.ts
+++ b/packages/databricks-vscode/src/sync/CodeSynchronizer.ts
@@ -118,28 +118,4 @@ export class CodeSynchronizer implements Disposable {
             this.state === "WATCHING_FOR_CHANGES"
         );
     }
-    // This function waits for sync to reach WATCHING_FOR_CHANGES which is a
-    // necessary condition to execute local code on databricks. This state denotes
-    // all local changes have been synced to remote workspace
-    async waitForSyncComplete(): Promise<void> {
-        if (this._state !== "WATCHING_FOR_CHANGES") {
-            return await new Promise((resolve) => {
-                const changeListener = this.onDidChangeState(() => {
-                    if (
-                        [
-                            "WATCHING_FOR_CHANGES",
-                            "FILES_IN_REPOS_DISABLED",
-                            "FILES_IN_WORKSPACE_DISABLED",
-                            "ERROR",
-                        ].includes(this.state)
-                    ) {
-                        changeListener.dispose();
-                        resolve();
-                    }
-                }, this);
-
-                this.disposables.push(changeListener);
-            });
-        }
-    }
 }

--- a/packages/databricks-vscode/src/sync/CodeSynchronizer.ts
+++ b/packages/databricks-vscode/src/sync/CodeSynchronizer.ts
@@ -1,0 +1,145 @@
+import {Disposable, Event, EventEmitter, TaskExecution, tasks} from "vscode";
+import {SyncTask, TASK_SYNC_TYPE} from "../cli/SyncTasks";
+import {CliWrapper} from "../cli/CliWrapper";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {PackageMetaData} from "../utils/packageJsonUtils";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+
+export type SyncState =
+    | "IN_PROGRESS"
+    | "WATCHING_FOR_CHANGES"
+    | "STOPPED"
+    | "FILES_IN_REPOS_DISABLED"
+    | "FILES_IN_WORKSPACE_DISABLED"
+    | "ERROR";
+
+export class CodeSynchronizer implements Disposable {
+    private _onDidChangeStateEmitter: EventEmitter<SyncState> =
+        new EventEmitter<SyncState>();
+    readonly onDidChangeState: Event<SyncState> =
+        this._onDidChangeStateEmitter.event;
+
+    // This state is updated from inside the SyncTask based on logs recieved from
+    // databricks sync stderr. Closing the SyncTask transitions the state back to
+    // stopped
+    private _state: SyncState = "STOPPED";
+    //The ERROR state represents an untyped error, so we use this to store the
+    // reason for the error, which is displayed to the user.
+    private _reason?: string;
+
+    disposables: Array<Disposable> = [];
+    currentTaskExecution?: TaskExecution;
+
+    constructor(
+        private connection: ConnectionManager,
+        private readonly configModel: ConfigModel,
+        private cli: CliWrapper,
+        private packageMetadata: PackageMetaData
+    ) {
+        this.disposables.push(
+            this.connection.onDidChangeState(() => {
+                this.stop();
+            }),
+            this.connection.onDidChangeSyncDestination(() => {
+                this.stop();
+            }),
+            tasks.onDidStartTask((e) => {
+                const {type, task} = e.execution.task.definition;
+                if (
+                    type === "databricks" &&
+                    Object.values(TASK_SYNC_TYPE).includes(task)
+                ) {
+                    this.currentTaskExecution = e.execution;
+                    this._onDidChangeStateEmitter.fire(this.state);
+                }
+            }),
+            tasks.onDidEndTask((e) => {
+                const {type, task} = e.execution.task.definition;
+                if (
+                    type === "databricks" &&
+                    Object.values(TASK_SYNC_TYPE).includes(task)
+                ) {
+                    this.currentTaskExecution = undefined;
+                    this._onDidChangeStateEmitter.fire(this.state);
+                }
+            })
+        );
+    }
+
+    get state(): SyncState {
+        return this._state;
+    }
+
+    get reason(): string | undefined {
+        return this._reason;
+    }
+
+    async start(syncType: "full" | "incremental") {
+        this._state = "IN_PROGRESS";
+        this._onDidChangeStateEmitter.fire(this._state);
+        const task = new SyncTask(
+            this.connection,
+            this.configModel,
+            this.cli,
+            syncType,
+            this.packageMetadata,
+            (state: SyncState, reason?: string) => {
+                this._state = state;
+                this._reason = reason;
+                this._onDidChangeStateEmitter.fire(state);
+                if (
+                    [
+                        "ERROR",
+                        "FILES_IN_REPOS_DISABLED",
+                        "FILES_IN_WORKSPACE_DISABLED",
+                    ].includes(state)
+                ) {
+                    this.stop();
+                }
+            }
+        );
+        await tasks.executeTask(task);
+    }
+
+    stop() {
+        if (this.currentTaskExecution) {
+            this.currentTaskExecution.terminate();
+        }
+    }
+
+    dispose() {
+        this.stop();
+        this.disposables.forEach((d) => d.dispose());
+    }
+
+    get isRunning() {
+        return (
+            this.state === "IN_PROGRESS" ||
+            this.state === "WATCHING_FOR_CHANGES"
+        );
+    }
+    // This function waits for sync to reach WATCHING_FOR_CHANGES which is a
+    // necessary condition to execute local code on databricks. This state denotes
+    // all local changes have been synced to remote workspace
+    async waitForSyncComplete(): Promise<void> {
+        if (this._state !== "WATCHING_FOR_CHANGES") {
+            return await new Promise((resolve) => {
+                const changeListener = this.onDidChangeState(() => {
+                    if (
+                        [
+                            "WATCHING_FOR_CHANGES",
+                            "FILES_IN_REPOS_DISABLED",
+                            "FILES_IN_WORKSPACE_DISABLED",
+                            "ERROR",
+                        ].includes(this.state)
+                    ) {
+                        changeListener.dispose();
+                        resolve();
+                    }
+                }, this);
+
+                this.disposables.push(changeListener);
+            });
+        }
+    }
+}

--- a/packages/databricks-vscode/src/sync/SyncCommands.ts
+++ b/packages/databricks-vscode/src/sync/SyncCommands.ts
@@ -1,0 +1,18 @@
+import {SyncType} from "../cli/CliWrapper";
+import {CodeSynchronizer} from "./CodeSynchronizer";
+
+export class SyncCommands {
+    constructor(private sync: CodeSynchronizer) {}
+
+    stopCommand() {
+        return () => {
+            this.sync.stop();
+        };
+    }
+
+    startCommand(syncType: SyncType) {
+        return async () => {
+            await this.sync.start(syncType);
+        };
+    }
+}

--- a/packages/databricks-vscode/src/sync/index.ts
+++ b/packages/databricks-vscode/src/sync/index.ts
@@ -1,0 +1,1 @@
+export * from "./CodeSynchronizer";

--- a/packages/databricks-vscode/src/test/e2e/sync.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/sync.e2e.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert";
+import {
+    dismissNotifications,
+    getUniqueResourceName,
+    getViewSection,
+    waitForLogin,
+    waitForSyncComplete,
+} from "./utils/commonUtils.ts";
+import {
+    getBasicBundleConfig,
+    writeRootBundleConfig,
+} from "./utils/dabsFixtures.ts";
+import path from "node:path";
+import fs from "fs/promises";
+import {BundleSchema} from "../../bundle/types.ts";
+import {WorkspaceClient} from "@databricks/databricks-sdk";
+
+describe("Sync", async function () {
+    let vscodeWorkspaceRoot: string;
+    let workspaceClient: WorkspaceClient;
+    let projectName: string;
+
+    this.timeout(3 * 60 * 1000);
+
+    async function createProject() {
+        /**
+         * process.env.WORKSPACE_PATH (cwd)
+         *  ├── databricks.yml
+         *  └── src
+         *    └── notebook.py
+         */
+
+        projectName = getUniqueResourceName("sync");
+        /* eslint-disable @typescript-eslint/naming-convention */
+
+        const schemaDef: BundleSchema = getBasicBundleConfig({
+            bundle: {
+                name: projectName,
+                deployment: {},
+            },
+            targets: {
+                dev_test: {
+                    default: true,
+                    mode: "development",
+                    workspace: {
+                        root_path:
+                            "/Users/${workspace.current_user.userName}/vscode-integration-test/${bundle.name}",
+                    },
+                },
+            },
+        });
+        /* eslint-enable @typescript-eslint/naming-convention */
+
+        await writeRootBundleConfig(schemaDef, vscodeWorkspaceRoot);
+
+        await fs.mkdir(path.join(vscodeWorkspaceRoot, "src"), {
+            recursive: true,
+        });
+    }
+
+    before(async function () {
+        assert(
+            process.env.WORKSPACE_PATH,
+            "WORKSPACE_PATH env var doesn't exist"
+        );
+        assert(
+            process.env.DATABRICKS_HOST,
+            "DATABRICKS_HOST env var doesn't exist"
+        );
+        assert(
+            process.env.DATABRICKS_TOKEN,
+            "DATABRICKS_TOKEN env var doesn't exist"
+        );
+
+        vscodeWorkspaceRoot = process.env.WORKSPACE_PATH;
+        workspaceClient = new WorkspaceClient({
+            host: process.env.DATABRICKS_HOST,
+            token: process.env.DATABRICKS_TOKEN,
+        });
+        await createProject();
+        await dismissNotifications();
+    });
+
+    it("should wait for extension activation", async () => {
+        const section = await getViewSection("CONFIGURATION");
+        assert(section);
+    });
+
+    it("should wait for connection", async () => {
+        await waitForLogin("DEFAULT");
+        await dismissNotifications();
+    });
+
+    it("should sync files", async () => {
+        await browser.executeWorkbench((vscode) => {
+            vscode.commands.executeCommand("databricks.sync.start");
+        });
+
+        const notebookContent = "print('original content')";
+        await fs.writeFile(
+            path.join(vscodeWorkspaceRoot, "src", "notebook.py"),
+            notebookContent
+        );
+
+        await waitForSyncComplete();
+
+        const userName = (await workspaceClient.currentUser.me()).userName;
+        const workspacePath = `/Users/${userName}/vscode-integration-test/${projectName}/files/src/notebook.py`;
+        const file = await workspaceClient.workspace.export({
+            path: workspacePath,
+        });
+
+        assert(file.content);
+        assert.strictEqual(atob(file.content), notebookContent);
+    });
+
+    it("should watch for file changes and sync changed files", async () => {
+        const newNotebookContent = "print('Hello, World!')";
+        await fs.writeFile(
+            path.join(vscodeWorkspaceRoot, "src", "notebook.py"),
+            newNotebookContent
+        );
+
+        await browser.executeWorkbench((vscode) => {
+            vscode.commands.executeCommand("workbench.action.files.saveAll");
+        });
+
+        await waitForSyncComplete();
+
+        const userName = (await workspaceClient.currentUser.me()).userName;
+        const workspacePath = `/Users/${userName}/vscode-integration-test/${projectName}/files/src/notebook.py`;
+        const file = await workspaceClient.workspace.export({
+            path: workspacePath,
+        });
+
+        assert(file.content);
+        assert.strictEqual(atob(file.content), newNotebookContent);
+    });
+});

--- a/packages/databricks-vscode/src/ui/configuration-view/ClusterComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/ClusterComponent.ts
@@ -101,7 +101,7 @@ export class ClusterComponent extends BaseComponent {
             return [
                 {
                     label: LabelUtils.highlightedLabel("Select a cluster"),
-                    collapsibleState: TreeItemCollapsibleState.Expanded,
+                    collapsibleState: TreeItemCollapsibleState.None,
                     contextValue: getContextValue("none"),
                     iconPath: new ThemeIcon(
                         "server",
@@ -135,7 +135,7 @@ export class ClusterComponent extends BaseComponent {
                 label: "Cluster",
                 tooltip: url ? undefined : "Created after deploy",
                 description: cluster.name,
-                collapsibleState: TreeItemCollapsibleState.Expanded,
+                collapsibleState: TreeItemCollapsibleState.Collapsed,
                 contextValue: url ? `${contextValue}.has-url` : contextValue,
                 resourceUri: url
                     ? undefined

--- a/packages/databricks-vscode/src/ui/configuration-view/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/ConfigurationDataProvider.ts
@@ -22,6 +22,7 @@ import {FeatureManager} from "../../feature-manager/FeatureManager";
 import {EnvironmentComponent} from "./EnvironmentComponent";
 import {WorkspaceFolderComponent} from "./WorkspaceFolderComponent";
 import {WorkspaceFolderManager} from "../../vscode-objs/WorkspaceFolderManager";
+import {CodeSynchronizer} from "../../sync";
 
 /**
  * Data provider for the cluster tree view
@@ -50,7 +51,11 @@ export class ConfigurationDataProvider
             this.cli
         ),
         new ClusterComponent(this.connectionManager, this.configModel),
-        new SyncDestinationComponent(this.connectionManager, this.configModel),
+        new SyncDestinationComponent(
+            this.connectionManager,
+            this.configModel,
+            this.codeSynchronizer
+        ),
         new EnvironmentComponent(
             this.featureManager,
             this.connectionManager,
@@ -59,6 +64,7 @@ export class ConfigurationDataProvider
     ];
     constructor(
         private readonly connectionManager: ConnectionManager,
+        private readonly codeSynchronizer: CodeSynchronizer,
         private readonly bundleProjectManager: BundleProjectManager,
         private readonly configModel: ConfigModel,
         private readonly cli: CliWrapper,

--- a/packages/databricks-vscode/src/ui/configuration-view/SyncDestinationComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/SyncDestinationComponent.ts
@@ -75,7 +75,7 @@ export class SyncDestinationComponent extends BaseComponent {
     }
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
         const workspaceFsPath = await this.configModel.get("remoteRootPath");
-
+        const mode = await this.configModel.get("mode");
         if (workspaceFsPath === undefined) {
             return [];
         }
@@ -91,7 +91,12 @@ export class SyncDestinationComponent extends BaseComponent {
             {
                 label: "Workspace Folder",
                 tooltip: url ? undefined : "Created after deploy",
-                collapsibleState: TreeItemCollapsibleState.Collapsed,
+                description:
+                    mode === "development" ? undefined : workspaceFsPath,
+                collapsibleState:
+                    mode === "development"
+                        ? TreeItemCollapsibleState.Collapsed
+                        : TreeItemCollapsibleState.None,
                 contextValue,
                 iconPath: getIconForSyncState(this.codeSynchronizer),
                 resourceUri: url
@@ -117,7 +122,10 @@ export class SyncDestinationComponent extends BaseComponent {
             return this.getRoot();
         }
 
-        if (parent.id !== TREE_ICON_ID) {
+        if (
+            parent.id !== TREE_ICON_ID ||
+            (await this.configModel.get("mode")) !== "development"
+        ) {
             return [];
         }
 

--- a/packages/databricks-vscode/src/ui/configuration-view/SyncDestinationComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/SyncDestinationComponent.ts
@@ -62,6 +62,9 @@ export class SyncDestinationComponent extends BaseComponent {
             }),
             this.codeSynchronizer.onDidChangeState(() => {
                 this.onDidChangeEmitter.fire();
+            }),
+            this.configModel.onDidChangeKey("mode")(async () => {
+                this.onDidChangeEmitter.fire();
             })
         );
     }

--- a/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
+++ b/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
@@ -35,6 +35,14 @@ export class CustomWhenContext {
         );
     }
 
+    isDevTarget(value: boolean) {
+        commands.executeCommand(
+            "setContext",
+            "databricks.context.bundle.isDevTarget",
+            value
+        );
+    }
+
     setSubProjectsAvailable(value: boolean) {
         commands.executeCommand(
             "setContext",


### PR DESCRIPTION
## Changes
* Bring back sync functionality. Users can choose to manually start sync from the UI and not rely on deploy before file runs. This avoids breaking some existing user flows. 
* The files are still run only after a deploy.
* There is possibility of race conditions between sync and deploy but the possibility is very small. Also, syncing is blocked for prod and staging targets. 
 
## Tests
<!-- How is this tested? -->

