### PR TITLE
[DECO-26060] Migrate integration tests to Checks API

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,7 +81,7 @@ jobs:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       run: |
         gh workflow run vscode-isolated-pr.yml -R ${{ secrets.ORG_NAME }}/${{secrets.REPO_NAME}} \
-        --ref main \
+        --ref deco-26060-vscode-checks-api \
         -f pull_request_number=${{ github.event.pull_request.number }} \
         -f commit_sha=${{ github.event.pull_request.head.sha }} \
         -f check_run_id=${{ steps.create-check.outputs.check_run_id }}


### PR DESCRIPTION
## Summary

Migrate integration tests from GitHub Statuses API to Checks API.

**Why:** This eliminates the need for `DECO_GITHUB_TOKEN` (PAT) for integration test status reporting, removing the monthly token rotation burden. Uses `DECO_TEST_APPROVAL_APP` (GitHub App) instead.

**Changes:**
- Generate `DECO_TEST_APPROVAL_APP` token and create check run before triggering workflow
- Pass `check_run_id` to eng-dev-ecosystem workflow
- Update `auto-approve` job to use Checks API instead of Statuses API
- Check for both `DECO_WORKFLOW_TRIGGER_APP_ID` and `DECO_TEST_APPROVAL_APP_ID` secrets

This aligns VS Code with how the SDKs handle integration test status reporting.

**Depends on:** https://github.com/databricks-eng/eng-dev-ecosystem/pull/1151