### PR TITLE
Add partial update to pipelines

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -220,7 +220,7 @@
             {
                 "command": "databricks.bundle.deployAndRunJob",
                 "icon": "$(run)",
-                "title": "Deploy the bundle and run the Job",
+                "title": "Deploy the bundle and run the workflow",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
                 "category": "Databricks"
             },

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -235,6 +235,13 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.bundle.deployAndRunSelected",
+                "icon": "$(debug-coverage)",
+                "title": "Deploy the bundle and select pipeline tables for partial update",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.bundle.cancelRun",
                 "title": "Cancel run",
                 "icon": "$(debug-stop)",
@@ -556,6 +563,11 @@
                 },
                 {
                     "command": "databricks.bundle.deployAndValidate",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
+                    "group": "inline@0"
+                },
+                {
+                    "command": "databricks.bundle.deployAndRunSelected",
                     "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
                     "group": "inline@0"
                 },

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -218,26 +218,33 @@
                 "category": "Databricks"
             },
             {
-                "command": "databricks.bundle.deployAndRun",
-                "icon": "$(debug-start)",
-                "title": "Deploy the bundle and run the resource",
+                "command": "databricks.bundle.deployAndRunJob",
+                "icon": "$(run)",
+                "title": "Deploy the bundle and run the Job",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
                 "category": "Databricks"
             },
             {
-                "command": "databricks.bundle.deployAndValidate",
+                "command": "databricks.bundle.deployAndRunPipeline",
+                "icon": "$(run-all)",
+                "title": "Deploy the bundle and run the pipeline",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.deployAndRunSelectedTables",
+                "icon": "$(run)",
+                "title": "Deploy the bundle and select pipeline tables for partial update",
+                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.bundle.deployAndValidatePipeline",
                 "icon": {
                     "dark": "resources/dark/check-line-icon.svg",
                     "light": "resources/light/check-line-icon.svg"
                 },
                 "title": "Deploy the bundle and validate the pipeline",
-                "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
-                "category": "Databricks"
-            },
-            {
-                "command": "databricks.bundle.deployAndRunSelected",
-                "icon": "$(debug-coverage)",
-                "title": "Deploy the bundle and select pipeline tables for partial update",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
                 "category": "Databricks"
             },
@@ -557,17 +564,22 @@
                     "group": "inline@0"
                 },
                 {
-                    "command": "databricks.bundle.deployAndRun",
-                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.*.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
+                    "command": "databricks.bundle.deployAndRunJob",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=jobs.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
                     "group": "inline@0"
                 },
                 {
-                    "command": "databricks.bundle.deployAndValidate",
+                    "command": "databricks.bundle.deployAndRunPipeline",
                     "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
                     "group": "inline@0"
                 },
                 {
-                    "command": "databricks.bundle.deployAndRunSelected",
+                    "command": "databricks.bundle.deployAndValidatePipeline",
+                    "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
+                    "group": "inline@0"
+                },
+                {
+                    "command": "databricks.bundle.deployAndRunSelectedTables",
                     "when": "view == dabsResourceExplorerView && viewItem =~ /^databricks.bundle.resource=pipelines.runnable.*$/ && databricks.context.bundle.deploymentState == idle",
                     "group": "inline@0"
                 },
