### PR TITLE
Show all dabs resources in the explorer panel

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1125,7 +1125,7 @@
         "useYarn": false
     },
     "cli": {
-        "version": "0.236.0"
+        "version": "0.238.0"
     },
     "scripts": {
         "vscode:prepublish": "rm -rf out && yarn run package:compile && yarn run package:wrappers:write && yarn run package:jupyter-init-script:write && yarn run package:copy-webview-toolkit && yarn run generate-telemetry",

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/UnknownResourceTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/UnknownResourceTreeNode.ts
@@ -1,0 +1,90 @@
+import {ThemeIcon} from "vscode";
+import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
+import {
+    BundleResourceExplorerResourceKey,
+    BundleResourceExplorerTreeItem,
+    BundleResourceExplorerTreeNode,
+} from "./types";
+import {ContextUtils} from "./utils";
+import {DecorationUtils} from "../utils";
+
+type UnknownResourcesMap = Map<
+    BundleResourceExplorerResourceKey,
+    BundleResourceExplorerTreeNode[]
+>;
+
+export class UnknownResourceTreeNode implements BundleResourceExplorerTreeNode {
+    readonly type = "unknown_resource";
+
+    constructor(
+        public readonly resourceType: BundleResourceExplorerResourceKey,
+        public readonly resourceKey: string,
+        public readonly data: any,
+        public parent?: BundleResourceExplorerTreeNode
+    ) {}
+
+    get url(): string | undefined {
+        return this.data.url;
+    }
+
+    getTreeItem(): BundleResourceExplorerTreeItem {
+        const name =
+            this.data.name ??
+            this.data.display_name ??
+            this.data.table_name ??
+            this.data.cluster_name ??
+            this.data.key ??
+            this.resourceKey;
+
+        return {
+            label: name,
+            iconPath: new ThemeIcon("file"),
+            contextValue: ContextUtils.getContextString({
+                nodeType: "unknown_resource",
+                resourceType: this.resourceType,
+                hasUrl: this.url !== undefined,
+                modifiedStatus: this.data.modified_status,
+            }),
+            resourceUri: DecorationUtils.getModifiedStatusDecoration(
+                name,
+                this.data.modified_status
+            ),
+        };
+    }
+
+    getChildren(): BundleResourceExplorerTreeNode[] {
+        return [];
+    }
+
+    static getRootGroups(
+        bundleRemoteState: BundleRemoteState,
+        knownResourceTypes: readonly string[]
+    ): UnknownResourcesMap {
+        const allResources = bundleRemoteState.resources || {};
+        const allTypes = Object.keys(
+            allResources
+        ) as BundleResourceExplorerResourceKey[];
+        const unknownTypes = allTypes.filter(
+            (type) =>
+                !knownResourceTypes.includes(type) &&
+                Object.keys(allResources[type] || {}).length > 0
+        ) as BundleResourceExplorerResourceKey[];
+
+        return unknownTypes.reduce((result, type) => {
+            const resources = allResources[type];
+            if (resources) {
+                result.set(
+                    type,
+                    Object.keys(resources).map((key) => {
+                        return new UnknownResourceTreeNode(
+                            type,
+                            key,
+                            resources[key]
+                        );
+                    })
+                );
+            }
+            return result;
+        }, new Map() as UnknownResourcesMap);
+    }
+}

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
@@ -20,6 +20,7 @@ export interface BundleResourceExplorerTreeNode {
         | "pipeline_datasets"
         | "pipeline_dataset"
         | "resource_type_header"
+        | "unknown_resource"
         | "task"
         | "job_run_status"
         | "task_header";
@@ -29,3 +30,8 @@ export interface BundleResourceExplorerTreeNode {
         | BundleResourceExplorerTreeNode[]
         | Promise<BundleResourceExplorerTreeNode[]>;
 }
+
+export const KNOWN_RESOURCE_TYPES: BundleResourceExplorerTreeNode["type"][] = [
+    "jobs",
+    "pipelines",
+];


### PR DESCRIPTION

## Changes

"Unknown" resources are shown with the "created/deleted" icons and external links (if they have been deployed already).

<img width="610" alt="Screenshot 2025-01-17 at 11 51 54" src="https://github.com/user-attachments/assets/aa8f030b-8afa-422a-92c7-df38e308199f" />
<img width="633" alt="Screenshot 2025-01-17 at 11 45 11" src="https://github.com/user-attachments/assets/e974a660-c495-47d8-a0ba-71aba282f4e9" />


## Tests

<!-- How is this tested? -->
