### PR TITLE
Don't initialise spark progress widget if it's not supported

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -376,6 +376,9 @@ def register_spark_progress(spark, show_progress: bool):
         import ipywidgets as widgets
     except Exception as e:
         return
+    
+    if not hasattr(spark, "clearProgressHandlers") or not hasattr(spark, "registerProgressHandler"):
+        return
 
     class Progress:
         SI_BYTE_SIZES = (1 << 60, 1 << 50, 1 << 40, 1 << 30, 1 << 20, 1 << 10, 1)


### PR DESCRIPTION
## Changes
Don't initialise spark progress widget if it's not supported

## Tests
Manually

