### PR TITLE
Add venv or conda to gitignore before deployments

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -640,7 +640,9 @@ export async function activate(
         bundleValidateModel,
         configModel,
         customWhenContext,
-        telemetry
+        telemetry,
+        workspaceFolderManager,
+        stateStorage
     );
     const decorationProvider = new TreeItemDecorationProvider(
         bundleResourceExplorerTreeDataProvider,

--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
@@ -26,6 +26,11 @@ const StorageConfigurations = {
         defaultValue: {},
     }),
 
+    "databricks.bundle.skipGitignoreCheck": withType<string[]>()({
+        location: "workspace",
+        defaultValue: [],
+    }),
+
     "databricks.wsfs.skipSwitchToWorkspace": withType<boolean>()({
         location: "workspace",
         defaultValue: false,


### PR DESCRIPTION
## Changes
This only covers top level .venv or .conda environments (the only two you can create with the python extension flow that we trigger).

We ask the user permission to do that, which can be permanently ignored for a specific project

## Tests
manually

