### PR TITLE
Add serverless support to the extension

### DIFF
--- a/.github/workflows/create-build-artifacts.yml
+++ b/.github/workflows/create-build-artifacts.yml
@@ -14,10 +14,10 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "yarn"
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BUILD_PLATFORM_ARCH: linux_amd64
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: databricks
           path: "packages/databricks-vscode/*.vsix"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,8 +21,8 @@ jobs:
       labels: ubuntu-latest-deco
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         id: download
         with:
           path: build

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
       labels: ubuntu-latest-deco
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: packages/databricks-vscode
 

--- a/.github/workflows/publish-to-openvsx.yml
+++ b/.github/workflows/publish-to-openvsx.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/publish-to-vscode.yml
+++ b/.github/workflows/publish-to-vscode.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,12 +11,12 @@ jobs:
     name: Package Arm64 VSIX
     runs-on: "macos-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           cache: "yarn"
 
       - run: yarn install --immutable
@@ -37,7 +37,7 @@ jobs:
         working-directory: packages/databricks-vscode
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VSIX artifacts
           path: packages/databricks-vscode/artifacts

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "noreply@github.com"
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,16 +29,16 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
 
       - name: Cache VSCode unit test runner
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/vscode-test-databricks
           key: ${{ matrix.arch.cli_arch }}-${{ matrix.vscode-version }}-vscode-test

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -124,7 +124,7 @@
                 "command": "databricks.run.runEditorContents",
                 "title": "Upload and Run File",
                 "category": "Databricks",
