### PR TITLE
Fix Cluster Selector

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -130,7 +130,8 @@ export class ConnectionCommands implements Disposable {
             const quickPick = window.createQuickPick<
                 ClusterItem | QuickPickItem
             >();
-            quickPick.title = title;
+            quickPick.title =
+                typeof title === "string" ? title : "Select Cluster";
             quickPick.keepScrollPosition = true;
             quickPick.busy = true;
 

--- a/packages/databricks-vscode/src/sdk-extensions/Cluster.ts
+++ b/packages/databricks-vscode/src/sdk-extensions/Cluster.ts
@@ -173,16 +173,16 @@ export class Cluster {
             ));
         }
 
-        const permissionApi = new iam.PermissionsService(this.client);
-        const perms = await permissionApi.get({
-            request_object_id: this.id,
-            request_object_type: "clusters",
+        const perms = await this.clusterApi.getPermissions({
+            cluster_id: this.id,
         });
-
         return (this._hasExecutePerms =
             (perms.access_control_list ?? []).find((ac) => {
                 return (
                     ac.user_name === userDetails.userName ||
+                    // `users` is a system group for "All Workspace Users"
+                    // https://docs.databricks.com/en/admin/users-groups/groups.html
+                    ac.group_name === "users" ||
                     userDetails.groups
                         ?.map((v) => v.display)
                         .includes(ac.group_name ?? "")


### PR DESCRIPTION
## Changes
- Show proper title when the selector is invoked from the tree view
- Fix the permission detection

iam API errors out on all the clusters for which a users doesn't have CAN_MANAGE permission. ClustersAPI works better in that regard and returns correct acl info.

Also add `users` to the groups check, which refers to "All Workspace Users".

## Tests
<!-- How is this tested? -->

