### PR TITLE
Fix az login on Windows under cmd.exe

### DIFF
--- a/packages/databricks-vscode/scripts/fetch-databricks-cli.sh
+++ b/packages/databricks-vscode/scripts/fetch-databricks-cli.sh
@@ -15,7 +15,7 @@ fi
 
 CLI_DIR=$(mktemp -d -t databricks-XXXXXXXXXX)
 pushd $CLI_DIR
-gh release download v${CLI_VERSION} --pattern "databricks_cli_${CLI_VERSION}_${CLI_ARCH}.zip" --repo databricks/cli
+curl -L -O "https://github.com/databricks/cli/releases/download/v${CLI_VERSION}/databricks_cli_${CLI_VERSION}_${CLI_ARCH}.zip"
 unzip databricks_*_$CLI_ARCH.zip
 rm databricks_*_$CLI_ARCH.zip
 ls

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -37,14 +37,8 @@ function getEscapedCommandAndAgrs(
         args = [
             "/d", // Disables execution of AutoRun commands, which are like .bashrc commands.
             "/c", // Carries out the command specified by <string> and then exits the command processor.
+            `""${cmd}" ${cmdArgs.map((a) => `"${a}"`).join(" ")}"`,
         ];
-        const shell = process.env.ComSpec || "cmd.exe";
-        // Fewer quotes are needed for arguments in the CMD.exe than in PowerShell
-        if (shell.includes("cmd.exe")) {
-            args.push(`"${cmd} ${cmdArgs.map((a) => `${a}`).join(" ")}"`);
-        } else {
-            args.push(`""${cmd}" ${cmdArgs.map((a) => `"${a}"`).join(" ")}"`);
-        }
         cmd = "cmd.exe";
         options = {...options, windowsVerbatimArguments: true};
     }

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -39,7 +39,7 @@ function getEscapedCommandAndAgrs(
             "/c", // Carries out the command specified by <string> and then exits the command processor.
         ];
         const shell = process.env.ComSpec || "cmd.exe";
-        // Fewer quotes are needed for arguments in the cmd.exe than in PowerShell
+        // Fewer quotes are needed for arguments in the CMD.exe than in PowerShell
         if (shell.includes("cmd.exe")) {
             args.push(`"${cmd} ${cmdArgs.map((a) => `${a}`).join(" ")}"`);
         } else {

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -33,11 +33,18 @@ function getEscapedCommandAndAgrs(
     options: SpawnOptionsWithoutStdio
 ) {
     if (process.platform === "win32") {
+        const cmdArgs = args.slice();
         args = [
-            "/d", //Disables execution of AutoRun commands, which are like .bashrc commands.
-            "/c", //Carries out the command specified by <string> and then exits the command processor.
-            `""${cmd}" ${args.map((a) => `"${a}"`).join(" ")}"`,
+            "/d", // Disables execution of AutoRun commands, which are like .bashrc commands.
+            "/c", // Carries out the command specified by <string> and then exits the command processor.
         ];
+        const shell = process.env.ComSpec || "cmd.exe";
+        // Fewer quotes are needed for arguments in the cmd.exe than in PowerShell
+        if (shell.includes("cmd.exe")) {
+            args.push(`"${cmd} ${cmdArgs.map((a) => `${a}`).join(" ")}"`);
+        } else {
+            args.push(`""${cmd}" ${cmdArgs.map((a) => `"${a}"`).join(" ")}"`);
+        }
         cmd = "cmd.exe";
         options = {...options, windowsVerbatimArguments: true};
     }

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -9,7 +9,7 @@ import {Loggers} from "../../logger";
 import {AzureCliAuthProvider} from "./AuthProvider";
 import {orchestrate, OrchestrationLoopError, Step} from "./orchestrate";
 import {ShellUtils} from "../../utils";
-import {execFile} from "../../cli/CliWrapper";
+import {cancellableExecFile} from "../../cli/CliWrapper";
 import {
     FileNotFoundException,
     isFileNotFound,
@@ -40,7 +40,12 @@ async function execFileWithShell(
     stderr: string;
 }> {
     try {
-        return await execFile(cmd, args, {shell: true}, cancellationToken);
+        return await cancellableExecFile(
+            cmd,
+            args,
+            {shell: true},
+            cancellationToken
+        );
     } catch (e) {
         if (isFileNotFound(e)) {
             throw new FileNotFoundException(e.message);


### PR DESCRIPTION
## Changes
If the default windows shell is cmd.exe, the az login fails due to our handling of the command arguments.

We've added the arg handling to fix issues when the vscode is installed in the folder that contains spaces, and so our databricks cli calls were failing. AZ cli doesn't have the same problems, as it's installed separately from the extension, so here I'm reverting back to using execFile without custom argument handling.

Fixes https://github.com/databricks/databricks-vscode/issues/1468


<!-- Summary of your changes that are easy to understand -->

## Tests

On win vm
