### PR TITLE
Do not load too many events

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.ts
@@ -67,7 +67,7 @@ type SourceLocation = {
     notebook_cell_number?: number;
 };
 
-const MAX_EVENTS_TO_LOAD = 2000;
+const MAX_EVENTS_TO_LOAD = 1000;
 
 export class BundlePipelinesManager {
     private disposables: Disposable[] = [];


### PR DESCRIPTION
## Changes
While preloading updates in order to generate datasets and their schemas,
it's possible to be stuck for a while in the loading (e.g. in the case of continuous pipelines with a lot of events).


## Tests
<!-- How is this tested? -->

