### PR TITLE
Increase the polling time for job run status

### DIFF
--- a/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
+++ b/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
@@ -8,6 +8,7 @@ import {Event, EventEmitter} from "vscode";
 import {AuthProvider} from "../../configuration/auth/AuthProvider";
 import {onError} from "../../utils/onErrorDecorator";
 import {BundleRunStatus} from "./BundleRunStatus";
+import {Time, TimeUnits} from "@databricks/databricks-sdk";
 
 export class JobRunStatus extends BundleRunStatus {
     readonly type = "jobs";
@@ -48,6 +49,7 @@ export class JobRunStatus extends BundleRunStatus {
             await (
                 await client.jobs.getRun({run_id: parseInt(this.runId)})
             ).wait({
+                timeout: new Time(48, TimeUnits.hours),
                 onProgress: async (progress) => {
                     this.data = progress;
                     this.onDidChangeEmitter.fire();


### PR DESCRIPTION
## Changes
We were not providing any timeouts and the SDK was falling back to 10min, which is not enough for many job runs.


## Tests
Manually and existing tests

