### PR TITLE
Avoid sys.exit in the jupyter init scripts

### DIFF
--- a/packages/databricks-vscode/resources/python/00-databricks-init.py
+++ b/packages/databricks-vscode/resources/python/00-databricks-init.py
@@ -600,14 +600,15 @@ def make_matplotlib_inline():
 def setup():
     import os
     import sys
-    print(sys.modules[__name__])
 
+    if not load_env_from_leaf(os.getcwd()):
+        return
+
+    print(sys.modules[__name__])
     global _sqldf
     # Suppress grpc warnings coming from databricks-connect with newer version of grpcio lib
     os.environ["GRPC_VERBOSITY"] = "NONE"
 
-    if not load_env_from_leaf(os.getcwd()):
-        sys.exit(1)
     cfg = LocalDatabricksNotebookConfig()
 
     # disable build-in progress bar


### PR DESCRIPTION


## Changes
Init scripts apply to all jupyter notebooks on the system, and for non-databricks projects we should not exit the kernel process.

Fixes:
https://github.com/databricks/databricks-vscode/issues/1688


## Tests

Manually and existing e2e tests for dbconnect
