### PR TITLE
Link bundle resources to their source definitions

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -167,8 +167,8 @@
                 "category": "Databricks"
             },
             {
-                "command": "databricks.utils.openSourceLocation",
-                "title": "Open source location",
+                "command": "databricks.utils.goToDefinition",
+                "title": "Go to definition",
                 "icon": "$(go-to-file)",
                 "category": "Databricks"
             },
@@ -587,12 +587,12 @@
                     "group": "navigation_2@0"
                 },
                 {
-                    "command": "databricks.utils.openSourceLocation",
+                    "command": "databricks.utils.goToDefinition",
                     "when": "viewItem =~ /^databricks.*\\.(has-source-location).*$/",
                     "group": "inline@1"
                 },
                 {
-                    "command": "databricks.utils.openSourceLocation",
+                    "command": "databricks.utils.goToDefinition",
                     "when": "viewItem =~ /^databricks.*\\.(has-source-location).*$/",
                     "group": "navigation_2@0"
                 },
@@ -839,7 +839,7 @@
                     "when": "false"
                 },
                 {
-                    "command": "databricks.utils.openSourceLocation",
+                    "command": "databricks.utils.goToDefinition",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -167,6 +167,12 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.utils.openSourceLocation",
+                "title": "Open source location",
+                "icon": "$(go-to-file)",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.wsfs.refresh",
                 "title": "Refresh workspace filesystem view",
                 "icon": "$(refresh)",
@@ -581,6 +587,16 @@
                     "group": "navigation_2@0"
                 },
                 {
+                    "command": "databricks.utils.openSourceLocation",
+                    "when": "viewItem =~ /^databricks.*\\.(has-source-location).*$/",
+                    "group": "inline@1"
+                },
+                {
+                    "command": "databricks.utils.openSourceLocation",
+                    "when": "viewItem =~ /^databricks.*\\.(has-source-location).*$/",
+                    "group": "navigation_2@0"
+                },
+                {
                     "command": "databricks.bundle.selectActiveProjectFolder",
                     "when": "viewItem =~ /^databricks.configuration.activeProjectFolder/ && databricks.context.bundle.deploymentState == idle",
                     "group": "navigation_2@0"
@@ -820,6 +836,10 @@
                 },
                 {
                     "command": "databricks.utils.openExternal",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.utils.openSourceLocation",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleRemoteStateModel.ts
@@ -25,6 +25,13 @@ export type BundleRemoteState = BundleTarget & {
             };
         };
     };