@@ -669,11 +681,15 @@
                     "when": "false"
                 },
                 {
-                    "command": "databricks.bundle.deployAndRun",
+                    "command": "databricks.bundle.deployAndRunJob",
                     "when": "false"
                 },
                 {
-                    "command": "databricks.bundle.deployAndValidate",
+                    "command": "databricks.bundle.deployAndValidatePipeline",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.bundle.deployAndRunSelectedTables",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -685,6 +685,10 @@
                     "when": "false"
                 },
                 {
+                    "command": "databricks.bundle.deployAndRunPipeline",
+                    "when": "false"
+                },
+                {
                     "command": "databricks.bundle.deployAndValidatePipeline",
                     "when": "false"
                 },

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
@@ -1,0 +1,114 @@
+import {BundlePipelinesManager} from "./BundlePipelinesManager";
+import {BundleRunStatusManager} from "./run/BundleRunStatusManager";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+// import {EventEmitter} from "events";
+import {mock, instance, when} from "ts-mockito";
+import assert from "assert";
+import {EventEmitter} from "vscode";
+import {install, InstalledClock} from "@sinonjs/fake-timers";
+
+describe(__filename, () => {
+    let runStatusManager: BundleRunStatusManager;
+    let configModel: ConfigModel;
+    let manager: BundlePipelinesManager;
+    let eventEmitter: EventEmitter<void>;
+    let clock: InstalledClock;
+
+    beforeEach(() => {
+        clock = install();
+        eventEmitter = new EventEmitter();
+        runStatusManager = mock<BundleRunStatusManager>();
+        configModel = mock<ConfigModel>();
+        when(runStatusManager.onDidChange).thenReturn(eventEmitter.event);
+        when(configModel.onDidChangeKey("remoteStateConfig")).thenReturn(
+            new EventEmitter<void>().event
+        );
+        when(configModel.onDidChangeTarget).thenReturn(
+            new EventEmitter<void>().event
+        );
+        manager = new BundlePipelinesManager(
+            instance(runStatusManager),
+            instance(configModel)
+        );
+    });
+
+    afterEach(() => {
+        clock.uninstall();
+    });
+
+    it("should update pipeline datasets from run events", async () => {
+        let datasets;
+        const remoteState = {resources: {pipelines: {pipeline1: {}}}};
+        when(configModel.get("remoteStateConfig")).thenResolve(remoteState);
+        const runStatuses = new Map();
+        when(runStatusManager.runStatuses).thenReturn(runStatuses);
+
+        const firstRun = {
+            data: {
+                update: {creation_time: 10},
+            },
+            events: [
+                {origin: {dataset_name: "table1"}},
+                {origin: {not_a_dataset_name: "table1.5"}},
+                {origin: {dataset_name: "table2"}},
+            ],
+        };
+        runStatuses.set("pipelines.pipeline1", firstRun);
+
+        eventEmitter.fire();
+        await clock.runToLastAsync();
+
+        datasets = manager.getDatasets("pipeline1");
+        assert.strictEqual(datasets.size, 2);
+        assert(datasets.has("table1"));
+        assert(datasets.has("table2"));
+
+        const secondPartialRun = {
+            data: {
+                update: {
+                    creation_time: 100,
+                    refresh_selection: ["table3", "table4"],
+                },
+            },
+            events: [
+                {origin: {dataset_name: "table3"}},
+                {origin: {not_a_dataset_name: "table3.5"}},
+                {origin: {dataset_name: "table4"}},
+            ],
+        };
+
+        runStatuses.set("pipelines.pipeline1", secondPartialRun);
+        eventEmitter.fire();
+        await clock.runToLastAsync();
+
+        datasets = manager.getDatasets("pipeline1");
+        assert.strictEqual(datasets.size, 4);
+        assert(datasets.has("table1"));
+        assert(datasets.has("table2"));
+        assert(datasets.has("table3"));
+        assert(datasets.has("table4"));
+
+        const finalFullRefreshRun = {
+            data: {
+                update: {
+                    creation_time: 200,
+                    refresh_selection: [],
+                },
+            },
+            events: [
+                {origin: {dataset_name: "table_new"}},
+                {origin: {not_a_dataset_name: "not a table"}},
+                {origin: {dataset_name: "table_final"}},
+            ],
+        };
+        runStatuses.set("pipelines.pipeline1", finalFullRefreshRun);
+        eventEmitter.fire();
+        await clock.runToLastAsync();
+
+        // Only the datasets from the final full-refresh run should be left
+        datasets = manager.getDatasets("pipeline1");
+        assert.strictEqual(datasets.size, 2);
+        assert(datasets.has("table_new"));
+        assert(datasets.has("table_final"));
+    });
+});

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
@@ -1,7 +1,6 @@
 import {BundlePipelinesManager} from "./BundlePipelinesManager";
 import {BundleRunStatusManager} from "./run/BundleRunStatusManager";
 import {ConfigModel} from "../configuration/models/ConfigModel";
