### PR TITLE
Always show serverless compute option in the cluster dropwodn

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -139,6 +139,11 @@ export class ConnectionCommands implements Disposable {
             quickPick.canSelectMany = false;
             const items: QuickPickItem[] = [
                 {
+                    label: "$(cloud) Serverless",
+                    detail: `Run files as Workflows or use Databricks Connect without a dedicated cluster`,
+                    alwaysShow: false,
+                },
+                {
                     label: "$(repo-create) Create New Cluster",
                     detail: `Open Databricks in the browser and create a new cluster`,
                     alwaysShow: false,
@@ -148,15 +153,6 @@ export class ConnectionCommands implements Disposable {
                     kind: QuickPickItemKind.Separator,
                 },
             ];
-            if (
-                this.connectionManager.databricksWorkspace?.isServerlessEnabled
-            ) {
-                items.unshift({
-                    label: "$(cloud) Serverless",
-                    detail: `Run files as Workflows or use Databricks Connect without a dedicated cluster`,
-                    alwaysShow: false,
-                });
-            }
             quickPick.items = items;
 
             this.clusterModel.refresh();

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -156,10 +156,7 @@ export class ConnectionManager implements Disposable {
         const serverless = await this.configModel.get("serverless");
         const computeId = this.apiClient?.config.serverlessComputeId;
         const autoEnable =
-            serverless === undefined &&
-            !this.cluster &&
-            computeId === "auto" &&
-            this.databricksWorkspace?.isServerlessEnabled;
+            serverless === undefined && !this.cluster && computeId === "auto";
         if (serverless || autoEnable) {
             await this.enableServerless();
         } else {

--- a/packages/databricks-vscode/src/configuration/DatabricksWorkspace.test.ts
+++ b/packages/databricks-vscode/src/configuration/DatabricksWorkspace.test.ts
@@ -16,7 +16,6 @@ describe(__filename, () => {
         const wsConf = {
             enableProjectTypeInWorkspace: "true",
             enableWorkspaceFilesystem: "dbr11.0+",
-            enableServerless: true,
         } as const;
         const authProvider = new ProfileAuthProvider(
             new URL("https://fabian.databricks.com"),
@@ -35,7 +34,6 @@ describe(__filename, () => {
         assert.equal(dbWorkspace.id, "workspace-id");
         assert(dbWorkspace.isFilesInReposEnabled);
         assert(dbWorkspace.isFilesInReposEnabled);
-        assert(dbWorkspace.isServerlessEnabled);
 
         assert(
             dbWorkspace.supportFilesInReposForCluster({

--- a/packages/databricks-vscode/src/configuration/DatabricksWorkspace.ts
+++ b/packages/databricks-vscode/src/configuration/DatabricksWorkspace.ts
@@ -6,23 +6,12 @@ import {Loggers} from "../logger";
 import {AuthProvider} from "./auth/AuthProvider";
 import {RemoteUri} from "../sync/SyncDestination";
 
-type ServerlessEnablementResponse = {
-    setting?: {
-        value?: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            serverless_jobs_notebooks_workspace_enable_val?: {
-                value: string;
-            };
-        };
-    };
-};
-
 export class DatabricksWorkspace {
     constructor(
         public readonly id: string,
         private _authProvider: AuthProvider,
         private me: iam.User,
-        private wsConf: WorkspaceConfProps & {enableServerless?: boolean}
+        private wsConf: WorkspaceConfProps
     ) {}
 
     /**
@@ -68,10 +57,6 @@ export class DatabricksWorkspace {
         return this.wsConf.enableWorkspaceFilesystem !== "false";
     }
 
-    get isServerlessEnabled(): boolean {
-        return this.wsConf.enableServerless === true;
-    }
-
     supportFilesInReposForCluster(cluster: Cluster): boolean {
         if (!this.isReposEnabled || !this.isFilesInReposEnabled) {
             return false;
@@ -110,7 +95,7 @@ export class DatabricksWorkspace {
         const id = (me as any)["x-databricks-org-id"] as string;
 
         const wsConfApi = new WorkspaceConf(client.apiClient);
-        let state: WorkspaceConfProps & {enableServerless?: boolean} = {
+        let state: WorkspaceConfProps = {
             enableProjectTypeInWorkspace: "true",
             enableWorkspaceFilesystem: "true",
         };
@@ -123,20 +108,6 @@ export class DatabricksWorkspace {
         } catch (e) {
             ctx?.logger?.error("Can't fetch workspace confs", e);
         }
-        try {
-            const serverlessEnablement = (await client.apiClient.request(
-                `/api/2.0/settings-api/workspace/${id}/serverless_jobs_ws_nb_enable`,
-                "GET"
-            )) as ServerlessEnablementResponse;
-            const enableServerless =
-                serverlessEnablement?.setting?.value
-                    ?.serverless_jobs_notebooks_workspace_enable_val?.value ===
-                "ENABLED";
-            state = {...state, enableServerless};
-        } catch (e) {
-            ctx?.logger?.error("Can't detect serverless support", e);
-        }
-
         return new DatabricksWorkspace(id, authProvider, me, state);
     }
 }

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
@@ -142,12 +142,16 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
                 );
             }
         } catch (e: unknown) {
-            if (e instanceof Error) {
-                const title = "Failed to check workspace permissions";
-                this.logger.error(title, e);
-                window.showErrorMessage(`${title}: "${e.message}".`);
-                return this.rejectStep("checkWorkspaceHasUc", title, e.message);
+            let title = "Failed to check workspace permissions";
+            this.logger.error(title, e);
+            let message = e instanceof Error ? e.message : (e as string) || "";
+            if (message.includes("METASTORE_DOES_NOT_EXIST")) {
+                title = "The workspace should have Unity Catalog enabled";
+                message = "No catalogues with read permission were found";
+            } else {
+                window.showErrorMessage(`${title}: "${message}".`);
             }
+            return this.rejectStep("checkWorkspaceHasUc", title, message);
         }
         return this.acceptStep("checkWorkspaceHasUc");
     }


### PR DESCRIPTION


## Changes

Serverless detection for a workspace is not full proof. Instead of having false negatives, we show serverless option for everyone.

Jobs and dbconnect runs already show clear errors if serverless is not supported.

## Tests

Existing integ tests
