### PR TITLE
Add OPEN_RESOURCE_EXTERNALLY telemetry event

### DIFF
--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -554,6 +554,7 @@ async function collectTokenForPatAuth(
     if (token === "Create a new Personal Access Token") {
         commands.executeCommand("databricks.utils.openExternal", {
             url: `${host.toString()}settings/user/developer/access-tokens`,
+            type: "pat_settings_page",
         });
         return collectTokenForPatAuth(host, input, step, totalSteps);
     }

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -852,7 +852,7 @@ export async function activate(
     });
 
     // Utils
-    const utilCommands = new UtilsCommands.UtilsCommands();
+    const utilCommands = new UtilsCommands.UtilsCommands(telemetry);
     context.subscriptions.push(
         telemetry.registerCommand(
             "databricks.utils.openExternal",

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -23,6 +23,7 @@ export enum Events {
     COMPUTE_SELECTED = "computeSelected",
     WORKFLOW_RUN = "workflowRun",
     DBCONNECT_RUN = "dbconnectRun",
+    OPEN_RESOURCE_EXTERNALLY = "openResourceExternally",
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -198,6 +199,14 @@ export class EventTypes {
         comment: "A Databricks Connect debug run",
         computeType: {
             comment: "The type of the compute",
+        },
+    };
+    [Events.OPEN_RESOURCE_EXTERNALLY]: EventType<{
+        type: string;
+    }> = {
+        comment: "An external resource URL was opened",
+        type: {
+            comment: "The resource type",
         },
     };
 }

--- a/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
@@ -57,52 +57,66 @@ export class DocsViewTreeDataProvider
 
         const items: DocsTreeItem[] = [quickStartItem];
 
-        const baseUrl = "https://docs.databricks.com/";
-        const docLinks = [
+        const baseUrl = "https://docs.databricks.com";
+        const guides = [
             {
                 label: "Setup authentication",
                 path: "dev-tools/vscode-ext/authentication",
+                type: "auth_guide",
             },
             {
                 label: "Configure your project",
                 path: "dev-tools/vscode-ext/configure",
+                type: "conriguration_guide",
             },
             {
                 label: "Work with Databricks Asset Bundles",
                 path: "dev-tools/vscode-ext/bundles",
+                type: "bundles_guide",
             },
             {
                 label: "Run files on a cluster",
                 path: "dev-tools/vscode-ext/run",
+                type: "run_files_guide",
             },
             {
                 label: "Run files with Databricks Connect",
                 path: "dev-tools/vscode-ext/databricks-connect",
+                type: "dbconnect_guide",
             },
             {
                 label: "Run notebooks cell by cell",
                 path: "dev-tools/vscode-ext/notebooks",
+                type: "notebooks_guide",
             },
             {
                 label: "Run tests on a cluster",
                 path: "dev-tools/vscode-ext/pytest",
+                type: "pytest_guide",
             },
             {
                 label: "Explore extension settings",
                 path: "dev-tools/vscode-ext/settings",
+                type: "settings_guide",
             },
             {
                 label: "Troubleshoot problems",
                 path: "dev-tools/vscode-ext/troubleshooting",
+                type: "troubleshooting_guide",
             },
         ];
-        for (const doc of docLinks) {
-            const item = new TreeItem(doc.label, TreeItemCollapsibleState.None);
+        for (const guide of guides) {
+            const item = new TreeItem(
+                guide.label,
+                TreeItemCollapsibleState.None
+            );
             item.iconPath = new ThemeIcon("link");
             item.command = {
-                command: "vscode.open",
+                command: "databricks.utils.openExternal",
                 title: "Open URL",
-                arguments: [Uri.parse(`${baseUrl}${doc.path}`)],
+                arguments: [
+                    {url: `${baseUrl}/${guide.path}`, type: guide.type},
+                ],
             };
             items.push(item);
         }

--- a/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
@@ -67,7 +67,7 @@ export class DocsViewTreeDataProvider
             {
                 label: "Configure your project",
                 path: "dev-tools/vscode-ext/configure",
-                type: "conriguration_guide",
+                type: "configuration_guide",
             },
             {
                 label: "Work with Databricks Asset Bundles",

--- a/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/docs-view/DocsViewTreeDataProvider.ts
@@ -4,7 +4,6 @@ import {
     TreeDataProvider,
     TreeItem,
     TreeItemCollapsibleState,
-    Uri,
 } from "vscode";
 import {logging} from "@databricks/databricks-sdk";
 import {Loggers} from "../../logger";

--- a/packages/databricks-vscode/src/utils/UtilsCommands.ts
+++ b/packages/databricks-vscode/src/utils/UtilsCommands.ts
@@ -27,7 +27,6 @@ export class UtilsCommands implements Disposable {
                 this.telemetry.recordEvent(Events.OPEN_RESOURCE_EXTERNALLY, {
                     type: value.type,
                 });
-                console.log("Tracked external resource", value.type);
             }
             await openExternal(url);
         };

--- a/packages/databricks-vscode/src/utils/UtilsCommands.ts
+++ b/packages/databricks-vscode/src/utils/UtilsCommands.ts
@@ -1,8 +1,11 @@
 import {Disposable, window, env} from "vscode";
 import {openExternal} from "./urlUtils";
+import {Events, Telemetry} from "../telemetry";
 
 export class UtilsCommands implements Disposable {
     private disposables: Disposable[] = [];
+
+    constructor(private telemetry: Telemetry) {}
 
     openExternalCommand() {
         return async (value: any | undefined) => {
@@ -19,6 +22,12 @@ export class UtilsCommands implements Disposable {
                     "Databricks: Can't open external link. No URL found."
                 );
                 return;
+            }
+            if (value.type !== undefined) {
+                this.telemetry.recordEvent(Events.OPEN_RESOURCE_EXTERNALLY, {
+                    type: value.type,
+                });
+                console.log("Tracked external resource", value.type);
             }
             await openExternal(url);
         };


### PR DESCRIPTION
## Changes

"openExternal" command is used for Bundle Resources and Docs panels. Resources already have "type" fields, I've added the same field for Docs panel items, and the new telemetry event is sent with the "type" information (and not a full url). 

It should help us understand what resources people open externally, or what documentation guides people open more frequently than others.
## Tests

Manually
