### PR TITLE
Hide auto-generated cell in ipynb workflows

### DIFF
--- a/packages/databricks-vscode/scripts/writeIpynbWrapper.ts
+++ b/packages/databricks-vscode/scripts/writeIpynbWrapper.ts
@@ -14,7 +14,11 @@ interface INbCell {
 const nbCell: INbCell = {
     cell_type: "code",
     source: [],
-    metadata: {},
+    metadata: {
+        jupyter: {
+            source_hidden: true,
+        },
+    },
     outputs: [],
     execution_count: null,
 };


### PR DESCRIPTION

## Changes

Using the same metadata that web UI sets when you click on "hide code" option for a cell.

It looks like this, and the cell can be expanded by clicking on the eye button (after which you can't hide it anymore)
<img width="991" alt="Screenshot 2025-02-25 at 15 31 09" src="https://github.com/user-attachments/assets/15029782-f4ee-4405-a3ba-e3cc322a8bad" />



Dbnb notebooks will still have the generated cells visible.



## Tests

Manually + existing integ tests
