### PR TITLE
Add validate runs for pipelines

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -225,6 +225,13 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.bundle.deployAndValidate",
+                "icon": "$(beaker)",
+                "title": "Deploy the bundle and validate the pipeline",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.bundle.cancelRun",
                 "title": "Cancel run",
                 "icon": "$(debug-stop)",
@@ -545,6 +552,11 @@
                     "group": "inline@0"
                 },
                 {
+                    "command": "databricks.bundle.deployAndValidate",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
+                    "group": "inline@0"
+                },
+                {
                     "command": "databricks.bundle.cancelRun",
                     "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.*.cancellable.*$/ && databricks.context.bundle.deploymentState == idle",
                     "group": "inline@0"
@@ -643,6 +655,10 @@
                 },
                 {
                     "command": "databricks.bundle.deployAndRun",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.bundle.deployAndValidate",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -122,7 +122,10 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
         );
     }
 
-    public async getRunCommand(resourceKey: string) {
+    public async getRunCommand(
+        resourceKey: string,
+        additionalArgs: string[] = []
+    ) {
         if (this.target === undefined) {
             throw new Error("Target is undefined");
         }
@@ -135,7 +138,8 @@ export class BundleRemoteStateModel extends BaseModelWithStateCache<BundleRemote
             this.authProvider,
             resourceKey,
             this.workspaceFolder,
-            this.workspaceConfigs.databrickscfgLocation
+            this.workspaceConfigs.databrickscfgLocation,
+            additionalArgs
         );
     }
 