+    __locations?: {
+        version: number;
+        files: string[];
+        locations: {
+            [key: string]: number[][];
+        };
+    };
 };
 
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -531,6 +531,7 @@ export class CliWrapper {
             [
                 "bundle",
                 "summary",
+                "--include-locations",
                 "--target",
                 target,
                 // Forces the CLI to regenerate local terraform state and pull the remote state.

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -860,6 +860,11 @@ export async function activate(
             utilCommands
         ),
         telemetry.registerCommand(
+            "databricks.utils.openSourceLocation",
+            utilCommands.openSourceLocation(),
+            utilCommands
+        ),
+        telemetry.registerCommand(
             "databricks.utils.copy",
             utilCommands.copyToClipboardCommand(),
             utilCommands

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -860,8 +860,8 @@ export async function activate(
             utilCommands
         ),
         telemetry.registerCommand(
-            "databricks.utils.openSourceLocation",
-            utilCommands.openSourceLocation(),
+            "databricks.utils.goToDefinition",
+            utilCommands.goToDefinition(),
             utilCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
@@ -1,4 +1,4 @@
-import {ExtensionContext} from "vscode";
+import {ExtensionContext, Location} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {
     BundleResourceExplorerResource,
@@ -13,9 +13,21 @@ import {JobRunStatusTreeNode} from "./JobRunStatusTreeNode";
 import {JobRunStatus} from "../../bundle/run/JobRunStatus";
 import {TaskTreeNode} from "./TaskTreeNode";
 import {TaskHeaderTreeNode} from "./TaskHeaderTreeNode";
+import {getSourceLocation} from "./utils/SourceLocationUtils";
 
 export class JobTreeNode implements BundleResourceExplorerTreeNode {
     readonly type = "jobs";
+
+    constructor(
+        private readonly context: ExtensionContext,
+        private readonly bundleRunStatusManager: BundleRunStatusManager,
+        private readonly connectionManager: ConnectionManager,
+        public readonly resourceKey: string,
+        public readonly data: BundleResourceExplorerResource<"jobs">,
+        private readonly locations: BundleRemoteState["__locations"],
+        public parent?: BundleResourceExplorerTreeNode
+    ) {}
+
     get url(): string | undefined {
         const host = this.connectionManager.databricksWorkspace?.host;
 
@@ -26,14 +38,13 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
         return `${host.toString()}#job/${this.data.id}`;
     }
 
-    constructor(
-        private readonly context: ExtensionContext,
-        private readonly bundleRunStatusManager: BundleRunStatusManager,
-        private readonly connectionManager: ConnectionManager,
-        public readonly resourceKey: string,
-        public readonly data: BundleResourceExplorerResource<"jobs">,
-        public parent?: BundleResourceExplorerTreeNode
-    ) {}
+    get sourceLocation(): Location | undefined {
+        return getSourceLocation(
+            this.locations,
+            this.connectionManager.projectRoot,
+            this.resourceKey
+        );
+    }
 
     get isRunning() {
         const runner = this.bundleRunStatusManager.runStatuses.get(
@@ -49,6 +60,7 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
                 resourceType: this.type,
                 running: this.isRunning,
                 hasUrl: this.url !== undefined,
+                hasSourceLocation: this.sourceLocation !== undefined,
                 cancellable: this.isRunning,
                 nodeType: this.type,
                 modifiedStatus: this.data.modified_status,
@@ -116,6 +128,7 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
                 connectionManager,
                 `jobs.${jobKey}`,
                 jobs[jobKey],
+                remoteStateConfig.__locations,
                 undefined
             );
         });

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/JobTreeNode.ts
@@ -97,10 +97,11 @@ export class JobTreeNode implements BundleResourceExplorerTreeNode {
                         this.connectionManager,
                         task,
                         this.resourceKey,
-                        `${this.resourceKey}.tasks.[${i}].${task.task_key}`,
+                        `${this.resourceKey}.tasks[${i}]`,
                         this,
                         this.data.id,
-                        runMonitor
+                        runMonitor,
+                        this.locations
                     );
                 }),
                 this

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/PipelineTreeNode.ts
@@ -7,14 +7,14 @@ import {
 import {BundleRunStatusManager} from "../../bundle/run/BundleRunStatusManager";
 import {ContextUtils} from "./utils";
 import {DecorationUtils} from "../utils";
-
 import {ConnectionManager} from "../../configuration/ConnectionManager";
 import {PipelineRunStatus} from "../../bundle/run/PipelineRunStatus";
 import {TreeItemTreeNode} from "../TreeItemTreeNode";
 import {PipelineRunStatusTreeNode} from "./PipelineRunStatusTreeNode";
-import {ThemeIcon} from "vscode";
+import {ThemeIcon, Location} from "vscode";
 import {PipelineDatasetsTreeNode} from "./PipelineDatasetsTreeNode";
 import {BundlePipelinesManager} from "../../bundle/BundlePipelinesManager";
+import {getSourceLocation} from "./utils/SourceLocationUtils";
 
 export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
     readonly type = "pipelines";
@@ -28,12 +28,21 @@ export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
         return `${host.toString()}#joblist/pipelines/${this.data.id}`;
     }
 
+    get sourceLocation(): Location | undefined {
+        return getSourceLocation(
+            this.locations,
+            this.connectionManager.projectRoot,
+            this.resourceKey
+        );
+    }
+
     constructor(
         private readonly connectionManager: ConnectionManager,
         private readonly bundleRunStatusManager: BundleRunStatusManager,
         private readonly pipelinesManager: BundlePipelinesManager,
         public readonly resourceKey: string,
         public readonly data: BundleResourceExplorerResource<"pipelines">,
+        private readonly locations: BundleRemoteState["__locations"],
         public parent?: BundleResourceExplorerTreeNode
     ) {}
 
@@ -51,6 +60,7 @@ export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
                 resourceType: this.type,
                 running: isRunning,
                 hasUrl: this.url !== undefined,
+                hasSourceLocation: this.sourceLocation !== undefined,
                 cancellable: isRunning,
                 nodeType: this.type,
                 modifiedStatus: this.data.modified_status,
@@ -139,6 +149,7 @@ export class PipelineTreeNode implements BundleResourceExplorerTreeNode {
                 pipelinesManager,
                 `pipelines.${pipelineKey}`,
                 pipelines[pipelineKey],
+                remoteStateConfig.__locations,
                 undefined
             );
         });

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
@@ -116,6 +116,7 @@ export class ResourceTypeHeaderTreeNode
         }
 
         const unknownResourceGroups = UnknownResourceTreeNode.getRootGroups(
+            connectionManager,
             bundleRemoteState,
             KNOWN_RESOURCE_TYPES
         );

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
@@ -4,12 +4,19 @@ import {
     BundleResourceExplorerTreeItem,
     BundleResourceExplorerTreeNode,
 } from "./types";
