### PR TITLE
Simplify UI for selecting virtual environments

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -277,6 +277,13 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.environment.setup",
+                "title": "Setup python environment",
+                "icon": "$(gear)",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.environment.selectPythonInterpreter",
                 "title": "Change Python environment",
                 "icon": "$(gear)",

--- a/packages/databricks-vscode/src/language/EnvironmentCommands.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentCommands.ts
@@ -5,7 +5,6 @@ import {Cluster} from "../sdk-extensions";
 import {EnvironmentDependenciesInstaller} from "./EnvironmentDependenciesInstaller";
 import {Environment} from "./MsPythonExtensionApi";
 import {environmentName} from "../utils/environmentUtils";
-import {env} from "yargs";
 
 export class EnvironmentCommands {
     constructor(

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
@@ -1,4 +1,4 @@
-import {EventEmitter, OutputChannel, window} from "vscode";
+import {commands, EventEmitter, OutputChannel, window} from "vscode";
 
 import {Disposable} from "vscode";
 import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
@@ -96,7 +96,10 @@ export class EnvironmentDependenciesInstaller implements Disposable {
             case "Change version":
                 return this.installWithVersionPrompt();
             case "Change environment":
-                return this.pythonExtension.selectPythonInterpreter();
+                await commands.executeCommand(
+                    "databricks.environment.selectPythonInterpreter"
+                );
+                return;
         }
     }
 }

--- a/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
+++ b/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
@@ -14,7 +14,6 @@ import {Mutex} from "../locking";
 import * as childProcess from "node:child_process";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {execFile} from "../cli/CliWrapper";
-import {resolve} from "node:path";
 
 export class MsPythonExtensionWrapper implements Disposable {
     public readonly api: MsPythonExtensionApi;

--- a/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
+++ b/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
@@ -14,6 +14,7 @@ import {Mutex} from "../locking";
 import * as childProcess from "node:child_process";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {execFile} from "../cli/CliWrapper";
+import {resolve} from "node:path";
 
 export class MsPythonExtensionWrapper implements Disposable {
     public readonly api: MsPythonExtensionApi;
@@ -60,7 +61,15 @@ export class MsPythonExtensionWrapper implements Disposable {
 
     async getAvailableEnvironments() {
         await this.api.environments.refreshEnvironments();
-        return this.api.environments.known.filter((env) => env.environment);
+        const filteredEnvs = [];
+        for (const env of this.api.environments.known) {
+            const resolvedEnv =
+                await this.api.environments.resolveEnvironment(env);
+            if (resolvedEnv && resolvedEnv.environment) {
+                filteredEnvs.push(env);
+            }
+        }
+        return filteredEnvs;
     }
 
     get onDidChangePythonExecutable(): Event<Uri | undefined> {

--- a/packages/databricks-vscode/src/utils/environmentUtils.ts
+++ b/packages/databricks-vscode/src/utils/environmentUtils.ts
@@ -1,0 +1,9 @@
+import {Environment} from "../language/MsPythonExtensionApi";
+
+export function environmentName(env: Environment) {
+    const version = env.version
+        ? `${env.version.major}.${env.version.minor}.${env.version.micro} `
+        : "";
+    const name = env.environment?.name ?? env.path;
+    return `${version}${name}`;
+}


### PR DESCRIPTION
## Changes
Create our own environment selector quick pick:
- Explicit "Select Python Environment" title, not "Select Interpreter" that the python extension uses
- Show only environments, not all interpreters as the python extension does
- Still show the option to use python extension selector for power users

New selector:
<img width="952" alt="Screenshot 2024-10-29 at 10 53 21" src="https://github.com/user-attachments/assets/757e5566-c5fb-419a-8480-68c09632cfab">

Old selector, or when you click on the "Use Python Extension to setup environments":
<img width="952" alt="Screenshot 2024-10-29 at 10 53 30" src="https://github.com/user-attachments/assets/feee5575-4c0c-486b-8f77-75e4d5108843">

As before, when there's no detected environments we show "create" dialog directly:
<img width="952" alt="Screenshot 2024-10-29 at 11 06 04" src="https://github.com/user-attachments/assets/b87ad8f0-fc7f-4702-a557-8833d394f19f">


## Tests
Manually

