### PR TITLE
Suppress grpc warnings

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -492,6 +492,10 @@ try:
     import sys
 
     print(sys.modules[__name__])
+
+    # Suppress grpc warnings coming from databricks-connect with newer version of grpcio lib
+    os.environ["GRPC_VERBOSITY"] = "NONE"
+
     if not load_env_from_leaf(os.getcwd()):
         sys.exit(1)
     cfg = LocalDatabricksNotebookConfig()

--- a/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
+++ b/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
@@ -32,6 +32,9 @@ except Exception as e:
     logging.error(f"Failed to get current directory: {e}")
     cur_dir = os.getcwd()
 
+# Suppress grpc warnings coming from databricks-connect with newer version of grpcio lib
+os.environ["GRPC_VERBOSITY"] = "NONE"
+
 root_dir = os.getcwd()
 load_env_file_from_cwd(root_dir)
 


### PR DESCRIPTION
## Changes

New `grpcio` lib (which is a dependency of `databricks-connect` package) produces warning when you run any code.

I've notified `databricks-connect` developers to solve it on their side, but in the meantime we can suppress warnings with the env vars

Fixes https://github.com/databricks/databricks-vscode/issues/1478