### PR TITLE
Add Collapse All button to Bundle Resource Explorer

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -668,10 +668,10 @@ export async function activate(
         bundlePipelinesManager,
         decorationProvider,
         window.registerFileDecorationProvider(decorationProvider),
-        window.registerTreeDataProvider(
-            "dabsResourceExplorerView",
-            bundleResourceExplorerTreeDataProvider
-        ),
+        window.createTreeView("dabsResourceExplorerView", {
+            treeDataProvider: bundleResourceExplorerTreeDataProvider,
+            showCollapseAll: true,
+        }),
         telemetry.registerCommand(
             "databricks.bundle.refreshRemoteState",
             bundleCommands.refreshCommand,

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.test.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.test.ts
@@ -1,0 +1,115 @@
+import * as assert from "assert";
+import {TreeItemCollapsibleState, ExtensionContext} from "vscode";
+import {ResourceTypeHeaderTreeNode} from "./ResourceTypeHeaderTreeNode";
+import {BundleResourceExplorerTreeNode} from "./types";
+
+function createMockContext(): ExtensionContext {
+    return {
+        asAbsolutePath: (relativePath: string) =>
+            `/mock/extension/${relativePath}`,
+    } as unknown as ExtensionContext;
+}
+
+function createMockChild(
+    type: string = "jobs"
+): BundleResourceExplorerTreeNode {
+    return {
+        type: type as any,
+        getTreeItem: () => ({label: "mock"}),
+        getChildren: () => [],
+    };
+}
+
+describe("ResourceTypeHeaderTreeNode", () => {
+    describe("getTreeItem", () => {
+        it("should return Collapsed collapsible state for 'jobs' header", () => {
+            const context = createMockContext();
+            const children = [createMockChild("jobs")];
+            const node = new ResourceTypeHeaderTreeNode(
+                context,
+                "jobs",
+                children
+            );
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(
+                treeItem.collapsibleState,
+                TreeItemCollapsibleState.Collapsed
+            );
+        });
+
+        it("should return Collapsed collapsible state for 'pipelines' header", () => {
+            const context = createMockContext();
+            const children = [createMockChild("pipelines")];
+            const node = new ResourceTypeHeaderTreeNode(
+                context,
+                "pipelines",
+                children
+            );
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(
+                treeItem.collapsibleState,
+                TreeItemCollapsibleState.Collapsed
+            );
+        });
+
+        it("should set the label to 'Jobs' for jobs resource type", () => {
+            const context = createMockContext();
+            const children = [createMockChild("jobs")];
+            const node = new ResourceTypeHeaderTreeNode(
+                context,
+                "jobs",
+                children
+            );
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(treeItem.label, "Jobs");
+        });
+
+        it("should set the label to 'Pipelines' for pipelines resource type", () => {
+            const context = createMockContext();
+            const children = [createMockChild("pipelines")];
+            const node = new ResourceTypeHeaderTreeNode(
+                context,
+                "pipelines",
+                children
+            );
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(treeItem.label, "Pipelines");
+        });
+    });
+
+    describe("getChildren", () => {
+        it("should return the children passed in the constructor", () => {
+            const context = createMockContext();
+            const child1 = createMockChild("jobs");
+            const child2 = createMockChild("jobs");
+            const node = new ResourceTypeHeaderTreeNode(context, "jobs", [
+                child1,
+                child2,
+            ]);
+
+            const children = node.getChildren();
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual(children[0], child1);
+            assert.strictEqual(children[1], child2);
+        });
+
+        it("should set parent on children", () => {
+            const context = createMockContext();
+            const child = createMockChild("jobs");
+            const node = new ResourceTypeHeaderTreeNode(context, "jobs", [
+                child,
+            ]);
+
+            assert.strictEqual(child.parent, node);
+        });
+    });
+});

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/ResourceTypeHeaderTreeNode.ts
@@ -67,7 +67,7 @@ export class ResourceTypeHeaderTreeNode
             label: humaniseResourceType(this.resourceType),
             iconPath: this.getIconPath(this.resourceType),
             contextValue: `${this.resourceType}-header`,
-            collapsibleState: TreeItemCollapsibleState.Expanded,
+            collapsibleState: TreeItemCollapsibleState.Collapsed,
         };
     }
 

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskHeaderTreeNode.test.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskHeaderTreeNode.test.ts
@@ -1,0 +1,119 @@
+import * as assert from "assert";
+import {TreeItemCollapsibleState} from "vscode";
+import {TaskHeaderTreeNode} from "./TaskHeaderTreeNode";
+import {BundleResourceExplorerTreeNode} from "./types";
+import {TaskTreeNode} from "./TaskTreeNode";
+
+function createMockParent(): BundleResourceExplorerTreeNode {
+    return {
+        type: "jobs" as any,
+        getTreeItem: () => ({label: "mock-job"}),
+        getChildren: () => [],
+    };
+}
+
+function createMockTaskTreeNode(): TaskTreeNode {
+    return {
+        type: "task",
+        getTreeItem: () => ({label: "mock-task"}),
+        getChildren: () => [],
+    } as unknown as TaskTreeNode;
+}
+
+describe("TaskHeaderTreeNode", () => {
+    describe("getTreeItem", () => {
+        it("should return Collapsed when there are children", () => {
+            const parent = createMockParent();
+            const tasks = [createMockTaskTreeNode()];
+            const node = new TaskHeaderTreeNode(tasks, parent);
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(
+                treeItem.collapsibleState,
+                TreeItemCollapsibleState.Collapsed
+            );
+        });
+
+        it("should return Collapsed when there are multiple children", () => {
+            const parent = createMockParent();
+            const tasks = [
+                createMockTaskTreeNode(),
+                createMockTaskTreeNode(),
+                createMockTaskTreeNode(),
+            ];
+            const node = new TaskHeaderTreeNode(tasks, parent);
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(
+                treeItem.collapsibleState,
+                TreeItemCollapsibleState.Collapsed
+            );
+        });
+
+        it("should return None when there are no children", () => {
+            const parent = createMockParent();
+            const node = new TaskHeaderTreeNode([], parent);
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(
+                treeItem.collapsibleState,
+                TreeItemCollapsibleState.None
+            );
+        });
+
+        it("should set the label to 'Tasks'", () => {
+            const parent = createMockParent();
+            const tasks = [createMockTaskTreeNode()];
+            const node = new TaskHeaderTreeNode(tasks, parent);
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(treeItem.label, "Tasks");
+        });
+
+        it("should set contextValue to 'task_header'", () => {
+            const parent = createMockParent();
+            const tasks = [createMockTaskTreeNode()];
+            const node = new TaskHeaderTreeNode(tasks, parent);
+
+            const treeItem = node.getTreeItem();
+
+            assert.strictEqual(treeItem.contextValue, "task_header");
+        });
+    });
+
+    describe("getChildren", () => {
+        it("should return the task children", () => {
+            const parent = createMockParent();
+            const task1 = createMockTaskTreeNode();
+            const task2 = createMockTaskTreeNode();
+            const node = new TaskHeaderTreeNode([task1, task2], parent);
+
+            const children = node.getChildren();
+
+            assert.strictEqual(children.length, 2);
+            assert.strictEqual(children[0], task1);
+            assert.strictEqual(children[1], task2);
+        });
+
+        it("should return empty array when no children", () => {
+            const parent = createMockParent();
+            const node = new TaskHeaderTreeNode([], parent);
+
+            const children = node.getChildren();
+
+            assert.strictEqual(children.length, 0);
+        });
+
+        it("should set parent on task children to this node", () => {
+            const parent = createMockParent();
+            const task = createMockTaskTreeNode();
+            const node = new TaskHeaderTreeNode([task], parent);
+
+            assert.strictEqual(task.parent, node);
+        });
+    });
+});