-                "enablement": "!inDebugMode && databricks.context.activated && databricks.context.loggedIn",
+                "enablement": "!inDebugMode && databricks.context.activated && databricks.context.loggedIn && !databricks.context.serverless",
                 "icon": {
                     "dark": "resources/dark/databricks-run-icon.svg",
                     "light": "resources/light/databricks-run-icon.svg"
@@ -778,7 +778,7 @@
                 },
                 {
                     "command": "databricks.run.runEditorContents",
-                    "when": "databricks.context.activated && resourceLangId == python",
+                    "when": "databricks.context.activated && resourceLangId == python && !databricks.context.serverless",
                     "group": "2_remote@1"
                 },
                 {

--- a/packages/databricks-vscode/resources/webview-ui/job.html
+++ b/packages/databricks-vscode/resources/webview-ui/job.html
@@ -44,8 +44,9 @@
             .vscode-button:hover {
                 background-color: var(--vscode-button-hoverBackground);
             }
-            .vscode-disabled {
-                color: var(--vscode-disabledForeground);
+            .vscode-disabled,
+            .vscode-button.vscode-disabled:hover {
+                background-color: var(--vscode-disabledForeground);
             }
 
             li .vscode-button {
@@ -213,7 +214,7 @@
                         </span>
                     </li>
                     <li>
-                        <span class="label">Cluster:</span>
+                        <span class="label">Compute:</span>
                         <span class="value" aria-label="cluster">
                             <vscode-link id="run-cluster" href="#"
                                 >N/A</vscode-link
@@ -306,7 +307,7 @@
                         .getElementById("run-cluster")
                         .setAttribute("href", details.clusterUrl);
                     document.getElementById("run-cluster").innerText =
-                        details.clusterId;
+                        details.serverless ? "Serverless" : details.clusterId;
 
                     document.getElementById("run-started").innerText =
                         details.started;

--- a/packages/databricks-vscode/src/cli/SyncTasks.test.ts
+++ b/packages/databricks-vscode/src/cli/SyncTasks.test.ts
@@ -18,6 +18,7 @@ describe(__filename, () => {
     beforeEach(() => {
         connection = mock<ConnectionManager>();
         when(connection.metadataServiceUrl).thenReturn("http://localhost:1234");
+        when(connection.serverless).thenReturn(false);
         cli = mock<CliWrapper>();
     });
 

--- a/packages/databricks-vscode/src/cli/SyncTasks.ts
+++ b/packages/databricks-vscode/src/cli/SyncTasks.ts
@@ -303,7 +303,7 @@ export class LazyCustomSyncTerminal extends CustomSyncTerminal {
                 ...EnvVarGenerators.removeUndefinedKeys(
                     EnvVarGenerators.getCommonDatabricksEnvVars(
                         this.connection,
-                        this.configModel
+                        this.configModel.target
                     )
                 ),
                 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -141,7 +141,12 @@ export class ConnectionCommands implements Disposable {
             quickPick.canSelectMany = false;
             const items: QuickPickItem[] = [
                 {
-                    label: "Create New Cluster",
+                    label: "$(cloud) Serverless",
+                    detail: `Run files as Workflows or use Databricks Connect without a dedicated cluster`,
+                    alwaysShow: false,
+                },
+                {
+                    label: "$(repo-create) Create New Cluster",
                     detail: `Open Databricks in the browser and create a new cluster`,
                     alwaysShow: false,
                 },
@@ -183,6 +188,8 @@ export class ConnectionCommands implements Disposable {
                 if ("cluster" in selectedItem) {
                     const cluster = selectedItem.cluster;
                     await this.connectionManager.attachCluster(cluster.id);
+                } else if (selectedItem.label === "$(cloud) Serverless") {
+                    await this.connectionManager.enableServerless();
                 } else {
                     await UrlUtils.openExternal(
                         `${

--- a/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
@@ -9,13 +9,19 @@ import {WorkspaceFolderManager} from "../../vscode-objs/WorkspaceFolderManager";
 export type OverrideableConfigState = {
     authProfile?: string;
     clusterId?: string;
+    serverless?: boolean;
     useClusterOverride?: boolean;
 };
 
 export function isOverrideableConfigKey(
     key: string
 ): key is keyof OverrideableConfigState {
-    return ["authProfile", "clusterId", "useClusterOverride"].includes(key);
+    return [
+        "authProfile",
+        "clusterId",
+        "useClusterOverride",
+        "serverless",
+    ].includes(key);
 }
 
 async function safeRead(filePath: Uri) {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -360,7 +360,10 @@ export async function activate(
     const clusterModel = new ClusterModel(connectionManager);
 
     const environmentDependenciesInstaller =
-        new EnvironmentDependenciesInstaller(pythonExtensionWrapper);
+        new EnvironmentDependenciesInstaller(
+            connectionManager,
+            pythonExtensionWrapper
+        );
     const featureManager = new FeatureManager<FeatureId>([]);
     featureManager.registerFeature(
         "environment.dependencies",

--- a/packages/databricks-vscode/src/file-managers/DatabricksEnvFileManager.ts
+++ b/packages/databricks-vscode/src/file-managers/DatabricksEnvFileManager.ts
@@ -148,7 +148,7 @@ export class DatabricksEnvFileManager implements Disposable {
     private getDatabricksEnvVars() {
         return EnvVarGenerators.getCommonDatabricksEnvVars(
             this.connectionManager,
-            this.configModel
+            this.configModel.target
         );
     }
 

--- a/packages/databricks-vscode/src/file-managers/DatabricksEnvFileManager.ts
+++ b/packages/databricks-vscode/src/file-managers/DatabricksEnvFileManager.ts
@@ -145,7 +145,7 @@ export class DatabricksEnvFileManager implements Disposable {
         );
     }
 
-    private getDatabrickseEnvVars() {
+    private getDatabricksEnvVars() {
         return EnvVarGenerators.getCommonDatabricksEnvVars(
             this.connectionManager,
             this.configModel
@@ -175,7 +175,7 @@ export class DatabricksEnvFileManager implements Disposable {
     async getEnv() {
         return Object.fromEntries(
             Object.entries({
-                ...(this.getDatabrickseEnvVars() || {}),
+                ...(this.getDatabricksEnvVars() || {}),
                 ...((await EnvVarGenerators.getDbConnectEnvVars(
                     this.connectionManager,
                     this.projectRoot,

--- a/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
+++ b/packages/databricks-vscode/src/language/MsPythonExtensionWrapper.ts
@@ -14,6 +14,7 @@ import {Mutex} from "../locking";
 import * as childProcess from "node:child_process";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {execFile} from "../cli/CliWrapper";
+import fs from "node:fs";
 
 export class MsPythonExtensionWrapper implements Disposable {
     public readonly api: MsPythonExtensionApi;
@@ -85,11 +86,13 @@ export class MsPythonExtensionWrapper implements Disposable {
     }
 
     get pythonEnvironment() {
-        return this.api.environments?.resolveEnvironment(
-            this.api.environments?.getActiveEnvironmentPath(
-                this.workspaceFolderManager.activeProjectUri
-            )
+        const env = this.api.environments?.getActiveEnvironmentPath(
+            this.workspaceFolderManager.activeProjectUri
         );
+        if (!env || !fs.existsSync(env.path)) {
+            return undefined;
+        }
+        return this.api.environments?.resolveEnvironment(env);
     }
 
     async runWithOutput(

--- a/packages/databricks-vscode/src/run/DatabricksWorkflowDebugAdapter.ts
+++ b/packages/databricks-vscode/src/run/DatabricksWorkflowDebugAdapter.ts
@@ -184,13 +184,6 @@ export class DatabricksWorkflowDebugSession extends LoggingDebugSession {
             return this.onError();
         }
 
-        const cluster = this.connection.cluster;
-        const workspaceClient = this.connection.workspaceClient;
-
-        if (!cluster || !workspaceClient) {
-            promptForClusterAttach();
-            return this.onError();
-        }
         const syncDestinationMapper = this.connection.syncDestinationMapper;
         if (!syncDestinationMapper) {
             return this.onError(
@@ -198,10 +191,21 @@ export class DatabricksWorkflowDebugSession extends LoggingDebugSession {
             );
         }
 
-        await cluster.refresh();
-        if (!["RUNNING", "RESIZING"].includes(cluster.state)) {
-            promptForClusterStart();
-            return this.onError();
+        const serverless = this.connection.serverless;
+        const cluster = this.connection.cluster;
+        const workspaceClient = this.connection.workspaceClient;
+
+        if (!serverless) {
+            if (!cluster || !workspaceClient) {
+                promptForClusterAttach();
+                return this.onError();
+            }
+
+            await cluster.refresh();
+            if (!["RUNNING", "RESIZING"].includes(cluster.state)) {
+                promptForClusterStart();
+                return this.onError();
+            }
         }
 
         await this.workflowRunner.run({

--- a/packages/databricks-vscode/src/run/WorkflowOutputPanel.ts
+++ b/packages/databricks-vscode/src/run/WorkflowOutputPanel.ts
@@ -92,7 +92,7 @@ export class WorkflowOutputPanel {
     }
 
     async updateState(
-        cluster: Cluster,
+        cluster: Cluster | undefined,
         runState: jobs.RunLifeCycleState,
         run: WorkflowRun
     ) {
@@ -108,7 +108,7 @@ export class WorkflowOutputPanel {
         const taskCluster = task.cluster_instance;
 
         let clusterUrl = "#";
-        if (taskCluster) {
+        if (taskCluster && cluster) {
             clusterUrl = await cluster.getSparkUiUrl(
                 taskCluster.spark_context_id
             );
@@ -120,6 +120,7 @@ export class WorkflowOutputPanel {
                 {
                     runUrl: run.runPageUrl,
                     runId: task.run_id,
+                    serverless: cluster === undefined,
                     clusterUrl,
                     clusterId: taskCluster?.cluster_id || "-",
                     started: task.start_time

--- a/packages/databricks-vscode/src/run/WorkflowRunner.ts
+++ b/packages/databricks-vscode/src/run/WorkflowRunner.ts
@@ -75,7 +75,7 @@ export class WorkflowRunner implements Disposable {
         program: LocalUri;
         parameters?: Record<string, string>;
         args?: Array<string>;
-        cluster: Cluster;
+        cluster?: Cluster;
         syncDestinationMapper: SyncDestinationMapper;
         token?: CancellationToken;
     }) {
@@ -153,8 +153,11 @@ export class WorkflowRunner implements Disposable {
                         : remoteFilePath;
                 }
                 panel.showExportedRun(
-                    await cluster.runNotebookAndWait({
+                    await WorkflowRun.runNotebookAndWait({
+                        client: this.connectionManager.workspaceClient!
+                            .apiClient,
                         path: remoteFilePath,
+                        clusterId: cluster?.id,
                         parameters,
                         onProgress: (
                             state: jobs.RunLifeCycleState,
@@ -178,7 +181,9 @@ export class WorkflowRunner implements Disposable {
                               syncDestinationMapper.remoteUri
                           )
                         : undefined;
-                const response = await cluster.runPythonAndWait({
+                const response = await WorkflowRun.runPythonAndWait({
+                    client: this.connectionManager.workspaceClient!.apiClient,
+                    clusterId: cluster?.id,
                     path: wrappedFile ? wrappedFile.path : originalFileUri.path,
                     args: args ?? [],
                     onProgress: (

--- a/packages/databricks-vscode/src/sdk-extensions/WorkflowRun.integ.ts
+++ b/packages/databricks-vscode/src/sdk-extensions/WorkflowRun.integ.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 import {jobs} from "@databricks/databricks-sdk";
 import {IntegrationTestSetup} from "./test/IntegrationTestSetup";
-import {Cluster} from "./Cluster";
 import {WorkflowRun} from "./WorkflowRun";
 
 describe(__filename, function () {
@@ -14,11 +13,6 @@ describe(__filename, function () {
     });
 
     it("should run a python job", async () => {
-        const cluster = await Cluster.fromClusterId(
-            integSetup.client.apiClient,
-            integSetup.cluster.id
-        );
-
         const dbfsApi = integSetup.client.dbfs;
         const jobPath = `/tmp/sdk-js-integ-${integSetup.testRunId}.py`;
 
@@ -32,7 +26,9 @@ describe(__filename, function () {
 
         try {
             const progress: Array<WorkflowRun> = [];
-            const output = await cluster.runPythonAndWait({
+            const output = await WorkflowRun.runPythonAndWait({
+                client: integSetup.client.apiClient,
+                clusterId: integSetup.cluster.id,
                 path: `dbfs:${jobPath}`,
                 onProgress: (
                     _state: jobs.RunLifeCycleState,
@@ -54,11 +50,6 @@ describe(__filename, function () {
     });
 
     it("should run a notebook job", async () => {
-        const cluster = await Cluster.fromClusterId(
-            integSetup.client.apiClient,
-            integSetup.cluster.id
-        );
-
         const jobPath = `/tmp/js-sdk-jobs-tests/sdk-js-integ-${integSetup.testRunId}.py`;
         await integSetup.client.workspace.mkdirs({
             path: "/tmp/js-sdk-jobs-tests",
@@ -76,7 +67,9 @@ describe(__filename, function () {
 
         try {
             const progress: Array<WorkflowRun> = [];
-            const output = await cluster.runNotebookAndWait({
+            const output = await WorkflowRun.runNotebookAndWait({
+                client: integSetup.client.apiClient,
+                clusterId: integSetup.cluster.id,
                 path: `${jobPath}`,
                 onProgress: (
                     _state: jobs.RunLifeCycleState,
@@ -104,11 +97,6 @@ describe(__filename, function () {
     });
 
     it("should run a broken notebook job", async () => {
-        const cluster = await Cluster.fromClusterId(
-            integSetup.client.apiClient,
-            integSetup.cluster.id
-        );
-
         const jobPath = `/tmp/js-sdk-jobs-tests/sdk-js-integ-${integSetup.testRunId}.py`;
         await integSetup.client.workspace.mkdirs({
             path: "/tmp/js-sdk-jobs-tests",
@@ -133,7 +121,9 @@ print("Cell 2")`
 
         try {
             const progress: Array<WorkflowRun> = [];
-            const output = await cluster.runNotebookAndWait({
+            const output = await WorkflowRun.runNotebookAndWait({
+                client: integSetup.client.apiClient,
+                clusterId: integSetup.cluster.id,
                 path: `${jobPath}`,
                 onProgress: (
                     _state: jobs.RunLifeCycleState,

--- a/packages/databricks-vscode/src/test/runTest.ts
+++ b/packages/databricks-vscode/src/test/runTest.ts
@@ -37,7 +37,7 @@ async function main() {
         });
     } catch (err) {
         // eslint-disable-next-line no-console
-        console.error("Failed to run tests");
+        console.error(err);
         process.exit(1);
     }
 }

--- a/packages/databricks-vscode/src/ui/configuration-view/ClusterComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/ClusterComponent.ts
@@ -93,9 +93,23 @@ export class ClusterComponent extends BaseComponent {
 
     @onError({popup: true})
     private async getRoot(): Promise<ConfigurationTreeItem[]> {
-        const config = await this.configModel.get("clusterId");
+        if (this.connectionManager.serverless) {
+            return [
+                {
+                    label: "Serverless",
+                    collapsibleState: TreeItemCollapsibleState.None,
+                    contextValue: getContextValue("serverless"),
+                    iconPath: new ThemeIcon(
+                        "cloud",
+                        new ThemeColor("debugIcon.startForeground")
+                    ),
+                    id: TREE_ICON_ID,
+                },
+            ];
+        }
 
-        if (config === undefined) {
+        const configClusterId = await this.configModel.get("clusterId");
+        if (configClusterId === undefined) {
             // Cluster is not set in bundle and override
             // We are logged in -> Select cluster prompt
             return [

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -66,7 +66,7 @@ export class EnvironmentComponent extends BaseComponent {
         );
         const children: ConfigurationTreeItem[] = [];
         for (const [id, step] of environmentState.steps) {
-            if (!step.available) {
+            if (!step.available && step.title) {
                 children.push({
                     contextValue: getItemContext(id, false),
                     label: step.title,

--- a/packages/databricks-vscode/src/utils/envVarGenerators.test.ts
+++ b/packages/databricks-vscode/src/utils/envVarGenerators.test.ts
@@ -6,6 +6,7 @@ import {ApiClient, Config} from "@databricks/databricks-sdk";
 import {Cluster} from "../sdk-extensions";
 import {
     getAuthEnvVars,
+    getCommonDatabricksEnvVars,
     getDbConnectEnvVars,
     getProxyEnvVars,
 } from "./envVarGenerators";
@@ -82,6 +83,37 @@ describe(__filename, () => {
             HTTP_PROXY: "http://example.com",
             HTTPS_PROXY: "https://example.com",
             NO_PROXY: "https://example.com",
+        });
+    });
+
+    it("should generate env vars with expected cluster id", () => {
+        const actual = getCommonDatabricksEnvVars(
+            instance(mockConnectionManager),
+            "target"
+        );
+        assert.deepEqual(actual, {
+            DATABRICKS_BUNDLE_TARGET: "target",
+            DATABRICKS_CLUSTER_ID: mockClusterId,
+            DATABRICKS_SERVERLESS_COMPUTE_ID: undefined,
+            HTTP_PROXY: undefined,
+            HTTPS_PROXY: undefined,
+            NO_PROXY: undefined,
+        });
+    });
+
+    it("should generate env vars with serverless", () => {
+        when(mockConnectionManager.serverless).thenReturn(true);
+        const actual = getCommonDatabricksEnvVars(
+            instance(mockConnectionManager),
+            "target"
+        );
+        assert.deepEqual(actual, {
+            DATABRICKS_BUNDLE_TARGET: "target",
+            DATABRICKS_CLUSTER_ID: undefined,
+            DATABRICKS_SERVERLESS_COMPUTE_ID: "auto",
+            HTTP_PROXY: undefined,
+            HTTPS_PROXY: undefined,
+            NO_PROXY: undefined,
         });
     });
 

--- a/packages/databricks-vscode/src/utils/envVarGenerators.ts
+++ b/packages/databricks-vscode/src/utils/envVarGenerators.ts
@@ -3,7 +3,6 @@ import {readFile} from "fs/promises";
 import {ExtensionContext, Uri} from "vscode";
 import {logging, Headers} from "@databricks/databricks-sdk";
 import {ConnectionManager} from "../configuration/ConnectionManager";
-import {ConfigModel} from "../configuration/models/ConfigModel";
 import {TerraformMetadata} from "./terraformUtils";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -71,12 +70,12 @@ export function getAuthEnvVars(connectionManager: ConnectionManager) {
 
 export function getCommonDatabricksEnvVars(
     connectionManager: ConnectionManager,
-    configModel: ConfigModel
+    bundleTarget?: string
 ) {
     const cluster = connectionManager.cluster;
     /* eslint-disable @typescript-eslint/naming-convention */
     return {
-        DATABRICKS_BUNDLE_TARGET: configModel.target,
+        DATABRICKS_BUNDLE_TARGET: bundleTarget,
         ...(getAuthEnvVars(connectionManager) || {}),
         ...(getProxyEnvVars() || {}),
         DATABRICKS_CLUSTER_ID: connectionManager.serverless

--- a/packages/databricks-vscode/src/utils/envVarGenerators.ts
+++ b/packages/databricks-vscode/src/utils/envVarGenerators.ts
@@ -79,7 +79,12 @@ export function getCommonDatabricksEnvVars(
         DATABRICKS_BUNDLE_TARGET: configModel.target,
         ...(getAuthEnvVars(connectionManager) || {}),
         ...(getProxyEnvVars() || {}),
-        DATABRICKS_CLUSTER_ID: cluster?.id,
+        DATABRICKS_CLUSTER_ID: connectionManager.serverless
+            ? undefined
+            : cluster?.id,
+        DATABRICKS_SERVERLESS_COMPUTE_ID: connectionManager.serverless
+            ? "auto"
+            : undefined,
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 }

--- a/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
+++ b/packages/databricks-vscode/src/vscode-objs/CustomWhenContext.ts
@@ -110,4 +110,12 @@ export class CustomWhenContext {
             value
         );
     }
+
+    setServerless(value: boolean) {
+        commands.executeCommand(
+            "setContext",
+            "databricks.context.serverless",
+            value
+        );
+    }
 }


### PR DESCRIPTION
## Changes
- Cluster quick-pick now has a new "Serverless" option
- Connection manager now has a new `serverless` mode
- EnvironmentDependenciesVerifier doesn't force a cluster if serverless mode is enabled
   - But if now requires a higher Databricks Connect version
   - EnvironmentDependenciesInstaller is also updated to install a more appropriate dbconnect version
- We now inject DATABRICKS_SERVERLESS_COMPUTE_ID env var when serverless is enabled
- Run file as Workflow command automatically
   - The run logic was moved from Cluster to WorkflowRun
   - Updated workflow output panel UI to show serverless when it's enabled
- Upload and run file command is disabled in the serverless mode
- Fix for the python wrapper to avoid exceptions when .venv folder is removed at runtime

Follow ups:
- Automatically enable serverless mode if the selected .databrickscfg profile has `serverless_compute_id = auto`
- Figure out if we can check if a workspace has serverless enabled before offering to use it
- Integ tests in a serverless-enabled environment (and we should finally cover dbconnect logic)


<!-- Summary of your changes that are easy to understand -->

## Tests

Manual, a few new unit tests, integ tests will be in a follow-up
