### PR TITLE
Use Info log level for the CLI stderr

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -170,7 +170,7 @@ async function runBundleCommand(
             logger?.info(data, {bundleOpName});
         },
         onStdError: (data: string) => {
-            logger?.warn(data, {bundleOpName});
+            logger?.info(data, {bundleOpName});
         },
     };
     const {onStdOut, onStdError} = {


### PR DESCRIPTION
## Changes
Stderr doesn't usually imply higher log level, at least in Databricks CLI


