### PR TITLE
Try to get saved profile from the legacy config

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleFileSet.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.test.ts
@@ -113,8 +113,8 @@ describe(__filename, async function () {
                     path.join(tmpdirUri.fsPath, "includes", "included.yaml")
                 ),
             ].map((v) => v.fsPath);
-            expect(Array.from(new Set(actual).values())).to.deep.equal(
-                Array.from(new Set(expected).values())
+            expect(Array.from(new Set(actual).values()).sort()).to.deep.equal(
+                Array.from(new Set(expected).values()).sort()
             );
         });
 

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -50,7 +50,9 @@ function createCliWrapper(logFilePath?: string) {
     );
 }
 
-describe(__filename, () => {
+describe(__filename, function () {
+    this.timeout("10s");
+
     it("should embed a working databricks CLI", async () => {
         const result = await execFile(cliPath, ["--help"]);
         assert.ok(result.stdout.indexOf("databricks") > 0);

--- a/packages/databricks-vscode/src/file-managers/ProjectConfigFile.ts
+++ b/packages/databricks-vscode/src/file-managers/ProjectConfigFile.ts
@@ -53,16 +53,14 @@ export class ProjectConfigFile {
         return await ProfileAuthProvider.from(config.profile, cli);
     }
 
-    static async load(
-        rootPath: string,
-        cli: CliWrapper
-    ): Promise<ProjectConfigFile | undefined> {
+    static async loadConfig(
+        rootPath: string
+    ): Promise<Record<string, any> | undefined> {
         const projectConfigFilePath = path.join(
             path.normalize(rootPath),
             ".databricks",
             "project.json"
         );
-
         let rawConfig;
         try {
             rawConfig = await fs.readFile(projectConfigFilePath, {
@@ -75,9 +73,18 @@ export class ProjectConfigFile {
                 throw error;
             }
         }
+        return JSON.parse(rawConfig);
+    }
 
+    static async load(
+        rootPath: string,
+        cli: CliWrapper
+    ): Promise<ProjectConfigFile | undefined> {
+        const config = await ProjectConfigFile.loadConfig(rootPath);
+        if (!config) {
+            return undefined;
+        }
         let authProvider: AuthProvider;
-        const config = JSON.parse(rawConfig);
         if (!config.authType && config.profile) {
             authProvider = await this.importOldConfig(config, cli);
         } else {

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -18,6 +18,7 @@ export enum Events {
     MANUAL_MIGRATION = "manualMigration",
     BUNDLE_RUN = "bundleRun",
     BUNDLE_INIT = "bundleInit",
+    BUNDLE_SUB_PROJECTS = "bundleSubProjects",
     CONNECTION_STATE_CHANGED = "connectionStateChanged",
 }
 /* eslint-enable @typescript-eslint/naming-convention */
@@ -138,6 +139,14 @@ export class EventTypes {
         } & DurationMeasurement
     > = {
         comment: "Initialize a new bundle project",
+    };
+    [Events.BUNDLE_SUB_PROJECTS]: EventType<{
+        count: number;
+    }> = {
+        comment: "Sub-projects in the active workspace folder",
+        count: {
+            comment: "Amount of sub-projects in the active workspace folder",
+        },
     };
     [Events.CONNECTION_STATE_CHANGED]: EventType<{
         newState: string;


### PR DESCRIPTION
## Changes
V2 extension currently requires manual action from users if we detect multiple profiles that match the selected target. But in the V1 users might have already disambiguated the profiles, so here we use this inromation to get the saved profile.

## Tests
Manually