--- a/packages/databricks-vscode/src/bundle/run/BundleRunStatusManager.ts
+++ b/packages/databricks-vscode/src/bundle/run/BundleRunStatusManager.ts
@@ -60,7 +60,8 @@ export class BundleRunStatusManager implements Disposable {
 
     async run(
         resourceKey: string,
-        resourceType: ResourceKey<BundleRemoteState>
+        resourceType: ResourceKey<BundleRemoteState>,
+        additionalArgs: string[] = []
     ) {
         const target = this.configModel.target;
         const authProvider = this.configModel.authProvider;
@@ -99,7 +100,8 @@ export class BundleRunStatusManager implements Disposable {
         try {
             const result = await this.bundleRunTerminalManager.run(
                 resourceKey,
-                (data) => remoteRunStatus.parseId(data)
+                (data) => remoteRunStatus.parseId(data),
+                additionalArgs
             );
             if (result.cancelled) {
                 await remoteRunStatus.cancel();

--- a/packages/databricks-vscode/src/bundle/run/BundleRunTerminalManager.ts
+++ b/packages/databricks-vscode/src/bundle/run/BundleRunTerminalManager.ts
@@ -25,7 +25,8 @@ export class BundleRunTerminalManager implements Disposable {
 
     async run(
         resourceKey: string,
-        onDidUpdate?: (data: string) => void
+        onDidUpdate?: (data: string) => void,
+        additionalArgs: string[] = []
     ): Promise<{cancelled: boolean; exitCode?: number | null}> {
         const target = this.bundleRemoteStateModel.target;
         if (target === undefined) {
@@ -72,8 +73,10 @@ export class BundleRunTerminalManager implements Disposable {
                     onCancellationEvent.dispose();
                 }, this.disposables);
 
-            const cmd =
-                await this.bundleRemoteStateModel.getRunCommand(resourceKey);
+            const cmd = await this.bundleRemoteStateModel.getRunCommand(
+                resourceKey,
+                additionalArgs
+            );
 
             // spawn a new process with the latest command, in the same terminal.
             terminal.pty.spawn(cmd);

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -690,7 +690,8 @@ export class CliWrapper {
         authProvider: AuthProvider,
         resourceKey: string,
         workspaceFolder: Uri,
-        configfilePath?: string
+        configfilePath?: string,
+        additionalArgs: string[] = []
     ): Promise<{
         cmd: string;
         args: string[];
@@ -711,7 +712,14 @@ export class CliWrapper {
 
         return {
             cmd: this.cliPath,
-            args: ["bundle", "run", "--target", target, resourceKey],
+            args: [
+                "bundle",
+                "run",
+                "--target",
+                target,
+                resourceKey,
+                ...additionalArgs,
+            ],
             options: {
                 cwd: workspaceFolder.fsPath,
                 env,

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -681,6 +681,11 @@ export async function activate(
             bundleCommands
         ),
         telemetry.registerCommand(
+            "databricks.bundle.deployAndValidate",
+            bundleCommands.deployAndValidate,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
             "databricks.bundle.cancelRun",
             bundleCommands.cancelRun,
             bundleCommands

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -30,6 +30,7 @@ export type ManualLoginSource =
     | "command"
     | "api";
 export type BundleRunResourceType = "pipelines" | "jobs";
+export type BundleRunType = "run" | "validate" | "partial-refresh";
 
 /** Documentation about all of the properties and metrics of the event. */
 type EventDescription<T> = {[K in keyof T]?: {comment?: string}};
@@ -129,6 +130,7 @@ export class EventTypes {
             success: boolean;
             cancelled?: boolean;
             resourceType?: BundleRunResourceType;
+            runType?: BundleRunType;
         } & DurationMeasurement
     > = {
         comment: "Execute a bundle resource",

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert";
 import {
     dismissNotifications,
-    getUniqueResourceName,
     getViewSection,
     waitForLogin,
     waitForTreeItems,

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
@@ -86,7 +86,8 @@ describe("Deploy and run pipeline", async function () {
             resourceExplorerView,
             "Pipelines",
             pipelineName,
-            "Completed",
+            // TODO: the account we are using to run tests doesn't have permissions to create clusters for the pipelines
+            "Failed",
             // Long timeout, as the pipeline will be waiting for its cluster to start
             15 * 60 * 1000
         );

--- a/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
@@ -14,7 +14,10 @@ import {
     writeRootBundleConfig,
 } from "./utils/dabsFixtures.ts";
 import {BundleSchema, BundleTarget, Resource} from "../../bundle/types";
-import {geTaskViewItem, getJobViewItem} from "./utils/dabsExplorerUtils.ts";
+import {
+    geTaskViewItem,
+    getResourceViewItem,
+} from "./utils/dabsExplorerUtils.ts";
 import {fileURLToPath} from "url";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -142,8 +145,9 @@ describe("Automatically refresh resource explorer", async function () {
 
         await browser.waitUntil(
             async () => {
-                const job = await getJobViewItem(
+                const job = await getResourceViewItem(
                     resourceExplorerView,
+                    "Workflows",
                     jobDef.name!
                 );
                 return job !== undefined;

--- a/packages/databricks-vscode/src/test/e2e/resources/dlt_pipeline.ipynb
+++ b/packages/databricks-vscode/src/test/e2e/resources/dlt_pipeline.ipynb
@@ -1,0 +1,28 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dlt\n",
+    "\n",
+    "@dlt.view\n",
+    "def test_view():\n",
+    "  return spark.sql(\"SELECT 1\")\n",
+    "\n",
+    "@dlt.table\n",
+    "def test_table():\n",
+    "  return dlt.read(\"test_view\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/packages/databricks-vscode/src/test/e2e/run_notebooks_ipynb.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_notebooks_ipynb.e2e.ts
@@ -59,8 +59,10 @@ describe("Run ipynb notebooks", async function () {
                 /* eslint-enable @typescript-eslint/naming-convention */
             })
         );
-
         await writeRootBundleConfig(getBasicBundleConfig(), projectDir);
+    });
+
+    it("should wait for connection", async () => {
         await waitForLogin("DEFAULT");
         await dismissNotifications();
     });

--- a/packages/databricks-vscode/src/test/e2e/run_notebooks_ipynb.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_notebooks_ipynb.e2e.ts
@@ -13,7 +13,9 @@ import {
     writeRootBundleConfig,
 } from "./utils/dabsFixtures.ts";
 
-describe("Run notebooks", async function () {
+// We split py and ipynb suites to avoid tests failing on GH workflows,
+// likely because the tests open webviews which are heavy on resources.
+describe("Run ipynb notebooks", async function () {
     let projectDir: string;
     this.timeout(3 * 60 * 1000);
 
@@ -31,15 +33,6 @@ describe("Run notebooks", async function () {
         await fs.mkdir(path.join(projectDir, "a", "b c"), {
             recursive: true,
         });
-        await fs.writeFile(
-            path.join(projectDir, "a", "b c", "notebook.py"),
-            [
-                "# Databricks notebook source",
-                `spark.sql('SELECT "hello world"').show()`,
-                "# COMMAND ----------",
-                "# MAGIC %sh pwd",
-            ].join("\n")
-        );
         await fs.writeFile(
             path.join(projectDir, "notebook.ipynb"),
             JSON.stringify({
@@ -70,12 +63,6 @@ describe("Run notebooks", async function () {
         await writeRootBundleConfig(getBasicBundleConfig(), projectDir);
         await waitForLogin("DEFAULT");
         await dismissNotifications();
-    });
-
-    it("should run a notebook.py file as a workflow", async () => {
-        await openFile("notebook.py");
-        await executeCommandWhenAvailable("Databricks: Run File as Workflow");
-        await waitForWorkflowWebview("a/b c");
     });
 
     it("should run a notebook.ipynb file as a workflow", async () => {

--- a/packages/databricks-vscode/src/test/e2e/run_notebooks_py.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_notebooks_py.e2e.ts
@@ -37,6 +37,9 @@ describe("Run py notebooks", async function () {
         );
 
         await writeRootBundleConfig(getBasicBundleConfig(), projectDir);
+    });
+
+    it("should wait for connection", async () => {
         await waitForLogin("DEFAULT");
         await dismissNotifications();
     });

--- a/packages/databricks-vscode/src/test/e2e/run_notebooks_py.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_notebooks_py.e2e.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import * as fs from "fs/promises";
+import assert from "node:assert";
+import {
+    dismissNotifications,
+    executeCommandWhenAvailable,
+    openFile,
+    waitForLogin,
+    waitForWorkflowWebview,
+} from "./utils/commonUtils.ts";
+import {
+    getBasicBundleConfig,
+    writeRootBundleConfig,
+} from "./utils/dabsFixtures.ts";
+
+// We split py and ipynb suites to avoid tests failing on GH workflows,
+// likely because the tests open webviews which are heavy on resources.
+describe("Run py notebooks", async function () {
+    let projectDir: string;
+    this.timeout(3 * 60 * 1000);
+
+    before(async () => {
+        assert(process.env.WORKSPACE_PATH);
+        projectDir = process.env.WORKSPACE_PATH;
+
+        await fs.mkdir(path.join(projectDir, "a", "b c"), {
+            recursive: true,
+        });
+        await fs.writeFile(
+            path.join(projectDir, "a", "b c", "notebook.py"),
+            [
+                "# Databricks notebook source",
+                `spark.sql('SELECT "hello world"').show()`,
+                "# COMMAND ----------",
+                "# MAGIC %sh pwd",
+            ].join("\n")
+        );
+
+        await writeRootBundleConfig(getBasicBundleConfig(), projectDir);
+        await waitForLogin("DEFAULT");
+        await dismissNotifications();
+    });
+
+    it("should run a notebook.py file as a workflow", async () => {
+        await openFile("notebook.py");
+        await executeCommandWhenAvailable("Databricks: Run File as Workflow");
+        await waitForWorkflowWebview("a/b c");
+    });
+});

--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -200,21 +200,27 @@ export async function waitForInput() {
 }
 
 export async function waitForLogin(profileName: string) {
+    console.log("Waiting for login");
     await browser.waitUntil(
         async () => {
-            await dismissNotifications();
             const section = (await getViewSection(
                 "CONFIGURATION"
             )) as CustomTreeSection;
             assert(section, "CONFIGURATION section doesn't exist");
             const items = await section.getVisibleItems();
+            console.log("Items in the CONFIGURATION section:", items.length);
             for (const item of items) {
                 const label = await item.getLabel();
                 if (label.toLowerCase().includes("auth type")) {
                     const desc = await item.getDescription();
+                    console.log("Auth type label:", desc);
                     return desc?.includes(profileName);
                 }
             }
+            console.log(
+                "Couldn't find the auth type label with the profile",
+                profileName
+            );
         },
         {timeout: 60_000, interval: 2_000, timeoutMsg: "Login didn't finish"}
     );

--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -269,11 +269,13 @@ export async function waitForWorkflowWebview(expectedOutput: string) {
     );
 
     const startTime = await browser.getTextByLabel("run-start-time");
+    console.log("Run start time:", startTime);
     expect(startTime).not.toHaveText("-");
 
     await browser.waitUntil(
         async () => {
             const status = await browser.getTextByLabel("run-status");
+            console.log("Run status:", status);
             return status.includes("Succeeded");
         },
         {

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
@@ -37,3 +37,42 @@ export async function geTaskViewItem(
         }
     }
 }
+
+export async function waitForRunStatus(
+    resourceExplorerView: CustomTreeSection,
+    resourceType: "Workflows" | "Pipelines",
+    resorceName: string,
+    successLabel: string,
+    timeout: number = 120_000
+) {
+    console.log("Waiting for run to finish");
+    await browser.waitUntil(
+        async () => {
+            const item = await getResourceViewItem(
+                resourceExplorerView,
+                resourceType,
+                resorceName
+            );
+            if (item === undefined) {
+                console.log(`Item ${resorceName} not found`);
+                return false;
+            }
+
+            const runStatusItem = await item.findChildItem("Run Status");
+            if (runStatusItem === undefined) {
+                console.log("Run status item not found");
+                return false;
+            }
+
+            const description = await runStatusItem.getDescription();
+            console.log(`Run status: ${description}`);
+
+            return description === successLabel;
+        },
+        {
+            timeout,
+            interval: 5_000,
+            timeoutMsg: `The run status didn't reach success within ${timeout}ms`,
+        }
+    );
+}

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
@@ -1,13 +1,14 @@
 import assert from "assert";
 import {CustomTreeSection} from "wdio-vscode-service";
 
-export async function getJobViewItem(
+export async function getResourceViewItem(
     resourceExplorer: CustomTreeSection,
-    jobDisplayName: string
+    resourceType: "Workflows" | "Pipelines",
+    resourceName: string
 ) {
-    const jobs = await resourceExplorer.openItem("Workflows");
+    const jobs = await resourceExplorer.openItem(resourceType);
     for (const job of jobs) {
-        if ((await job.elem.getText()).includes(jobDisplayName)) {
+        if ((await job.elem.getText()).includes(resourceName)) {
             return job;
         }
     }
@@ -15,11 +16,15 @@ export async function getJobViewItem(
 
 export async function geTaskViewItem(
     resourceExplorerView: CustomTreeSection,
-    jobName: string,
+    resourceName: string,
     taskName: string
 ) {
-    const jobViewItem = await getJobViewItem(resourceExplorerView, jobName);
-    assert(jobViewItem, `Job view item with name ${jobName} not found`);
+    const jobViewItem = await getResourceViewItem(
+        resourceExplorerView,
+        "Workflows",
+        resourceName
+    );
+    assert(jobViewItem, `Job view item with name ${resourceName} not found`);
 
     const tasks = await resourceExplorerView.openItem(
         "Workflows",

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {Resource, BundleTarget, BundleSchema} from "../../../bundle/types.ts";
+import fs from "fs/promises";
 import path from "path";
 import assert from "assert";
 import {writeFile, unlink} from "fs/promises";
 import {getUniqueResourceName} from "./commonUtils.ts";
 import yaml from "yaml";
 import lodash from "lodash";
+import {fileURLToPath} from "url";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+/* eslint-enable @typescript-eslint/naming-convention */
 
 type SimpleJob = Pick<
     Resource<BundleTarget, "jobs">,
@@ -16,6 +23,7 @@ export function getSimpleJobsResource(def: Omit<SimpleJob, "name">) {
     const defaultSimpleJob: SimpleJob = {
         name: getUniqueResourceName(),
         tasks: undefined,
+        /* eslint-disable @typescript-eslint/naming-convention */
         job_clusters: [
             {
                 job_cluster_key: "job_cluster",
@@ -29,6 +37,7 @@ export function getSimpleJobsResource(def: Omit<SimpleJob, "name">) {
                 },
             },
         ],
+        /* eslint-enable @typescript-eslint/naming-convention */
     };
     def = Object.assign({}, def);
 
@@ -55,10 +64,11 @@ export function getBasicBundleConfig(
         process.env.TEST_DEFAULT_CLUSTER_ID,
         "TEST_DEFAULT_CLUSTER_ID doesn't exist"
     );
+    /* eslint-disable @typescript-eslint/naming-convention */
     const defaultBundleConfig = {
         bundle: {
             name: getUniqueResourceName("basic_bundle"),
-            compute_id: topLevelComputeId
+            cluster_id: topLevelComputeId
                 ? process.env.TEST_DEFAULT_CLUSTER_ID
                 : undefined,
         },
@@ -72,6 +82,7 @@ export function getBasicBundleConfig(
             },
         },
     };
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     return lodash.merge(defaultBundleConfig, overrides);
 }
@@ -87,4 +98,115 @@ export async function writeRootBundleConfig(
 export async function clearRootBundleConfig(workspacePath: string) {
     const bundleConfig = path.join(workspacePath, "databricks.yml");
     await unlink(bundleConfig);
+}
+
+export async function createProjectWithJob(
+    vscodeWorkspaceRoot: string,
+    clusterId: string
+) {
+    /**
+     * process.env.WORKSPACE_PATH (cwd)
+     *  ├── databricks.yml
+     *  └── src
+     *    └── notebook.ipynb
+     */
+
+    const projectName = getUniqueResourceName("deploy_and_run_job");
+    const notebookTaskName = getUniqueResourceName("notebook_task");
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const jobDef = getSimpleJobsResource({
+        tasks: [
+            {
+                task_key: notebookTaskName,
+                notebook_task: {
+                    notebook_path: "src/notebook.ipynb",
+                },
+                existing_cluster_id: clusterId,
+            },
+        ],
+    });
+    const schemaDef: BundleSchema = getBasicBundleConfig({
+        bundle: {
+            name: projectName,
+            deployment: {},
+        },
+        targets: {
+            dev_test: {
+                resources: {
+                    jobs: {
+                        vscode_integration_test: jobDef,
+                    },
+                },
+            },
+        },
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    await writeRootBundleConfig(schemaDef, vscodeWorkspaceRoot);
+
+    await fs.mkdir(path.join(vscodeWorkspaceRoot, "src"), {
+        recursive: true,
+    });
+    await fs.copyFile(
+        path.join(__dirname, "../resources/spark_select_1.ipynb"),
+        path.join(vscodeWorkspaceRoot, "src", "notebook.ipynb")
+    );
+
+    return jobDef!.name!;
+}
+
+export async function createProjectWithPipeline(vscodeWorkspaceRoot: string) {
+    //
+    // process.env.WORKSPACE_PATH (cwd)
+    //  ├── databricks.yml
+    //  └── src
+    //    └── notebook.ipynb
+    //
+    // dlt_pipeline:
+    //   name: dlt_pipeline
+    //   libraries:
+    //     - notebook:
+    //         path: src/notebook.ipynb
+
+    const projectName = getUniqueResourceName("deploy_and_validate_pipeline");
+    const pipelineName = getUniqueResourceName("dlt_pipeline");
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const schemaDef: BundleSchema = getBasicBundleConfig({
+        bundle: {
+            name: projectName,
+            deployment: {},
+        },
+        targets: {
+            dev_test: {
+                resources: {
+                    pipelines: {
+                        vscode_integration_test: {
+                            name: pipelineName,
+                            target: "vscode_integration_test",
+                            libraries: [
+                                {
+                                    notebook: {
+                                        path: "src/notebook.ipynb",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    await writeRootBundleConfig(schemaDef, vscodeWorkspaceRoot);
+
+    await fs.mkdir(path.join(vscodeWorkspaceRoot, "src"), {
+        recursive: true,
+    });
+    await fs.copyFile(
+        path.join(__dirname, "../resources/dlt_pipeline.ipynb"),
+        path.join(vscodeWorkspaceRoot, "src", "notebook.ipynb")
+    );
+
+    return pipelineName;
 }

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -488,15 +488,12 @@ export const config: Options.Testrunner = {
         console.log("Starting cleanup");
         console.log("Extension dir:", EXTENSION_DIR);
         console.log("Workspace dir:", WORKSPACE_PATH);
-        let dbCli = path.join(
-            EXTENSION_DIR,
+        const dbCli = path.join(
+            EXTENSION_DIR.replace(" ", "\\ "),
             `${packageJson.publisher}.${packageJson.name}-${packageJson.version}`,
             "bin",
             "databricks"
         );
-        if (process.platform === "win32") {
-            dbCli += ".exe";
-        }
         const subfolders = await fs.readdir(WORKSPACE_PATH, {
             withFileTypes: true,
         });

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -18,7 +18,6 @@ import {sleep} from "wdio-vscode-service";
 import {glob} from "glob";
 import {getUniqueResourceName} from "./utils/commonUtils.ts";
 import {promisify} from "node:util";
-import {cwd} from "node:process";
 
 const WORKSPACE_PATH = path.resolve(tmpdir(), "test-root");
 

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -35,12 +35,11 @@ const VSIX_PATH = path.resolve(
 );
 const VSCODE_STORAGE_DIR = path.resolve(tmpdir(), "user-data-dir");
 
-const metaCharsRegExp = /([()\][%!^"`<>&|;,*?])/g;
+const metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
 
 export function escapeCommand(arg: string): string {
     // Escape meta chars
-    arg = arg.replace(metaCharsRegExp, "^$1");
-
+    arg = `"${arg}"`.replace(metaCharsRegExp, "^$1");
     return arg;
 }
 

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -35,7 +35,7 @@ const VSIX_PATH = path.resolve(
 );
 const VSCODE_STORAGE_DIR = path.resolve(tmpdir(), "user-data-dir");
 
-const metaCharsRegExp = /([()\][%!^"`<>&|;, *?])/g;
+const metaCharsRegExp = /([()\][%!^"`<>&|;,*?])/g;
 
 export function escapeCommand(arg: string): string {
     // Escape meta chars

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -489,7 +489,7 @@ export const config: Options.Testrunner = {
         console.log("Extension dir:", EXTENSION_DIR);
         console.log("Workspace dir:", WORKSPACE_PATH);
         const dbCli = path.join(
-            EXTENSION_DIR.replace(" ", "\\ "),
+            EXTENSION_DIR,
             `${packageJson.publisher}.${packageJson.name}-${packageJson.version}`,
             "bin",
             "databricks"

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -200,7 +200,7 @@ export class BundleCommands implements Disposable {
     }
 
     async deployAndValidate(treeNode: BundleResourceExplorerTreeNode) {
-        return this.deployAndRun(treeNode, ["--validate-only"]);
+        return this.deployAndRun(treeNode, ["--validate-only"], "validate");
     }
 
     @onError({popup: {prefix: "Error cancelling run."}})


### PR DESCRIPTION
## Changes
Validate action is available as a separate button on the pipeline item in the resource explorer:


<img width="748" alt="Screenshot 2024-11-01 at 10 02 27" src="https://github.com/user-attachments/assets/5dd2a147-f074-4443-9018-b101e53439c6">

Haven't found a super suitable icon for this action (in the workspace we don't use any icons for the validate action). Currently using the "beaker" icon that's generally used in tests, and reached out to the designers for help.

## Tests
Yes

