### PR TITLE
Python launch config is deprecated

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -879,6 +879,19 @@
                         }
                     }
                 }
+            },
+            {
+                "type": "debugpy",
+                "configurationAttributes": {
+                    "launch": {
+                        "properties": {
+                            "databricks": {
+                                "type": "boolean",
+                                "description": "Setup databricks environment variables and globals."
+                            }
+                        }
+                    }
+                }
             }
         ],
         "configuration": [
@@ -957,6 +970,7 @@
     },
     "extensionDependencies": [
         "ms-python.python",
+        "ms-python.debugpy",
         "ms-toolsai.jupyter",
         "redhat.vscode-yaml"
     ],

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -139,7 +139,7 @@ export class RunCommands {
         }
         const config: DatabricksPythonDebugConfiguration = {
             program: targetResource.fsPath,
-            type: "python",
+            type: "debugpy",
             name: "Databricks Connect",
             request: "launch",
             databricks: true,


### PR DESCRIPTION
## Changes
`debugpy` is the new python debugger, and `python` launch config type is deprecated - https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy

Python extension already depends on it, but I'm still adding it as an explicit dependency to our extension too


## Tests
Manual testing
