### PR TITLE
Fix deployment tag and README links on Marketplace

### DIFF
--- a/packages/databricks-vscode/scripts/package-vsix.sh
+++ b/packages/databricks-vscode/scripts/package-vsix.sh
@@ -58,7 +58,7 @@ if [ $ARCH != "win32-arm64" ]; then
 fi
 
 yarn run prettier package.json --write
-TAG="release-v$(cat package.json | jq -r .version)" yarn run package -t $VSXI_ARCH
+TAG="release-v$(cat package.json | jq -r .version)-preview" yarn run package -t $VSXI_ARCH
 
 git checkout -- package.json
 


### PR DESCRIPTION
## Changes

`package` script uses TAG in this way:
```
vsce package --pre-release --baseContentUrl https://github.com/databricks/databricks-vscode/blob/${TAG:-bundle-integ}/packages/databricks-vscode --baseImagesUrl https://raw.githubusercontent.com/databricks/databricks-vscode/${TAG:-bundle-integ}/packages/databricks-vscode
```

When we set an incorrect tag, content and images urls point to wrong locations, breaking the readme in the vscode marketplace




