### PR TITLE
Rename workflows to jobs in the bundle explorer UI

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -234,7 +234,7 @@
             {
                 "command": "databricks.bundle.deployAndRunJob",
                 "icon": "$(run)",
-                "title": "Deploy the bundle and run the workflow",
+                "title": "Deploy the bundle and run the job",
                 "enablement": "databricks.context.activated && databricks.context.bundle.isTargetSet && databricks.context.bundle.deploymentState == idle",
                 "category": "Databricks"
             },

--- a/packages/databricks-vscode/src/test/e2e/bundle_sub_folder.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/bundle_sub_folder.e2e.ts
@@ -111,7 +111,7 @@ describe("Bundle in a sub folder", async function () {
                 async () => {
                     const job = await getResourceViewItem(
                         resourceExplorerView,
-                        "Workflows",
+                        "Jobs",
                         jobs[folder].name!
                     );
                     return job !== undefined;

--- a/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/deploy_and_run_job.e2e.ts
@@ -70,13 +70,13 @@ describe("Deploy and run job", async function () {
 
         const jobItem = await getResourceViewItem(
             resourceExplorerView,
-            "Workflows",
+            "Jobs",
             jobName
         );
         assert(jobItem, `Job ${jobName} not found in resource explorer`);
 
         const deployAndRunButton = await jobItem.getActionButton(
-            "Deploy the bundle and run the workflow"
+            "Deploy the bundle and run the job"
         );
         assert(deployAndRunButton, "Deploy and run button not found");
         await deployAndRunButton.elem.click();
@@ -85,7 +85,7 @@ describe("Deploy and run job", async function () {
 
         await waitForRunStatus(
             resourceExplorerView,
-            "Workflows",
+            "Jobs",
             jobName,
             "Success"
         );

--- a/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
@@ -90,7 +90,7 @@ describe("Automatically refresh resource explorer", async function () {
             async () => {
                 const job = await getResourceViewItem(
                     resourceExplorerView,
-                    "Workflows",
+                    "Jobs",
                     jobDef.name!
                 );
                 return job !== undefined;

--- a/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/dabsExplorerUtils.ts
@@ -3,7 +3,7 @@ import {CustomTreeSection} from "wdio-vscode-service";
 
 export async function getResourceViewItem(
     resourceExplorer: CustomTreeSection,
-    resourceType: "Workflows" | "Pipelines",
+    resourceType: "Jobs" | "Pipelines",
     resourceName: string
 ) {
     const jobs = await resourceExplorer.openItem(resourceType);
@@ -21,7 +21,7 @@ export async function geTaskViewItem(
 ) {
     const tasks = await getResourceSubItems(
         resourceExplorerView,
-        "Workflows",
+        "Jobs",
         resourceName,
         "Tasks"
     );
@@ -34,7 +34,7 @@ export async function geTaskViewItem(
 
 export async function getResourceSubItems(
     resourceExplorerView: CustomTreeSection,
-    resourceType: "Workflows" | "Pipelines",
+    resourceType: "Jobs" | "Pipelines",
     resourceName: string,
     ...subItemNames: string[]
 ) {
@@ -56,8 +56,8 @@ export async function getResourceSubItems(
 
 export async function waitForRunStatus(
     resourceExplorerView: CustomTreeSection,
-    resourceType: "Workflows" | "Pipelines",
-    resorceName: string,
+    resourceType: "Jobs" | "Pipelines",
+    resourceName: string,
     successLabel: string,
     timeout: number = 120_000
 ) {
@@ -67,10 +67,10 @@ export async function waitForRunStatus(
             const item = await getResourceViewItem(
                 resourceExplorerView,
                 resourceType,
-                resorceName
+                resourceName
             );
             if (item === undefined) {
-                console.log(`Item ${resorceName} not found`);
+                console.log(`Item ${resourceName} not found`);
                 return false;
             }
 

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/BundleCommands.ts
@@ -226,22 +226,22 @@ export class BundleCommands implements Disposable {
                 type: "pipelines",
                 key: `pipelines.${key}`,
             }));
-            const workflows = remoteState?.resources?.jobs ?? {};
-            const workflowItems = Object.keys(workflows).map((key) => ({
+            const jobs = remoteState?.resources?.jobs ?? {};
+            const jobItems = Object.keys(jobs).map((key) => ({
                 label: key,
-                description: "Workflow",
+                description: "Job",
                 type: "jobs",
             }));
-            if (pipelineItems.length === 0 && workflowItems.length === 0) {
+            if (pipelineItems.length === 0 && jobItems.length === 0) {
                 window.showErrorMessage(
-                    "No pipelines or workflows found in the bundle."
+                    "No pipelines or jobs found in the bundle."
                 );
                 return;
             }
             const pick = await window.showQuickPick(
-                [...pipelineItems, ...workflowItems],
+                [...pipelineItems, ...jobItems],
                 {
-                    placeHolder: "Select a pipeline or workflow to run",
+                    placeHolder: "Select a pipeline or a job to run",
                 }
             );
             if (!pick) {

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
@@ -20,7 +20,7 @@ function humaniseResourceType(type: BundleResourceExplorerTreeNode["type"]) {
         case "pipelines":
             return "Pipelines";
         case "jobs":
-            return "Workflows";
+            return "Jobs";
         default:
             return capitalize(type).replace(/_/g, " ");
     }


### PR DESCRIPTION
## Changes

This change renames workflows to jobs in the bundle explorer UI to align with the terminology used in the Databricks UI.

Note that we still have "run file as workflow" command and `databricks-workflow` launch config - decided to leave it as is to not break existing users' workflows (and it's still a correct term in that context)

## Tests

Manually and existing integ tests
