### PR TITLE
[Internal] Migrate workflows that need write access to use hosted runners

### DIFF
--- a/.github/.prettierrc.yml
+++ b/.github/.prettierrc.yml
@@ -1,0 +1,8 @@
+# Local configuration for Prettier.
+# This applies exclusively to the files in the ".github" directory.
+#
+# We like to keep the formatting of these files consistent
+# across repositories to keep diffs small and copy-paste friendly.
+#
+tabWidth: 2
+useTabs: false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,8 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ## Changes
+
 <!-- Summary of your changes that are easy to understand -->
 
 ## Tests
-<!-- How is this tested? -->
 
+<!-- How is this tested? -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,16 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "@databricks/*"          
+      - dependency-name: "@databricks/*"
   - package-ecosystem: "npm"
     directory: "/packages/databricks-vscode"
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "@databricks/*"    
+      - dependency-name: "@databricks/*"
   - package-ecosystem: "npm"
     directory: "/packages/databricks-vscode-types"
     ignore:
-      - dependency-name: "@databricks/*"    
+      - dependency-name: "@databricks/*"
     schedule:
       interval: "daily"

--- a/.github/workflows/create-build-artifacts.yml
+++ b/.github/workflows/create-build-artifacts.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   create-build-artifacts:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     defaults:
       run:
         shell: bash

--- a/.github/workflows/create-build-artifacts.yml
+++ b/.github/workflows/create-build-artifacts.yml
@@ -1,33 +1,33 @@
 name: Create Build Artefacts
 
 on:
-    workflow_call:
+  workflow_call:
 
 jobs:
-    create-build-artifacts:
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                shell: bash
+  create-build-artifacts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
-        steps:
-            - uses: actions/checkout@v3
+    steps:
+      - uses: actions/checkout@v3
 
-            - name: Use Node.js 18
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-                  cache: "yarn"
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "yarn"
 
-            - run: yarn install
-            - run: yarn run build
-            - run: yarn run package:all
-              working-directory: packages/databricks-vscode
-              env:
-                  GH_TOKEN: ${{ github.token }}
-                  BUILD_PLATFORM_ARCH: linux_amd64
+      - run: yarn install
+      - run: yarn run build
+      - run: yarn run package:all
+        working-directory: packages/databricks-vscode
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_PLATFORM_ARCH: linux_amd64
 
-            - uses: actions/upload-artifact@v3
-              with:
-                  name: databricks
-                  path: "packages/databricks-vscode/*.vsix"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: databricks
+          path: "packages/databricks-vscode/*.vsix"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,7 +15,11 @@ jobs:
   create-release:
     if: startsWith(github.event.head_commit.message, 'Release:') || github.event_name == 'workflow_dispatch'
     needs: ["create-build-artifacts"]
-    runs-on: macos-latest
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,40 +1,40 @@
 name: Create Draft Release
 
 on:
-    push:
-        branches: ["main"]
+  push:
+    branches: ["main"]
 
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
-    create-build-artifacts:
-        if: startsWith(github.event.head_commit.message, 'Release:') || github.event_name == 'workflow_dispatch'
-        uses: ./.github/workflows/create-build-artifacts.yml
-        secrets: inherit
+  create-build-artifacts:
+    if: startsWith(github.event.head_commit.message, 'Release:') || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/create-build-artifacts.yml
+    secrets: inherit
 
-    create-release:
-        if: startsWith(github.event.head_commit.message, 'Release:') || github.event_name == 'workflow_dispatch'
-        needs: ["create-build-artifacts"]
-        runs-on: macos-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/download-artifact@v3
-              id: download
-              with:
-                  path: build
+  create-release:
+    if: startsWith(github.event.head_commit.message, 'Release:') || github.event_name == 'workflow_dispatch'
+    needs: ["create-build-artifacts"]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        id: download
+        with:
+          path: build
 
-            - run: ls -lr ${{ steps.download.outputs.download-path }}
+      - run: ls -lr ${{ steps.download.outputs.download-path }}
 
