### PR TITLE
Prevent welcome view flashes

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -387,6 +387,11 @@
         "viewsWelcome": [
             {
                 "view": "configurationView",
+                "contents": "Initializing...",
+                "when": "workspaceFolderCount > 0 && !databricks.context.initialized"
+            },
+            {
+                "view": "configurationView",
                 "contents": "There are multiple Databricks projects in the folder:\n[Open existing Databricks Project](command:databricks.bundle.openSubProject)",
                 "when": "workspaceFolderCount > 0 && databricks.context.initialized && databricks.context.subProjectsAvailable"
             },
@@ -398,12 +403,12 @@
             {
                 "view": "configurationView",
                 "contents": "[Create a new Databricks Project](command:databricks.bundle.initNewProject)",
-                "when": "workspaceFolderCount > 0 && databricks.context.initialized"
+                "when": "workspaceFolderCount > 0 && databricks.context.initialized && !databricks.context.isBundleProject"
             },
             {
                 "view": "configurationView",
-                "contents": "Initializing...",
-                "when": "workspaceFolderCount > 0 && !databricks.context.initialized"
+                "contents": "Loading configuration",
+                "when": "workspaceFolderCount > 0 && databricks.context.initialized && databricks.context.isBundleProject"
             },
             {
                 "view": "configurationView",
@@ -923,7 +928,7 @@
         "package:copy-webview-toolkit": "cp ./node_modules/@vscode/webview-ui-toolkit/dist/toolkit.js ./out/toolkit.js",
         "esbuild:base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --sourcemap --target=es2019",
         "build": "yarn run package:wrappers:write && yarn run package:jupyter-init-script:write && tsc --build --force",
-        "watch": "yarn run package:wrappers:write && yarn run package:jupyter-init-script:write && yarn run package:copy-webview-toolkit && tsc --build --watch --force",
+        "watch": "yarn run package:wrappers:write && yarn run package:jupyter-init-script:write && yarn run package:copy-webview-toolkit && tsc --build --watch --force --verbose",
         "fix": "eslint src --ext ts --fix && prettier . --write",
         "test:lint": "eslint src --ext ts && prettier . -c",
         "test:unit": "yarn run build && node ./out/test/runTest.js",

--- a/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleProjectManager.ts
@@ -114,11 +114,13 @@ export class BundleProjectManager {
             this.logger.debug(
                 "Detected an existing bundle project, initializing project services"
             );
+            this.customWhenContext.setIsBundleProject(true);
             return this.initProjectServices();
         } else {
             this.logger.debug(
                 "No bundle config detected, disposing project services"
             );
+            this.customWhenContext.setIsBundleProject(false);
             await this.disposeProjectServices();
         }
     }

--- a/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
+++ b/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
@@ -43,6 +43,14 @@ export class CustomWhenContext {
         );
     }
 
+    setIsBundleProject(value: boolean) {
+        commands.executeCommand(
+            "setContext",
+            "databricks.context.isBundleProject",
+            value
+        );
+    }
+
     setSubProjectsAvailable(value: boolean) {
         commands.executeCommand(
             "setContext",


### PR DESCRIPTION


## Changes
Right now if you switch to the Databricks panel (after the extension is already logged in), you will still see "Create a new Databricks Project" welcome view for half a second.

This is because our main view takes this long to load all the relevant information (sync component make API request to the workspace). This PR prevents UI flashed by adding "Loading configuration" welcome view based on the isBundleProject flag.

## Tests
Manual and existing tests