-// import {EventEmitter} from "events";
 import {mock, instance, when} from "ts-mockito";
 import assert from "assert";
 import {EventEmitter} from "vscode";

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
@@ -42,6 +42,7 @@ describe(__filename, () => {
         const runStatuses = new Map();
         when(runStatusManager.runStatuses).thenReturn(runStatuses);
 
+        /* eslint-disable @typescript-eslint/naming-convention */
         const firstRun = {
             data: {
                 update: {creation_time: 10},
@@ -52,6 +53,7 @@ describe(__filename, () => {
                 {origin: {dataset_name: "table2"}},
             ],
         };
+        /* eslint-enable @typescript-eslint/naming-convention */
         runStatuses.set("pipelines.pipeline1", firstRun);
 
         eventEmitter.fire();
@@ -62,6 +64,7 @@ describe(__filename, () => {
         assert(datasets.has("table1"));
         assert(datasets.has("table2"));
 
+        /* eslint-disable @typescript-eslint/naming-convention */
         const secondPartialRun = {
             data: {
                 update: {
@@ -75,6 +78,7 @@ describe(__filename, () => {
                 {origin: {dataset_name: "table4"}},
             ],
         };
+        /* eslint-enable @typescript-eslint/naming-convention */
 
         runStatuses.set("pipelines.pipeline1", secondPartialRun);
         eventEmitter.fire();
@@ -87,6 +91,7 @@ describe(__filename, () => {
         assert(datasets.has("table3"));
         assert(datasets.has("table4"));
 
+        /* eslint-disable @typescript-eslint/naming-convention */
         const finalFullRefreshRun = {
             data: {
                 update: {
@@ -100,6 +105,7 @@ describe(__filename, () => {
                 {origin: {dataset_name: "table_final"}},
             ],
         };
+        /* eslint-enable @typescript-eslint/naming-convention */
         runStatuses.set("pipelines.pipeline1", finalFullRefreshRun);
         eventEmitter.fire();
         await clock.runToLastAsync();

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
@@ -1,0 +1,222 @@
+// The pipeline managers keeps track of the latest piepline updates (runs),
+// and the events associated with them. Based on the events it knows about the table definitions
+// for each pipeline, and provides functionality for selecting tables for a partial update.
+
+import {
+    Disposable,
+    QuickPick,
+    QuickPickItem,
+    QuickPickItemKind,
+    window,
+} from "vscode";
+import {PipelineRunStatus} from "./run/PipelineRunStatus";
+import {BundleRunStatusManager} from "./run/BundleRunStatusManager";
+import {ConfigModel} from "../configuration/models/ConfigModel";
+import {
+    PipelineEvent,
+    UpdateInfo,
+} from "@databricks/databricks-sdk/dist/apis/pipelines";
+
+type PipelineState = {
+    key: string;
+    datasets: Set<string>;
+    runs: Set<PipelineRunStatus>;
+};
+
+type Pick = QuickPickItem & {isDataset?: boolean; isDefault?: boolean};
+
+export class BundlePipelinesManager {
+    private disposables: Disposable[] = [];
+    private readonly pipelines: Map<string, PipelineState> = new Map();
+
+    constructor(
+        private readonly runStatusManager: BundleRunStatusManager,
+        private readonly configModel: ConfigModel
+    ) {
+        this.disposables.push(
+            this.configModel.onDidChangeTarget(() => {
+                this.updatePipelines();
+            }),
+            this.configModel.onDidChangeKey("remoteStateConfig")(async () => {
+                this.updatePipelines();
+            }),
+            this.runStatusManager.onDidChange(() => {
+                this.updatePipelines();
+            })
+        );
+        this.updatePipelines();
+    }
+
+    private async updatePipelines() {
+        const remoteState = await this.configModel.get("remoteStateConfig");
+        if (!remoteState) {
+            this.pipelines.clear();
+            return;
+        }
+        const pipelines = remoteState.resources?.pipelines ?? {};
+        Object.keys(pipelines).map((pipelineKey) => {
+            if (!this.pipelines.has(pipelineKey)) {
+                this.pipelines.set(pipelineKey, {
+                    key: pipelineKey,
+                    datasets: new Set(),
+                    runs: new Set(),
+                });
+            }
+            const state = this.pipelines.get(pipelineKey)!;
+            const runStatus = this.runStatusManager.runStatuses.get(
+                `pipelines.${pipelineKey}`
+            );
+            if (runStatus) {
+                state.runs.add(runStatus as PipelineRunStatus);
+                state.datasets = this.updatePipelineDatasets(state.runs);
+            }
+        });
+    }
+
+    public getDatasets(pipelineKey: string) {
+        return this.pipelines.get(pipelineKey)?.datasets ?? new Set();
+    }
+
+    private updatePipelineDatasets(runs: Set<PipelineRunStatus>) {
+        const datasets = new Set<string>();
+        const runsByStartTimeDesc = Array.from(runs).sort(
+            (a, b) =>
+                (b.data?.update?.creation_time ?? 0) -
+                (a.data?.update?.creation_time ?? 0)
+        );
+        for (const run of runsByStartTimeDesc) {
+            for (const event of run.events ?? []) {
+                const datasetName = extractDatasetName(event);
+                console.log("event", event);
+                console.log("datasetName", datasetName);
+                if (datasetName) {
+                    datasets.add(datasetName);
+                }
+            }
+            if (isFullGraphUpdate(run.data?.update)) {
+                break;
+            }
+        }
+        return datasets;
+    }
+
+    async showTableSelectionQuickPick(pipelineKey: string) {
+        const key = pipelineKey.split(".")[1];
+        const datasets = this.getDatasets(key);
+        const defaultsSeparatorPick: Pick = {
+            label: "Defaults",
+            kind: QuickPickItemKind.Separator,
+            alwaysShow: true,
+        };
+        const datasetPicks: Pick[] = Array.from(datasets).map((dataset) => ({
+            label: dataset,
+            isDataset: true,
+            alwaysShow: true,
+            isDefault: true,
+        }));
+        const optionsSeparatorPick: Pick = {
+            label: "Options",
+            kind: QuickPickItemKind.Separator,
+            alwaysShow: true,
+        };
+        const fullRefreshPick: Pick = {
+            label: "Full Refresh",
+            description: "Reset tables before the update",
+            alwaysShow: true,
+            isDefault: true,
+        };
+        const ui = window.createQuickPick<Pick>();
+        ui.canSelectMany = true;
+        const defaultItems = [
+            defaultsSeparatorPick,
+            ...datasetPicks,
+            optionsSeparatorPick,
+            fullRefreshPick,
+        ];
+        ui.items = defaultItems;
+        if (datasets.size > 0) {
+            ui.title = "Select or type in tables to update";
+        } else {
+            ui.title = "Provide table names to update";
+        }
+        ui.placeholder = "Comma separated list of table names";
+        ui.show();
+        const disposables: Disposable[] = [];
+        ui.onDidChangeValue(
+            () => {
+                const manualItems = stringToPicks(ui.value);
+                ui.items = manualItems.concat(defaultItems);
+                ui.selectedItems = manualItems.concat(
+                    ui.selectedItems.filter((item) => item.isDefault)
+                );
+            },
+            null,
+            disposables
+        );
+        const picks = await waitForPicks(ui, disposables);
+        const selectedTables = picksToString(picks);
+        disposables.forEach((d) => d.dispose());
+        ui.hide();
+        return {
+            tables: selectedTables,
+            fullRefresh: ui.selectedItems.includes(fullRefreshPick),
+        };
+    }
+
+    dispose() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}
+
+function isFullGraphUpdate(update?: UpdateInfo) {
+    if (!update) {
+        return false;
+    }
+    return (
+        (!update.full_refresh_selection ||
+            update.full_refresh_selection.length === 0) &&
+        (!update.refresh_selection || update.refresh_selection.length === 0)
+    );
+}
+
+// "details" is not a publicly documented field
+function extractDatasetName(
+    event: PipelineEvent & {details?: any}
+): string | undefined {
+    if (!event.origin?.dataset_name) {
+        return;
+    }
+    // VIEWs can't be used for a partial refresh (they are always refreshed)
+    if (event.details?.dataset_definition?.dataset_type === "VIEW") {
+        return;
+    }
+    return event.origin.dataset_name;
+}
+
+function picksToString(picks?: readonly Pick[]): string | undefined {
+    return picks
+        ?.filter((p) => p.isDataset)
+        .map((p) => p.label)
+        .join(",");
+}
+
+function stringToPicks(str: string): Pick[] {
+    return str
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .map((item) => {
+            return {
+                label: item,
+                alwaysShow: true,
+                isDataset: true,
+            };
+        });
+}
+
+async function waitForPicks(ui: QuickPick<Pick>, disposables: Disposable[]) {
+    return new Promise<readonly Pick[] | undefined>((resolve) => {
+        ui.onDidAccept(() => resolve(ui.selectedItems), null, disposables);
+        ui.onDidHide(() => resolve(undefined), null, disposables);
+    });
+}

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
@@ -87,8 +87,6 @@ export class BundlePipelinesManager {
         for (const run of runsByStartTimeDesc) {
             for (const event of run.events ?? []) {
                 const datasetName = extractDatasetName(event);
-                console.log("event", event);
-                console.log("datasetName", datasetName);
                 if (datasetName) {
                     datasets.add(datasetName);
                 }

--- a/packages/databricks-vscode/src/bundle/run/PipelineRunStatus.ts
+++ b/packages/databricks-vscode/src/bundle/run/PipelineRunStatus.ts
@@ -68,7 +68,7 @@ export class PipelineRunStatus extends BundleRunStatus {
                     this.events = await this.fetchUpdateEvents(
                         client,
                         this.data.update.creation_time,
-                        this.data.update?.update_id
+                        this.data.update.update_id
                     );
                 }
 

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -72,6 +72,7 @@ import {EnvironmentCommands} from "./language/EnvironmentCommands";
 import {WorkspaceFolderManager} from "./vscode-objs/WorkspaceFolderManager";
 import {SyncCommands} from "./sync/SyncCommands";
 import {CodeSynchronizer} from "./sync";
+import {BundlePipelinesManager} from "./bundle/BundlePipelinesManager";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require("../package.json");
@@ -633,9 +634,14 @@ export async function activate(
             connectionManager
         );
 
+    const bundlePipelinesManager = new BundlePipelinesManager(
+        bundleRunStatusManager,
+        configModel
+    );
     const bundleCommands = new BundleCommands(
         bundleRemoteStateModel,
         bundleRunStatusManager,
+        bundlePipelinesManager,
         bundleValidateModel,
         configModel,
         customWhenContext,
@@ -649,6 +655,7 @@ export async function activate(
         bundleResourceExplorerTreeDataProvider,
         bundleCommands,
         bundleRunTerminalManager,
+        bundlePipelinesManager,
         decorationProvider,
         window.registerFileDecorationProvider(decorationProvider),
         window.registerTreeDataProvider(
@@ -683,6 +690,11 @@ export async function activate(
         telemetry.registerCommand(
             "databricks.bundle.deployAndValidate",
             bundleCommands.deployAndValidate,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.bundle.deployAndRunSelected",
+            bundleCommands.deployAndRunSelected,
             bundleCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -683,18 +683,23 @@ export async function activate(
             bundleCommands
         ),
         telemetry.registerCommand(
-            "databricks.bundle.deployAndRun",
+            "databricks.bundle.deployAndRunJob",
             bundleCommands.deployAndRun,
             bundleCommands
         ),
         telemetry.registerCommand(
-            "databricks.bundle.deployAndValidate",
+            "databricks.bundle.deployAndRunPipeline",
+            bundleCommands.deployAndRun,
+            bundleCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.bundle.deployAndValidatePipeline",
             bundleCommands.deployAndValidate,
             bundleCommands
         ),
         telemetry.registerCommand(
-            "databricks.bundle.deployAndRunSelected",
-            bundleCommands.deployAndRunSelected,
+            "databricks.bundle.deployAndRunSelectedTables",
+            bundleCommands.deployAndRunSelectedTables,
             bundleCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
@@ -72,7 +72,7 @@ describe("Deploy and run job", async function () {
         assert(jobItem, `Job ${jobName} not found in resource explorer`);
 
         const deployAndRunButton = await jobItem.getActionButton(
-            "Deploy the bundle and run the resource"
+            "Deploy the bundle and run the job"
         );
         assert(deployAndRunButton, "Deploy and run button not found");
         await deployAndRunButton.elem.click();

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
@@ -72,7 +72,7 @@ describe("Deploy and run job", async function () {
         assert(jobItem, `Job ${jobName} not found in resource explorer`);
 
         const deployAndRunButton = await jobItem.getActionButton(
-            "Deploy the bundle and run the job"
+            "Deploy the bundle and run the workflow"
         );
         assert(deployAndRunButton, "Deploy and run button not found");
         await deployAndRunButton.elem.click();

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_pipeline.e2e.ts
@@ -75,7 +75,7 @@ describe("Deploy and run pipeline", async function () {
         );
 
         const deployAndRunButton = await pipelineItem.getActionButton(
-            "Deploy the bundle and run the resource"
+            "Deploy the bundle and run the pipeline"
         );
         assert(deployAndRunButton, "Deploy and run button not found");
         await deployAndRunButton.elem.click();

--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -222,7 +222,7 @@ export async function waitForLogin(profileName: string) {
                 profileName
             );
         },
-        {timeout: 60_000, interval: 2_000, timeoutMsg: "Login didn't finish"}
+        {timeout: 120_000, interval: 2_000, timeoutMsg: "Login didn't finish"}
     );
 }
 

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -205,7 +205,7 @@ export class BundleCommands implements Disposable {
         return this.deployAndRun(treeNode, ["--validate-only"], "validate");
     }
 
-    async deployAndRunSelected(treeNode: BundleResourceExplorerTreeNode) {
+    async deployAndRunSelectedTables(treeNode: BundleResourceExplorerTreeNode) {
         if (!isRunnable(treeNode)) {
             throw new Error(`Cannot run resource of type ${treeNode.type}`);
         }

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -14,6 +14,7 @@ import {ProcessError} from "../../cli/CliWrapper";
 import {ConfigModel} from "../../configuration/models/ConfigModel";
 import {humaniseMode} from "../utils/BundleUtils";
 import {BundleRunType} from "../../telemetry/constants";
+import {BundlePipelinesManager} from "../../bundle/BundlePipelinesManager";
 export const RUNNABLE_BUNDLE_RESOURCES = [
     "pipelines",
     "jobs",
@@ -33,6 +34,7 @@ export class BundleCommands implements Disposable {
     constructor(
         private readonly bundleRemoteStateModel: BundleRemoteStateModel,
         private readonly bundleRunStatusManager: BundleRunStatusManager,
+        private readonly bundlePipelinesManager: BundlePipelinesManager,
         private readonly bundleValidateModel: BundleValidateModel,
         private readonly configModel: ConfigModel,
         private readonly whenContext: CustomWhenContext,
@@ -201,6 +203,26 @@ export class BundleCommands implements Disposable {
 
     async deployAndValidate(treeNode: BundleResourceExplorerTreeNode) {
         return this.deployAndRun(treeNode, ["--validate-only"], "validate");
+    }
+
+    async deployAndRunSelected(treeNode: BundleResourceExplorerTreeNode) {
+        if (!isRunnable(treeNode)) {
+            throw new Error(`Cannot run resource of type ${treeNode.type}`);
+        }
+        const key = treeNode.resourceKey;
+        const result =
+            await this.bundlePipelinesManager.showTableSelectionQuickPick(key);
+        if (!result.tables) {
+            return;
+        }
+        return this.deployAndRun(
+            treeNode,
+            [
+                result.fullRefresh ? "--full-refresh" : "--refresh",
+                result.tables,
+            ],
+            "partial-refresh"
+        );
     }
 
     @onError({popup: {prefix: "Error cancelling run."}})

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -136,15 +136,20 @@ export class BundleCommands implements Disposable {
                     return;
                 }
             }
-            await window.withProgress(
-                {
-                    location: ProgressLocation.Notification,
-                    title: title,
-                    cancellable: true,
-                },
-                async (progress, token) => {
-                    await this.bundleRemoteStateModel.deploy(force, token);
-                }
+            const viewProgressOptions = {
+                location: {viewId: "dabsResourceExplorerView"},
+            };
+            const notificationProgressOptions = {
+                location: ProgressLocation.Notification,
+                title: title,
+                cancellable: true,
+            };
+            await window.withProgress(viewProgressOptions, () =>
+                window.withProgress(
+                    notificationProgressOptions,
+                    (progress, token) =>
+                        this.bundleRemoteStateModel.deploy(force, token)
+                )
             );
 
             await this.refreshRemoteState();


### PR DESCRIPTION
## Changes
I've changed the "normal" pipeline run action to use `run-all` icon, and the partial update run uses the `run` instead.

Currently we don't pre-load pipeline updates, so if a user hasn't executed a pipeline from the extension, the partial update action will not show a list of tables to select from (and users will have to type the table names manually). After the pipeline is executed we show the tables selection in the partial update action.

Pre-loading pipeline updates is for later.

New action:
<img width="676" alt="Screenshot 2024-11-18 at 15 31 07" src="https://github.com/user-attachments/assets/31022043-9820-497a-a5bf-8d2b71fed24a">


The case when we don't know about past events:
<img width="896" alt="Screenshot 2024-11-15 at 11 24 52" src="https://github.com/user-attachments/assets/6bdf0f49-399b-4657-a2d1-8207d4e8f78c">
<img width="896" alt="Screenshot 2024-11-15 at 11 25 01" src="https://github.com/user-attachments/assets/3044ddf2-1059-4775-aa00-9a28165c1e77">

The case when we offer a selection of table names based on past runs:
<img width="896" alt="Screenshot 2024-11-15 at 11 26 28" src="https://github.com/user-attachments/assets/e4f834c3-918a-4f0a-92ab-182305fe450c">

<img width="896" alt="Screenshot 2024-11-15 at 11 25 13" src="https://github.com/user-attachments/assets/48c5a21f-7423-4585-99f9-62a682101ece">



## Tests
Partially covered by unit tests

