### PR TITLE
Fix login flow in the databricks-cli-check by removing trailing slashes from the URL

### DIFF
--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -104,9 +104,10 @@ export class DatabricksCliCheck implements Disposable {
 
     private async login(cancellationToken?: CancellationToken): Promise<void> {
         try {
+            const host = this.authProvider.host.toString().replace(/\/+$/, "");
             await execFile(
                 this.authProvider.cliPath,
-                ["auth", "login", "--host", this.authProvider.host.toString()],
+                ["auth", "login", "--host", host],
                 {},
                 cancellationToken
             );


### PR DESCRIPTION


## Changes
"databricks auth login" specifically doesn't like trailing slashes in the URL. Bundle commands normilize the host internally and don't have this problem.

## Tests

Manual and existing e2e tests
