### PR TITLE
Attemp to retry failed integ spec once

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -266,7 +266,8 @@ export const config: Options.Testrunner = {
     framework: "mocha",
     //
     // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 0,
+    // With new Github runners we experience web-driver craches and lost connections, hence the retry here
+    specFileRetries: 1,
     //
     // Delay in seconds between the spec file retry attempts
     specFileRetriesDelay: 0,


### PR DESCRIPTION
## Changes
With new github runners we experience flakiness due to webdriver crashes or lost connections. Not sure if the retry on this level will help, we might need to add aretry on a GH workflow level.

## Tests
integ

