### PR TITLE
Improve venv python version messages

### DIFF
--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -283,6 +283,12 @@ export class LoginWizard {
                         type: "error",
                     };
                 }
+                if (value.includes(".")) {
+                    return {
+                        message: "Profile name cannot contain dots",
+                        type: "error",
+                    };
+                }
                 if (profiles.find((profile) => profile.name === value)) {
                     return {
                         message: `Profile ${value} already exists`,


### PR DESCRIPTION


## Changes
Add 3.12 version message for newly released DBR 16 

(unrelated) Prohibit dots in profile names created from the extension. Our ini lib thinks that the dot indicates a subsection and escapes it, creating a profile under a technically different name

## Tests
<!-- How is this tested? -->