--- a/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskHeaderTreeNode.ts
+++ b/packages/databricks-vscode/src/ui/bundle-resource-explorer/TaskHeaderTreeNode.ts
@@ -23,7 +23,7 @@ export class TaskHeaderTreeNode implements BundleResourceExplorerTreeNode {
             contextValue: "task_header",
             collapsibleState:
                 this.children.length > 0
-                    ? TreeItemCollapsibleState.Expanded
+                    ? TreeItemCollapsibleState.Collapsed
                     : TreeItemCollapsibleState.None,
         };
     }

--- a/packages/databricks-vscode/src/ui/utils/DecorationUtils.test.ts
+++ b/packages/databricks-vscode/src/ui/utils/DecorationUtils.test.ts
@@ -1,0 +1,47 @@
+import * as assert from "assert";
+import {TreeItemCollapsibleState} from "vscode";
+import {getCollapsibleState} from "./DecorationUtils";
+
+describe("DecorationUtils", () => {
+    describe("getCollapsibleState", () => {
+        it("should return None when modifiedStatus is 'deleted'", () => {
+            const result = getCollapsibleState(false, "deleted");
+            assert.strictEqual(result, TreeItemCollapsibleState.None);
+        });
+
+        it("should return None when modifiedStatus is 'deleted' even if running", () => {
+            const result = getCollapsibleState(true, "deleted");
+            assert.strictEqual(result, TreeItemCollapsibleState.None);
+        });
+
+        it("should return Collapsed when isRunning is true and not deleted", () => {
+            const result = getCollapsibleState(true, undefined);
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+
+        it("should return Collapsed when isRunning is true with 'created' status", () => {
+            const result = getCollapsibleState(true, "created");
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+
+        it("should return Collapsed when isRunning is true with 'updated' status", () => {
+            const result = getCollapsibleState(true, "updated");
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+
+        it("should return Collapsed when not running and no modifiedStatus", () => {
+            const result = getCollapsibleState(false, undefined);
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+
+        it("should return Collapsed when not running with 'created' status", () => {
+            const result = getCollapsibleState(false, "created");
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+
+        it("should return Collapsed when not running with 'updated' status", () => {
+            const result = getCollapsibleState(false, "updated");
+            assert.strictEqual(result, TreeItemCollapsibleState.Collapsed);
+        });
+    });
+});

--- a/packages/databricks-vscode/src/ui/utils/DecorationUtils.ts
+++ b/packages/databricks-vscode/src/ui/utils/DecorationUtils.ts
@@ -40,9 +40,5 @@ export function getCollapsibleState(
         return TreeItemCollapsibleState.None;
     }
 
-    if (isRunning) {
-        return TreeItemCollapsibleState.Collapsed;
-    }
-
-    return TreeItemCollapsibleState.Expanded;
+    return TreeItemCollapsibleState.Collapsed;
 }


### PR DESCRIPTION
  Closes #1698

  ## What changed
  - Replaced `registerTreeDataProvider` with `createTreeView` + `showCollapseAll: true` in `extension.ts` to surface the native VS Code Collapse All button in the tree view title bar
  - Changed default `collapsibleState` to `Collapsed` in `ResourceTypeHeaderTreeNode`, `TaskHeaderTreeNode`, and `getCollapsibleState` so all nodes start folded on load

  ## Testing
  - Added unit tests for all three changed modules (22 new assertions, all passing)
  - Manually verified with a local Databricks bundle project containing multiple jobs and tasks

See screenshot of implemented feature:
<img width="444" height="264" alt="image" src="https://github.com/user-attachments/assets/a7dcc1a9-28a9-48c2-87e1-cea45524ab13" />