-import {ExtensionContext, TreeItemCollapsibleState, ThemeIcon} from "vscode";
+import {
+    ExtensionContext,
+    TreeItemCollapsibleState,
+    ThemeIcon,
+    Location,
+} from "vscode";
 import {JobRunStatus} from "../../bundle/run/JobRunStatus";
 import {ConnectionManager} from "../../configuration/ConnectionManager";
 import {jobs} from "@databricks/databricks-sdk";
 import {TaskRunStatusTreeNode} from "./TaskRunStatusTreeNode";
 import {ContextUtils} from "./utils";
+import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
+import {getSourceLocation} from "./utils/SourceLocationUtils";
 
 type Task = Required<BundleResourceExplorerResource<"jobs">>["tasks"][number];
 type TaskType = keyof {
@@ -37,6 +44,15 @@ export class TaskTreeNode implements BundleResourceExplorerTreeNode {
             this.taskKey
         }`;
     }
+
+    get sourceLocation(): Location | undefined {
+        return getSourceLocation(
+            this.locations,
+            this.connectionManager.projectRoot,
+            this.resourceKey
+        );
+    }
+
     constructor(
         private readonly context: ExtensionContext,
         private readonly connectionManager: ConnectionManager,
@@ -45,7 +61,8 @@ export class TaskTreeNode implements BundleResourceExplorerTreeNode {
         public readonly resourceKey: string,
         public parent: BundleResourceExplorerTreeNode,
         public readonly jobId?: string,
-        public readonly runMonitor?: JobRunStatus
+        public readonly runMonitor?: JobRunStatus,
+        private readonly locations?: BundleRemoteState["__locations"]
     ) {}
 
     private getIconPathForType(taskType: string) {
@@ -135,6 +152,7 @@ export class TaskTreeNode implements BundleResourceExplorerTreeNode {
                 nodeType: this.type,
                 running: this.isRunning,
                 hasUrl: this.url !== undefined,
+                hasSourceLocation: this.sourceLocation !== undefined,
                 cancellable: false,
             }),
             collapsibleState:

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskTreeNode.ts
@@ -25,9 +25,11 @@ type TaskType = keyof {
 
 export class TaskTreeNode implements BundleResourceExplorerTreeNode {
     readonly type = "task";
+
     get taskKey(): string {
         return this.data.task_key;
     }
+
     get runDetails(): jobs.RunTask | undefined {
         return this.runMonitor?.data?.tasks?.find(
             (t) => t.task_key === this.taskKey

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/types.ts
@@ -1,4 +1,4 @@
-import {TreeItem} from "vscode";
+import {Location, TreeItem} from "vscode";
 import {BundleRemoteState} from "../../bundle/models/BundleRemoteStateModel";
 import {Resource, ResourceKey} from "../../bundle/types";
 
@@ -25,6 +25,8 @@ export interface BundleResourceExplorerTreeNode {
         | "job_run_status"
         | "task_header";
     parent?: BundleResourceExplorerTreeNode;
+    url?: string;
+    sourceLocation?: Location;
     getTreeItem(): BundleResourceExplorerTreeItem;
     getChildren():
         | BundleResourceExplorerTreeNode[]

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/ContextUtils.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/ContextUtils.ts
@@ -11,6 +11,7 @@ type BundleTreeItemContext = {
     running?: boolean;
     cancellable?: boolean;
     hasUrl?: boolean;
+    hasSourceLocation?: boolean;
     hasPipelineDetails?: boolean;
     modifiedStatus?: BundleResourceModifiedStatus;
 };
@@ -41,6 +42,10 @@ export function getContextString(context: BundleTreeItemContext) {
 
     if (context.hasUrl) {
         parts.push("has-url");
+    }
+
+    if (context.hasSourceLocation) {
+        parts.push("has-source-location");
     }
 
     if (context.hasPipelineDetails) {

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/SourceLocationUtils.test.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/SourceLocationUtils.test.ts
@@ -1,0 +1,115 @@
+import {Location, Position, Uri} from "vscode";
+import {getSourceLocation} from "./SourceLocationUtils";
+import {BundleRemoteState} from "../../../bundle/models/BundleRemoteStateModel";
+import * as assert from "assert";
+
+describe("getSourceLocation", () => {
+    const projectRoot = Uri.file("/project/root");
+    const resourceKey = "test-resource";
+
+    it("should return undefined when locations is undefined", () => {
+        const locations = undefined;
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when locations.version is not 1", () => {
+        const locations = {
+            version: 2,
+            locations: {},
+            files: [],
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when locations.locations is undefined", () => {
+        const locations = {
+            version: 1,
+            files: [],
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when locations.files is undefined", () => {
+        const locations = {
+            version: 1,
+            locations: {},
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when resource key is not found", () => {
+        const locations = {
+            version: 1,
+            locations: {
+                uknownResource: [[0, 1, 1]],
+            },
+            files: ["path/to/file.py"],
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when location is not an array of exactly 3 elements", () => {
+        const locations = {
+            version: 1,
+            locations: {
+                [`resources.${resourceKey}`]: [[0, 1]], // Missing the third element
+            },
+            files: ["path/to/file.py"],
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return undefined when file is not found in files array", () => {
+        const locations = {
+            version: 1,
+            locations: {
+                [`resources.${resourceKey}`]: [[1, 10, 20]],
+            },
+            files: ["path/to/file.py"], // No entry at index 1
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("should return a valid Location when all conditions are met", () => {
+        const filePath = "path/to/file.py";
+        const lineNumber = 10;
+        const columnNumber = 20;
+
+        const locations = {
+            version: 1,
+            locations: {
+                [`resources.${resourceKey}`]: [[0, lineNumber, columnNumber]],
+            },
+            files: [filePath],
+        } as unknown as BundleRemoteState["__locations"];
+
+        const result = getSourceLocation(locations, projectRoot, resourceKey);
+
+        const expectedUri = Uri.joinPath(projectRoot, filePath);
+        const expectedPosition = new Position(lineNumber - 1, columnNumber - 1);
+        const expectedLocation = new Location(expectedUri, expectedPosition);
+
+        assert.deepStrictEqual(result, expectedLocation);
+    });
+});

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/SourceLocationUtils.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/utils/SourceLocationUtils.ts
@@ -1,0 +1,31 @@
+import {Location, Position, Uri} from "vscode";
+import {BundleRemoteState} from "../../../bundle/models/BundleRemoteStateModel";
+
+export function getSourceLocation(
+    locations: BundleRemoteState["__locations"] | undefined,
+    projectRoot: Uri,
+    resourceKey: string
+): Location | undefined {
+    if (
+        !locations ||
+        !locations.locations ||
+        !locations.files ||
+        locations.version !== 1
+    ) {
+        return undefined;
+    }
+
+    const location = locations.locations[`resources.${resourceKey}`]?.[0];
+    if (!Array.isArray(location) || location.length !== 3) {
+        return undefined;
+    }
+
+    const file = locations.files[location[0]];
+    if (!file) {
+        return undefined;
+    }
+
+    const path = Uri.joinPath(projectRoot, file);
+    const position = new Position(location[1] - 1, location[2] - 1);
+    return new Location(path, position);
+}

--- a/packages/databricks-vscode/src/utils/UtilsCommands.ts
+++ b/packages/databricks-vscode/src/utils/UtilsCommands.ts
@@ -1,4 +1,12 @@
-import {Disposable, window, env} from "vscode";
+import {
+    Disposable,
+    window,
+    env,
+    Location,
+    workspace,
+    Selection,
+    TextEditorRevealType,
+} from "vscode";
 import {openExternal} from "./urlUtils";
 import {Events, Telemetry} from "../telemetry";
 
@@ -29,6 +37,26 @@ export class UtilsCommands implements Disposable {
                 });
             }
             await openExternal(url);
+        };
+    }
+
+    openSourceLocation() {
+        return async (value: any | undefined) => {
+            const location: Location | undefined = value?.sourceLocation;
+            if (location === undefined) {
+                window.showErrorMessage(
+                    "Databricks: Can't open source location. No URL found."
+                );
+                return;
+            }
+
+            const doc = await workspace.openTextDocument(location.uri);
+            const editor = await window.showTextDocument(doc);
+            editor.selection = new Selection(
+                location.range.start,
+                location.range.end
+            );
+            editor.revealRange(location.range, TextEditorRevealType.InCenter);
         };
     }
 

--- a/packages/databricks-vscode/src/utils/UtilsCommands.ts
+++ b/packages/databricks-vscode/src/utils/UtilsCommands.ts
@@ -40,7 +40,7 @@ export class UtilsCommands implements Disposable {
         };
     }
 
-    openSourceLocation() {
+    goToDefinition() {
         return async (value: any | undefined) => {
             const location: Location | undefined = value?.sourceLocation;
             if (location === undefined) {


### PR DESCRIPTION
## Changes

WIP: need to update and merge this CLI PR https://github.com/databricks/cli/pull/2189


We execute summary with `--include-locations` to get the source locations of the resources. Jobs, Tasks, Pipelines, or Unknown resources now can have an icon/context-menu that opens their location.



https://github.com/user-attachments/assets/ee38c4df-93be-48b0-b818-6667e30a80fe




<img width="524" alt="Screenshot 2025-03-06 at 13 39 46" src="https://github.com/user-attachments/assets/c2a447f0-d6f0-4163-aab5-2caf52e78c21" />
<img width="582" alt="Screenshot 2025-03-06 at 13 39 54" src="https://github.com/user-attachments/assets/c6f5282e-850c-455d-84ab-af4faf0af30f" />
<img width="476" alt="Screenshot 2025-03-06 at 13 40 10" src="https://github.com/user-attachments/assets/edb899f6-dabf-4109-8b3a-9c0a5bae4c1b" />



## Tests

A few unit tests for now, will add an integration test in a follow up.