-            - run: |
-                  TITLE=$(git show -s --format=%B HEAD | head -n1)
-                  CHANGELOG_FILE=packages/databricks-vscode/CHANGELOG.md
-                  RELEASE_VERSION=$(cat $CHANGELOG_FILE | grep -E "^# Release: v(([0-9]+\.){2}[0-9]+).*" | head -n1 | sed -nr 's/.*Release: v(([0-9]+\.){2}[0-9]+).*/\1/p')
+      - run: |
+          TITLE=$(git show -s --format=%B HEAD | head -n1)
+          CHANGELOG_FILE=packages/databricks-vscode/CHANGELOG.md
+          RELEASE_VERSION=$(cat $CHANGELOG_FILE | grep -E "^# Release: v(([0-9]+\.){2}[0-9]+).*" | head -n1 | sed -nr 's/.*Release: v(([0-9]+\.){2}[0-9]+).*/\1/p')
 
-                  tmpfile=$(mktemp /tmp/commit-message.XXXXX)
-                  cat $CHANGELOG_FILE | awk 'BEGIN{C=0} $0 ~ /^# Release: v.*/ && C==1{C=2} $0 ~ /^# Release: v'"$RELEASE_VERSION"'.*/{C=1} C==1 {print $0}' > $tmpfile
-                  cat $tmpfile >> $GITHUB_STEP_SUMMARY
-                  gh release create release-v$RELEASE_VERSION ${{ steps.download.outputs.download-path }}/databricks*/*.vsix \
-                      -d --target main -t "$TITLE" -F $tmpfile
+          tmpfile=$(mktemp /tmp/commit-message.XXXXX)
+          cat $CHANGELOG_FILE | awk 'BEGIN{C=0} $0 ~ /^# Release: v.*/ && C==1{C=2} $0 ~ /^# Release: v'"$RELEASE_VERSION"'.*/{C=1} C==1 {print $0}' > $tmpfile
+          cat $tmpfile >> $GITHUB_STEP_SUMMARY
+          gh release create release-v$RELEASE_VERSION ${{ steps.download.outputs.download-path }}/databricks*/*.vsix \
+              -d --target main -t "$TITLE" -F $tmpfile
 
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   comment-on-pr:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     permissions:
       pull-requests: write
 

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -6,51 +6,51 @@ name: PR Comment
 # DO NOT PULL THE PR OR EXECUTE ANY CODE FROM THE PR.
 
 on:
-    pull_request_target:
-        types: [opened, reopened, synchronize]
-        branches:
-            - main
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
 
 jobs:
-    comment-on-pr:
-        runs-on: ubuntu-latest
-        permissions:
-            pull-requests: write
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
-        steps:
-            - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Delete old comments
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  # Delete previous comment if it exists
-                  previous_comment_ids=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-                    --jq '.[] | select(.body | startswith("<!-- INTEGRATION_TESTS_MANUAL -->")) | .id')
-                  echo "Previous comment IDs: $previous_comment_ids"
-                  # Iterate over each comment ID and delete the comment
-                  if [ ! -z "$previous_comment_ids" ]; then
-                    echo "$previous_comment_ids" | while read -r comment_id; do
-                      echo "Deleting comment with ID: $comment_id"
-                      gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X DELETE
-                    done
-                  fi
+      - name: Delete old comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Delete previous comment if it exists
+          previous_comment_ids=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- INTEGRATION_TESTS_MANUAL -->")) | .id')
+          echo "Previous comment IDs: $previous_comment_ids"
+          # Iterate over each comment ID and delete the comment
+          if [ ! -z "$previous_comment_ids" ]; then
+            echo "$previous_comment_ids" | while read -r comment_id; do
+              echo "Deleting comment with ID: $comment_id"
+              gh api "repos/${{ github.repository }}/issues/comments/$comment_id" -X DELETE
+            done
+          fi
 
-            - name: Comment on PR
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-              run: |
-                  gh pr comment ${{ github.event.pull_request.number }} --body \
-                  "<!-- INTEGRATION_TESTS_MANUAL -->
-                  If integration tests don't run automatically, an authorized user can run them manually by following the instructions below:
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body \
+          "<!-- INTEGRATION_TESTS_MANUAL -->
+          If integration tests don't run automatically, an authorized user can run them manually by following the instructions below:
 
-                  Trigger:
-                  [go/deco-tests-run/vscode](https://go/deco-tests-run/vscode)
+          Trigger:
+          [go/deco-tests-run/vscode](https://go/deco-tests-run/vscode)
 
-                  Inputs:
-                  * PR number: ${{github.event.pull_request.number}}
-                  * Commit SHA: \`${{ env.COMMIT_SHA }}\`
+          Inputs:
+          * PR number: ${{github.event.pull_request.number}}
+          * Commit SHA: \`${{ env.COMMIT_SHA }}\`
 
-                  Checks will be approved automatically on success.
-                  "
+          Checks will be approved automatically on success.
+          "

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   check-token:
     name: Check secrets access
-    runs-on: ubuntu-latest
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     environment: "test-trigger-is"
     outputs:
       has_token: ${{ steps.set-token-status.outputs.has_token }}
@@ -27,7 +31,11 @@ jobs:
 
   trigger-tests:
     name: Trigger Tests
-    runs-on: ubuntu-latest
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     needs: check-token
     if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
     environment: "test-trigger-is"
@@ -61,7 +69,11 @@ jobs:
   # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
   auto-approve:
     if: github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     steps:
       - name: Mark Check
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,75 +1,75 @@
 name: Integration Tests
 
 on:
-    pull_request:
-        types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
 
-    merge_group:
+  merge_group:
 
 jobs:
-    check-token:
-        name: Check secrets access
-        runs-on: ubuntu-latest
-        environment: "test-trigger-is"
-        outputs:
-            has_token: ${{ steps.set-token-status.outputs.has_token }}
-        steps:
-            - name: Check if DECO_WORKFLOW_TRIGGER_APP_ID is set
-              id: set-token-status
-              run: |
-                  if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ]; then
-                      echo "DECO_WORKFLOW_TRIGGER_APP_ID is empty. User has no access to secrets."
-                      echo "::set-output name=has_token::false"
-                  else
-                      echo "DECO_WORKFLOW_TRIGGER_APP_ID is set. User has access to secrets."
-                      echo "::set-output name=has_token::true"
-                  fi
+  check-token:
+    name: Check secrets access
+    runs-on: ubuntu-latest
+    environment: "test-trigger-is"
+    outputs:
+      has_token: ${{ steps.set-token-status.outputs.has_token }}
+    steps:
+      - name: Check if DECO_WORKFLOW_TRIGGER_APP_ID is set
+        id: set-token-status
+        run: |
+          if [ -z "${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}" ]; then
+              echo "DECO_WORKFLOW_TRIGGER_APP_ID is empty. User has no access to secrets."
+              echo "::set-output name=has_token::false"
+          else
+              echo "DECO_WORKFLOW_TRIGGER_APP_ID is set. User has access to secrets."
+              echo "::set-output name=has_token::true"
+          fi
 
-    trigger-tests:
-        name: Trigger Tests
-        runs-on: ubuntu-latest
-        needs: check-token
-        if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
-        environment: "test-trigger-is"
-        steps:
-            - uses: actions/checkout@v4
+  trigger-tests:
+    name: Trigger Tests
+    runs-on: ubuntu-latest
+    needs: check-token
+    if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
+    environment: "test-trigger-is"
+    steps:
+      - uses: actions/checkout@v4
 
-            - name: Generate GitHub App Token
-              id: generate-token
-              uses: actions/create-github-app-token@v1
-              with:
-                  app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
-                  private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
-                  owner: ${{ secrets.ORG_NAME }}
-                  repositories: ${{secrets.REPO_NAME}}
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DECO_WORKFLOW_TRIGGER_APP_ID }}
+          private-key: ${{ secrets.DECO_WORKFLOW_TRIGGER_PRIVATE_KEY }}
+          owner: ${{ secrets.ORG_NAME }}
+          repositories: ${{secrets.REPO_NAME}}
 
-            - name: Trigger Workflow in Another Repo
-              env:
-                  GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-              run: |
-                  gh workflow run vscode-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
-                  --ref main \
-                  -f pull_request_number=${{ github.event.pull_request.number }} \
-                  -f commit_sha=${{ github.event.pull_request.head.sha }}
+      - name: Trigger Workflow in Another Repo
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          gh workflow run vscode-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
+          --ref main \
+          -f pull_request_number=${{ github.event.pull_request.number }} \
+          -f commit_sha=${{ github.event.pull_request.head.sha }}
 
-    # Statuses and checks apply to specific commits (by hash).
-    # Enforcement of required checks is done both at the PR level and the merge queue level.
-    # In case of multiple commits in a single PR, the hash of the squashed commit
-    # will not match the one for the latest (approved) commit in the PR.
-    # We auto approve the check for the merge queue for two reasons:
-    # * Queue times out due to duration of tests.
-    # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
-    auto-approve:
-        if: github.event_name == 'merge_group'
-        runs-on: ubuntu-latest
-        steps:
-            - name: Mark Check
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              shell: bash
-              run: |
-                  gh api -X POST -H "Accept: application/vnd.github+json" \
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    /repos/${{ github.repository }}/statuses/${{ github.sha }} \
-                    -f 'state=success' \
-                    -f 'context=Integration Tests Check'
+  # Statuses and checks apply to specific commits (by hash).
+  # Enforcement of required checks is done both at the PR level and the merge queue level.
+  # In case of multiple commits in a single PR, the hash of the squashed commit
+  # will not match the one for the latest (approved) commit in the PR.
+  # We auto approve the check for the merge queue for two reasons:
+  # * Queue times out due to duration of tests.
+  # * Avoid running integration tests twice, since it was already run at the tip of the branch before squashing.
+  auto-approve:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark Check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh api -X POST -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -f 'state=success' \
+            -f 'context=Integration Tests Check'

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -12,7 +12,10 @@ jobs:
 
   create-release:
     needs: "create-build-artifacts"
-    runs-on: ubuntu-latest
+
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,31 +1,31 @@
 name: Publish nightly release
 
 on:
-    push:
-        branches: [main]
-    workflow_dispatch:
+  push:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
-    create-build-artifacts:
-        uses: ./.github/workflows/create-build-artifacts.yml
-        secrets: inherit
+  create-build-artifacts:
+    uses: ./.github/workflows/create-build-artifacts.yml
+    secrets: inherit
 
-    create-release:
-        needs: "create-build-artifacts"
-        runs-on: ubuntu-latest
+  create-release:
+    needs: "create-build-artifacts"
+    runs-on: ubuntu-latest
 
-        steps:
-            - uses: actions/download-artifact@v3
-              with:
-                  path: packages/databricks-vscode
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: packages/databricks-vscode
 
-            - run: ls -lR packages/databricks-vscode
+      - run: ls -lR packages/databricks-vscode
 
-            - name: Update nightly release
-              uses: softprops/action-gh-release@v1
-              with:
-                  name: Nightly - ${{ github.ref_name }}
-                  prerelease: true
-                  tag_name: nightly-${{ github.ref_name }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  files: "packages/databricks-vscode/databricks*/*.vsix"
+      - name: Update nightly release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Nightly - ${{ github.ref_name }}
+          prerelease: true
+          tag_name: nightly-${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "packages/databricks-vscode/databricks*/*.vsix"

--- a/.github/workflows/publish-to-openvsx.yml
+++ b/.github/workflows/publish-to-openvsx.yml
@@ -1,57 +1,57 @@
 name: Publish to Open VSX Marketplace
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: "Release tag"
-                required: true
-                type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag"
+        required: true
+        type: string
 
-    release:
-        types: [published]
+  release:
+    types: [published]
 
 jobs:
-    publish-to-openvsx:
-        runs-on: ubuntu-latest
-        environment: Production
+  publish-to-openvsx:
+    runs-on: ubuntu-latest
+    environment: Production
 
-        steps:
-            - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18.x
+    steps:
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
 
-            - name: Download release
-              run: |
-                  set x
-                  echo Version: ${{ github.event.inputs.version }}
-                  echo REF: ${{ github.ref }}
-                  TAG=${{ github.event.inputs.version }}
-                  if [[ ! -z "${{ github.event.inputs.version }}" ]]; then
-                    TAG=${{ github.event.inputs.version }}
-                  elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-                    TAG=$(echo ${{ github.ref }} | sed -e "s|^refs/tags/||")
-                  else
-                    exit 1
-                  fi
-                  echo Tag: $TAG
-                  gh release download $TAG -R databricks/databricks-vscode
-                  ls -lR
-                  echo "TAG=$TAG" >> $GITHUB_ENV
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download release
+        run: |
+          set x
+          echo Version: ${{ github.event.inputs.version }}
+          echo REF: ${{ github.ref }}
+          TAG=${{ github.event.inputs.version }}
+          if [[ ! -z "${{ github.event.inputs.version }}" ]]; then
+            TAG=${{ github.event.inputs.version }}
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG=$(echo ${{ github.ref }} | sed -e "s|^refs/tags/||")
+          else
+            exit 1
+          fi
+          echo Tag: $TAG
+          gh release download $TAG -R databricks/databricks-vscode
+          ls -lR
+          echo "TAG=$TAG" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Install vcse
-              run: npm install -g @vscode/vsce
+      - name: Install vcse
+        run: npm install -g @vscode/vsce
 
-            - name: Install ovsx
-              run: npm install -g ovsx
+      - name: Install ovsx
+        run: npm install -g ovsx
 
-            - name: Publish to Open VSX
-              run: |
-                  ovsx verify-pat databricks
-                  ovsx publish --packagePath databricks-*.vsix
+      - name: Publish to Open VSX
+        run: |
+          ovsx verify-pat databricks
+          ovsx publish --packagePath databricks-*.vsix
 
-              env:
-                  OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish-to-openvsx.yml
+++ b/.github/workflows/publish-to-openvsx.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   publish-to-openvsx:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     environment: Production
 
     steps:

--- a/.github/workflows/publish-to-vscode.yml
+++ b/.github/workflows/publish-to-vscode.yml
@@ -13,7 +13,10 @@ on:
 
 jobs:
   publish-to-vscode:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     environment: Production
 
     steps:

--- a/.github/workflows/publish-to-vscode.yml
+++ b/.github/workflows/publish-to-vscode.yml
@@ -1,54 +1,54 @@
 name: Publish to VS Code Marketplace
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: "Release tag"
-                required: true
-                type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag"
+        required: true
+        type: string
 
-    release:
-        types: [published]
+  release:
+    types: [published]
 
 jobs:
-    publish-to-vscode:
-        runs-on: ubuntu-latest
-        environment: Production
+  publish-to-vscode:
+    runs-on: ubuntu-latest
+    environment: Production
 
-        steps:
-            - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18.x
+    steps:
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
 
-            - name: download release
-              run: |
-                  set x
-                  echo Version: ${{ github.event.inputs.version }}
-                  echo REF: ${{ github.ref }}
-                  TAG=${{ github.event.inputs.version }}
-                  if [[ ! -z "${{ github.event.inputs.version }}" ]]; then
-                    TAG=${{ github.event.inputs.version }}
-                  elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-                    TAG=$(echo ${{ github.ref }} | sed -e "s|^refs/tags/||")
-                  else
-                    exit 1
-                  fi
-                  echo Tag: $TAG
-                  gh release download $TAG -R databricks/databricks-vscode
-                  ls -lR
-                  echo "TAG=$TAG" >> $GITHUB_ENV
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: download release
+        run: |
+          set x
+          echo Version: ${{ github.event.inputs.version }}
+          echo REF: ${{ github.ref }}
+          TAG=${{ github.event.inputs.version }}
+          if [[ ! -z "${{ github.event.inputs.version }}" ]]; then
+            TAG=${{ github.event.inputs.version }}
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG=$(echo ${{ github.ref }} | sed -e "s|^refs/tags/||")
+          else
+            exit 1
+          fi
+          echo Tag: $TAG
+          gh release download $TAG -R databricks/databricks-vscode
+          ls -lR
+          echo "TAG=$TAG" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Install vcse
-              run: npm install -g @vscode/vsce
+      - name: Install vcse
+        run: npm install -g @vscode/vsce
 
-            - name: Publish to VS Code Marketplace
-              run: |
-                  vsce -V
-                  vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath databricks-*.vsix
+      - name: Publish to VS Code Marketplace
+        run: |
+          vsce -V
+          vsce publish -p ${{ secrets.VSCE_TOKEN }} --packagePath databricks-*.vsix
 
-              env:
-                  VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,43 +1,43 @@
 name: VSCode Extensions CI
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-        branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-    package:
-        name: Package Arm64 VSIX
-        runs-on: "macos-latest"
-        steps:
-            - uses: actions/checkout@v3
+  package:
+    name: Package Arm64 VSIX
+    runs-on: "macos-latest"
+    steps:
+      - uses: actions/checkout@v3
 
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  cache: "yarn"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
-            - run: yarn install --immutable
+      - run: yarn install --immutable
 
-            - run: yarn run package:cli:fetch
-              working-directory: packages/databricks-vscode
-              env:
-                  CLI_ARCH: darwin_amd64
-                  GH_TOKEN: ${{ github.token }}
+      - run: yarn run package:cli:fetch
+        working-directory: packages/databricks-vscode
+        env:
+          CLI_ARCH: darwin_amd64
+          GH_TOKEN: ${{ github.token }}
 
-            - name: Building packages
-              run: yarn run build
+      - name: Building packages
+        run: yarn run build
 
-            - run: mkdir -p packages/databricks-vscode/artifacts
+      - run: mkdir -p packages/databricks-vscode/artifacts
 
-            - name: Build VSIX
-              run: yarn package -o artifacts -t darwin-arm64
-              working-directory: packages/databricks-vscode
+      - name: Build VSIX
+        run: yarn package -o artifacts -t darwin-arm64
+        working-directory: packages/databricks-vscode
 
-            - name: Upload artifacts
-              uses: actions/upload-artifact@v3
-              with:
-                  name: VSIX artifacts
-                  path: packages/databricks-vscode/artifacts
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: VSIX artifacts
+          path: packages/databricks-vscode/artifacts

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,90 +1,90 @@
 name: Create Release PR
 
 on:
-    workflow_dispatch:
-        inputs:
-            extension_version:
-                description: "Extension Release version"
-                required: true
-                default: 0.0.0
-                type: string
+  workflow_dispatch:
+    inputs:
+      extension_version:
+        description: "Extension Release version"
+        required: true
+        default: 0.0.0
+        type: string
 
-    workflow_call:
-        inputs:
-            extension_version:
-                default: 0.0.0
-                type: string
+  workflow_call:
+    inputs:
+      extension_version:
+        default: 0.0.0
+        type: string
 
 jobs:
-    release-pr:
-        runs-on: "macos-latest"
-        strategy:
-            matrix:
-                node-version: [18.x]
-        steps:
-            - uses: actions/checkout@v3
-              with:
-                  fetch-depth: 0
+  release-pr:
+    runs-on: "macos-latest"
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-            - run: git fetch --all --tags
+      - run: git fetch --all --tags
 
-            - name: Check Extension Version
-              run: bash -c '$([[ "${{ inputs.extension_version }}" =~ ^([0-9]+\.){2}[0-9]+ ]])'
+      - name: Check Extension Version
+        run: bash -c '$([[ "${{ inputs.extension_version }}" =~ ^([0-9]+\.){2}[0-9]+ ]])'
 
-            - run: |
-                  git config --global user.name "releasebot"
-                  git config --global user.email "noreply@github.com"
+      - run: |
+          git config --global user.name "releasebot"
+          git config --global user.email "noreply@github.com"
 
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  cache: "yarn"
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
-            - run: yarn install --immutable
+      - run: yarn install --immutable
 
-            - name: Bump Extension version
-              if: ${{ inputs.extension_version != '0.0.0' }}
-              run: |
-                  yarn workspace databricks version ${{ inputs.extension_version }}
-                  yarn workspace @databricks/databricks-vscode-types version ${{ inputs.extension_version }}
-                  yarn version ${{ inputs.extension_version }}
+      - name: Bump Extension version
+        if: ${{ inputs.extension_version != '0.0.0' }}
+        run: |
+          yarn workspace databricks version ${{ inputs.extension_version }}
+          yarn workspace @databricks/databricks-vscode-types version ${{ inputs.extension_version }}
+          yarn version ${{ inputs.extension_version }}
 
-            - name: Changelog
-              id: create-changelog
-              run: |
-                  TMPFILE=$(mktemp /tmp/tmpfile.XXXX)
-                  bash scripts/generate_changelog.sh ${{ inputs.extension_version }} $TMPFILE
+      - name: Changelog
+        id: create-changelog
+        run: |
+          TMPFILE=$(mktemp /tmp/tmpfile.XXXX)
+          bash scripts/generate_changelog.sh ${{ inputs.extension_version }} $TMPFILE
 
-                  cat $TMPFILE >> $GITHUB_STEP_SUMMARY
+          cat $TMPFILE >> $GITHUB_STEP_SUMMARY
 
-                  echo "changelog_file=$TMPFILE" >> $GITHUB_OUTPUT
+          echo "changelog_file=$TMPFILE" >> $GITHUB_OUTPUT
 
-            - name: Generate notice file
-              if: ${{ inputs.extension_version != '0.0.0' }}
-              run: yarn run generate-notice
+      - name: Generate notice file
+        if: ${{ inputs.extension_version != '0.0.0' }}
+        run: yarn run generate-notice
 
-            - name: lint fix
-              if: ${{ inputs.extension_version != '0.0.0' }}
-              run: yarn run fix
+      - name: lint fix
+        if: ${{ inputs.extension_version != '0.0.0' }}
+        run: yarn run fix
 
-            - name: Create Branch
-              if: ${{ inputs.extension_version != '0.0.0' }}
-              id: create-branch
-              run: |
-                  COMMIT_SHA=$(git rev-parse --short HEAD)
-                  BRANCH=releases/draft-$COMMIT_SHA-$(date +%s)
-                  git checkout -b $BRANCH
-                  git add  **/CHANGELOG.md **/package.json package.json **/NOTICE.md
-                  git status
-                  git commit -m "Changelog & version bump to ${{ inputs.extension_version }}"
-                  git push origin HEAD
-                  echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT
+      - name: Create Branch
+        if: ${{ inputs.extension_version != '0.0.0' }}
+        id: create-branch
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          BRANCH=releases/draft-$COMMIT_SHA-$(date +%s)
+          git checkout -b $BRANCH
+          git add  **/CHANGELOG.md **/package.json package.json **/NOTICE.md
+          git status
+          git commit -m "Changelog & version bump to ${{ inputs.extension_version }}"
+          git push origin HEAD
+          echo "branch_name=$BRANCH" >> $GITHUB_OUTPUT
 
-            - name: Create PR
-              if: ${{ inputs.extension_version != '0.0.0'}}
-              run: |
-                  gh pr create -B main -H ${{ steps.create-branch.outputs.branch_name }} --title "Release: v${{ inputs.extension_version }}" --body-file ${{ steps.create-changelog.outputs.changelog_file }}
-                  rm ${{ steps.create-changelog.outputs.changelog_file }}
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create PR
+        if: ${{ inputs.extension_version != '0.0.0'}}
+        run: |
+          gh pr create -B main -H ${{ steps.create-branch.outputs.branch_name }} --title "Release: v${{ inputs.extension_version }}" --body-file ${{ steps.create-changelog.outputs.changelog_file }}
+          rm ${{ steps.create-changelog.outputs.changelog_file }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,7 +17,10 @@ on:
 
 jobs:
   release-pr:
-    runs-on: "macos-latest"
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
+
     strategy:
       matrix:
         node-version: [18.x]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,65 +1,65 @@
 name: Unit Tests
 
 on:
-    pull_request:
-        types: [opened, synchronize]
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
-    unit-test-extension:
-        name: Run unit tests
-        strategy:
-            fail-fast: false
-            matrix:
-                arch:
-                    - cli_arch: darwin_amd64
-                      os: macos-latest
-                    - cli_arch: windows_amd64
-                      os: windows-latest
-                node-version: [18.x]
-                vscode-version: [stable]
+  unit-test-extension:
+    name: Run unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - cli_arch: darwin_amd64
+            os: macos-latest
+          - cli_arch: windows_amd64
+            os: windows-latest
+        node-version: [18.x]
+        vscode-version: [stable]
 
-        runs-on: ${{ matrix.arch.os }}
+    runs-on: ${{ matrix.arch.os }}
 
+    env:
+      VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
+      CLI_ARCH: ${{ matrix.arch.cli_arch }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+
+      - name: Cache VSCode unit test runner
+        uses: actions/cache@v3
+        with:
+          path: /tmp/vscode-test-databricks
+          key: ${{ matrix.arch.cli_arch }}-${{ matrix.vscode-version }}-vscode-test
+
+      - run: yarn install --immutable
+
+      - name: Prettier and Linting
+        run: yarn run test:lint
+        working-directory: packages/databricks-vscode
+
+      - name: Fetching Databricks CLI
+        run: yarn run package:cli:fetch
+        working-directory: packages/databricks-vscode
         env:
-            VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
-            CLI_ARCH: ${{ matrix.arch.cli_arch }}
+          GH_TOKEN: ${{ github.token }}
 
-        defaults:
-            run:
-                shell: bash
+      - name: Building packages
+        run: yarn run build
 
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
-              with:
-                  node-version: ${{ matrix.node-version }}
-                  cache: "yarn"
-
-            - name: Cache VSCode unit test runner
-              uses: actions/cache@v3
-              with:
-                  path: /tmp/vscode-test-databricks
-                  key: ${{ matrix.arch.cli_arch }}-${{ matrix.vscode-version }}-vscode-test
-
-            - run: yarn install --immutable
-
-            - name: Prettier and Linting
-              run: yarn run test:lint
-              working-directory: packages/databricks-vscode
-
-            - name: Fetching Databricks CLI
-              run: yarn run package:cli:fetch
-              working-directory: packages/databricks-vscode
-              env:
-                  GH_TOKEN: ${{ github.token }}
-
-            - name: Building packages
-              run: yarn run build
-
-            - name: Unit Tests with Coverage
-              uses: coactions/setup-xvfb@v1
-              with:
-                  run: yarn run test:cov
-                  working-directory: packages/databricks-vscode
+      - name: Unit Tests with Coverage
+        uses: coactions/setup-xvfb@v1
+        with:
+          run: yarn run test:cov
+          working-directory: packages/databricks-vscode

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   update-cli-version:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-deco-testing-runner-group
+      labels: ubuntu-latest-deco
 
     strategy:
       matrix:

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-        matrix:
-            node-version: [18.x]
+      matrix:
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,5 +34,5 @@ jobs:
           body: Update Databricks CLI to v${{ github.event.inputs.version }}
           committer: GitHub <noreply@github.com>
           branch: update-cli-v${{ github.event.inputs.version }}
-          title: 'Update Databricks CLI to v${{ github.event.inputs.version }}'
+          title: "Update Databricks CLI to v${{ github.event.inputs.version }}"
           draft: false


### PR DESCRIPTION
This fixes an issue with newly configured IP access lists.

Beware: the workflow in `push.yml` still runs on `macos-latest` and is the only workflow I didn't update.

Note: the YAML files were formatted differently from the other repositories; please review with "hide whitespace".

A potential follow-up is to configure and run Prettier on `.github` everywhere.