### PR TITLE
Use cluster policy in pipeline tests

### DIFF
--- a/packages/databricks-vscode/.vscode/launch.json
+++ b/packages/databricks-vscode/.vscode/launch.json
@@ -6,12 +6,24 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run Extension",
+            "name": "Run and Watch Extension",
             "type": "extensionHost",
             "request": "launch",
             "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
             "outFiles": ["${workspaceFolder}/out/**/*.js"],
             "preLaunchTask": "${defaultBuildTask}",
+            "env": {
+                "DATABRICKS_DEBUG_HEADERS": "false",
+                "EXTENSION_DEVELOPMENT": "true"
+            }
+        },
+        {
+            "name": "Build and Run Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+            "outFiles": ["${workspaceFolder}/out/**/*.js"],
+            "preLaunchTask": "NPM build",
             "env": {
                 "DATABRICKS_DEBUG_HEADERS": "false",
                 "EXTENSION_DEVELOPMENT": "true"

--- a/packages/databricks-vscode/.vscode/tasks.json
+++ b/packages/databricks-vscode/.vscode/tasks.json
@@ -21,6 +21,15 @@
             }
         },
         {
+            "label": "NPM build",
+            "type": "npm",
+            "script": "build",
+            "presentation": {
+                "reveal": "always",
+                "group": "build"
+            }
+        },
+        {
             "label": "Build",
             "dependsOn": ["NPM watch"],
             "group": {

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
@@ -87,7 +87,7 @@ describe("Deploy and run pipeline", async function () {
             "Pipelines",
             pipelineName,
             // TODO: the account we are using to run tests doesn't have permissions to create clusters for the pipelines
-            "Failed",
+            "Completed",
             // Long timeout, as the pipeline will be waiting for its cluster to start
             15 * 60 * 1000
         );

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
@@ -86,7 +86,6 @@ describe("Deploy and run pipeline", async function () {
             resourceExplorerView,
             "Pipelines",
             pipelineName,
-            // TODO: the account we are using to run tests doesn't have permissions to create clusters for the pipelines
             "Completed",
             // Long timeout, as the pipeline will be waiting for its cluster to start
             15 * 60 * 1000

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
@@ -185,7 +185,9 @@ export async function createProjectWithPipeline(vscodeWorkspaceRoot: string) {
                             target: "vscode_integration_test",
                             clusters: [
                                 {
-                                    num_workers: 0,
+                                    label: "default",
+                                    policy_id: "000880C28D1101F5",
+                                    apply_policy_default_values: true,
                                 },
                             ],
                             libraries: [

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
@@ -183,6 +183,11 @@ export async function createProjectWithPipeline(vscodeWorkspaceRoot: string) {
                         vscode_integration_test: {
                             name: pipelineName,
                             target: "vscode_integration_test",
+                            clusters: [
+                                {
+                                    num_workers: 0,
+                                },
+                            ],
                             libraries: [
                                 {
                                     notebook: {

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsFixtures.ts
@@ -186,7 +186,7 @@ export async function createProjectWithPipeline(vscodeWorkspaceRoot: string) {
                             clusters: [
                                 {
                                     label: "default",
-                                    policy_id: "000880C28D1101F5",
+                                    policy_id: "001196FD671F30D0",
                                     apply_policy_default_values: true,
                                 },
                             ],


### PR DESCRIPTION
## Changes
I've created a simple cluster policy in our terraform infra to let the test user create clusters for pipelines.

Also added non-watch build targets, can be useful when you want to re-run all our preparation scripts before starting the extension

## Tests
e2e

