### PR TITLE
Add DABs LSP language client for bundle files

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1201,6 +1201,7 @@
         "minimatch": "^10.0.1",
         "shell-quote": "^1.8.1",
         "triple-beam": "^1.4.1",
+        "vscode-languageclient": "^9.0.1",
         "winston": "^3.11.0",
         "yaml": "^2.3.4"
     },

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1105,11 +1105,13 @@
                         "items": {
                             "enum": [
                                 "views.cluster",
-                                "views.workspace"
+                                "views.workspace",
+                                "features.bundleLsp"
                             ],
                             "enumDescriptions": [
                                 "Show cluster view in the explorer.",
-                                "Show workspace browser in the explorer."
+                                "Show workspace browser in the explorer.",
+                                "Enable the DABs Language Server for bundle YAML files (autocomplete, go-to-definition, diagnostics)."
                             ],
                             "type": "string"
                         },

--- a/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
+++ b/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
@@ -1,0 +1,93 @@
+import {
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+} from "vscode-languageclient/node";
+import {Disposable, Uri, workspace} from "vscode";
+import {CliWrapper} from "../cli/CliWrapper";
+
+/**
+ * Manages the lifecycle of the DABs Language Server Protocol client.
+ * Spawns `databricks bundle lsp` and connects via stdio to provide
+ * deployment-aware features (document links, hover) for bundle YAML files.
+ */
+export class BundleLSPClient implements Disposable {
+    private client: LanguageClient | undefined;
+    private readonly cli: CliWrapper;
+
+    constructor(cli: CliWrapper) {
+        this.cli = cli;
+    }
+
+    async start(workspaceFolder: Uri, target?: string): Promise<void> {
+        // Stop existing client if running.
+        await this.stop();
+
+        const args = ["bundle", "lsp"];
+        if (target) {
+            args.push("--target", target);
+        }
+
+        const serverOptions: ServerOptions = {
+            command: this.cli.cliPath,
+            args: args,
+            options: {
+                cwd: workspaceFolder.fsPath,
+            },
+        };
+
+        const clientOptions: LanguageClientOptions = {
+            documentSelector: [
+                {
+                    scheme: "file",
+                    language: "yaml",
+                    pattern: "**/databricks.yml",
+                },
+                {
+                    scheme: "file",
+                    language: "yaml",
+                    pattern: "**/databricks.yaml",
+                },
+                {
+                    scheme: "file",
+                    language: "yaml",
+                    pattern: "**/bundle.yml",
+                },
+                {
+                    scheme: "file",
+                    language: "yaml",
+                    pattern: "**/bundle.yaml",
+                },
+            ],
+            workspaceFolder: {
+                uri: workspaceFolder,
+                name: workspace.name ?? "workspace",
+                index: 0,
+            },
+        };
+
+        this.client = new LanguageClient(
+            "databricks-bundle-lsp",
+            "Databricks Bundle LSP",
+            serverOptions,
+            clientOptions
+        );
+
+        await this.client.start();
+    }
+
+    async stop(): Promise<void> {
+        if (this.client) {
+            try {
+                await this.client.stop();
+            } catch {
+                // Client may already be stopped.
+            }
+            this.client = undefined;
+        }
+    }
+
+    dispose(): void {
+        this.stop();
+    }
+}

--- a/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
+++ b/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
@@ -36,27 +36,20 @@ export class BundleLSPClient implements Disposable {
             },
         };
 
+        // Match all YAML files in the workspace, not just the root databricks.yml.
+        // Bundle configs can include other YAML files via the "include" directive,
+        // so the LSP needs to handle any .yml/.yaml file in the project.
         const clientOptions: LanguageClientOptions = {
             documentSelector: [
                 {
                     scheme: "file",
                     language: "yaml",
-                    pattern: "**/databricks.yml",
+                    pattern: `${workspaceFolder.fsPath}/**/*.yml`,
                 },
                 {
                     scheme: "file",
                     language: "yaml",
-                    pattern: "**/databricks.yaml",
-                },
-                {
-                    scheme: "file",
-                    language: "yaml",
-                    pattern: "**/bundle.yml",
-                },
-                {
-                    scheme: "file",
-                    language: "yaml",
-                    pattern: "**/bundle.yaml",
+                    pattern: `${workspaceFolder.fsPath}/**/*.yaml`,
                 },
             ],
             workspaceFolder: {
@@ -87,7 +80,7 @@ export class BundleLSPClient implements Disposable {
         }
     }
 
-    dispose(): void {
-        this.stop();
+    dispose(): Promise<void> {
+        return this.stop();
     }
 }

--- a/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
+++ b/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
@@ -1,6 +1,9 @@
 import {
+    CloseAction,
+    ErrorAction,
     LanguageClient,
     LanguageClientOptions,
+    RevealOutputChannelOn,
     ServerOptions,
 } from "vscode-languageclient/node";
 import {Disposable, Uri, workspace} from "vscode";
@@ -56,6 +59,16 @@ export class BundleLSPClient implements Disposable {
                 uri: workspaceFolder,
                 name: workspace.name ?? "workspace",
                 index: 0,
+            },
+            // Suppress error popups if the server binary doesn't support
+            // the bundle-lsp command (e.g. older CLI versions).
+            revealOutputChannelOn: RevealOutputChannelOn.Never,
+            errorHandler: {
+                error: () => ({action: ErrorAction.Shutdown}),
+                closed: () => ({
+                    action: CloseAction.DoNotRestart,
+                    handled: true,
+                }),
             },
         };
 

--- a/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
+++ b/packages/databricks-vscode/src/bundle/BundleLSPClient.ts
@@ -8,7 +8,7 @@ import {CliWrapper} from "../cli/CliWrapper";
 
 /**
  * Manages the lifecycle of the DABs Language Server Protocol client.
- * Spawns `databricks bundle lsp` and connects via stdio to provide
+ * Spawns `databricks experimental bundle-lsp` and connects via stdio to provide
  * deployment-aware features (document links, hover) for bundle YAML files.
  */
 export class BundleLSPClient implements Disposable {
@@ -23,7 +23,7 @@ export class BundleLSPClient implements Disposable {
         // Stop existing client if running.
         await this.stop();
 
-        const args = ["bundle", "lsp"];
+        const args = ["experimental", "bundle-lsp"];
         if (target) {
             args.push("--target", target);
         }
@@ -68,7 +68,7 @@ export class BundleLSPClient implements Disposable {
 
         this.client = new LanguageClient(
             "databricks-bundle-lsp",
-            "Databricks Bundle LSP",
+            "Databricks Experimental Bundle LSP",
             serverOptions,
             clientOptions
         );

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -50,6 +50,7 @@ import {
     BundleFileSet,
     registerBundleAutocompleteProvider,
 } from "./bundle";
+import {BundleLSPClient} from "./bundle/BundleLSPClient";
 import {showWhatsNewPopup} from "./whatsNewPopup";
 import {BundleValidateModel} from "./bundle/models/BundleValidateModel";
 import {ConfigModel} from "./configuration/models/ConfigModel";
@@ -889,6 +890,20 @@ export async function activate(
             e
         );
     });
+
+    // Start the DABs LSP client for deployment-aware features (document links, hover).
+    const bundleLSPClient = new BundleLSPClient(cli);
+    context.subscriptions.push(bundleLSPClient);
+
+    const workspaceFolder = workspace.workspaceFolders?.[0]?.uri;
+    if (workspaceFolder) {
+        bundleLSPClient.start(workspaceFolder).catch((e) => {
+            logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                "Failed to start bundle LSP: ",
+                e
+            );
+        });
+    }
 
     setDbnbCellLimits(workspaceFolderManager, connectionManager).catch((e) => {
         logging.NamedLogger.getOrCreate(Loggers.Extension).error(

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -897,12 +897,31 @@ export async function activate(
 
     const workspaceFolder = workspace.workspaceFolders?.[0]?.uri;
     if (workspaceFolder) {
-        bundleLSPClient.start(workspaceFolder).catch((e) => {
-            logging.NamedLogger.getOrCreate(Loggers.Extension).error(
-                "Failed to start bundle LSP: ",
-                e
-            );
-        });
+        bundleLSPClient
+            .start(workspaceFolder, configModel.target)
+            .catch((e) => {
+                logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                    "Failed to start bundle LSP: ",
+                    e
+                );
+            });
+
+        // Restart the LSP client when the bundle target changes so the server
+        // picks up the new target's configuration.
+        context.subscriptions.push(
+            configModel.onDidChangeTarget(() => {
+                bundleLSPClient
+                    .start(workspaceFolder, configModel.target)
+                    .catch((e) => {
+                        logging.NamedLogger.getOrCreate(
+                            Loggers.Extension
+                        ).error(
+                            "Failed to restart bundle LSP after target change: ",
+                            e
+                        );
+                    });
+            })
+        );
     }
 
     setDbnbCellLimits(workspaceFolderManager, connectionManager).catch((e) => {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -891,37 +891,45 @@ export async function activate(
         );
     });
 
-    // Start the DABs LSP client for deployment-aware features (document links, hover).
-    const bundleLSPClient = new BundleLSPClient(cli);
-    context.subscriptions.push(bundleLSPClient);
+    // Start the DABs LSP client for deployment-aware features
+    // (autocomplete, go-to-definition, hover, diagnostics).
+    // Gated behind the "features.bundleLsp" experimental flag.
+    if (
+        workspaceConfigs.experimetalFeatureOverides.includes(
+            "features.bundleLsp"
+        )
+    ) {
+        const bundleLSPClient = new BundleLSPClient(cli);
+        context.subscriptions.push(bundleLSPClient);
 
-    const workspaceFolder = workspace.workspaceFolders?.[0]?.uri;
-    if (workspaceFolder) {
-        bundleLSPClient
-            .start(workspaceFolder, configModel.target)
-            .catch((e) => {
-                logging.NamedLogger.getOrCreate(Loggers.Extension).error(
-                    "Failed to start bundle LSP: ",
-                    e
-                );
-            });
+        const workspaceFolder = workspace.workspaceFolders?.[0]?.uri;
+        if (workspaceFolder) {
+            bundleLSPClient
+                .start(workspaceFolder, configModel.target)
+                .catch((e) => {
+                    logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                        "Failed to start bundle LSP: ",
+                        e
+                    );
+                });
 
-        // Restart the LSP client when the bundle target changes so the server
-        // picks up the new target's configuration.
-        context.subscriptions.push(
-            configModel.onDidChangeTarget(() => {
-                bundleLSPClient
-                    .start(workspaceFolder, configModel.target)
-                    .catch((e) => {
-                        logging.NamedLogger.getOrCreate(
-                            Loggers.Extension
-                        ).error(
-                            "Failed to restart bundle LSP after target change: ",
-                            e
-                        );
-                    });
-            })
-        );
+            // Restart the LSP client when the bundle target changes so the server
+            // picks up the new target's configuration.
+            context.subscriptions.push(
+                configModel.onDidChangeTarget(() => {
+                    bundleLSPClient
+                        .start(workspaceFolder, configModel.target)
+                        .catch((e) => {
+                            logging.NamedLogger.getOrCreate(
+                                Loggers.Extension
+                            ).error(
+                                "Failed to restart bundle LSP after target change: ",
+                                e
+                            );
+                        });
+                })
+            );
+        }
     }
 
     setDbnbCellLimits(workspaceFolderManager, connectionManager).catch((e) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3799,6 +3799,7 @@ __metadata:
     ts-node: ^10.9.2
     typescript: ^5.3.3
     vsce: ^2.15.0
+    vscode-languageclient: ^9.0.1
     wdio-video-reporter: ^5.1.4
     wdio-vscode-service: ^6.0.2
     winston: ^3.11.0
@@ -9520,6 +9521,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.7":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 9b4a6a58e98b9723fafcafa393c9d4e8edefaa60b8dfbe39e30892a3604cf1f45f52df9cfb1ae1a22b44c8b3d57fec8a9bb7b3e1645431587cb272399ede152e
+  languageName: node
+  linkType: hard
+
 "semver@npm:^7.5.2, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
@@ -10837,6 +10847,41 @@ __metadata:
   bin:
     vsce: vsce
   checksum: 0c7b195fc6c60af9da01f950feff3e42f2ebee51d52c239b9bbeac39abe97a68886b28cafc60fdc9d927a1b618f7736b5e4d44042b84230a53f8798fb1903d1e
+  languageName: node
+  linkType: hard
+
+"vscode-jsonrpc@npm:8.2.0":
+  version: 8.2.0
+  resolution: "vscode-jsonrpc@npm:8.2.0"
+  checksum: f302a01e59272adc1ae6494581fa31c15499f9278df76366e3b97b2236c7c53ebfc71efbace9041cfd2caa7f91675b9e56f2407871a1b3c7f760a2e2ee61484a
+  languageName: node
+  linkType: hard
+
+"vscode-languageclient@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "vscode-languageclient@npm:9.0.1"
+  dependencies:
+    minimatch: ^5.1.0
+    semver: ^7.3.7
+    vscode-languageserver-protocol: 3.17.5
+  checksum: ff30e5a9aac6726a88fe443fd631fe7e6130225299667c13162547f0a13ca2548d3f277d68cfb3ef6dc1810c048b2cf0e05024e1bcbd11982cd8acf681a67873
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-protocol@npm:3.17.5":
+  version: 3.17.5
+  resolution: "vscode-languageserver-protocol@npm:3.17.5"
+  dependencies:
+    vscode-jsonrpc: 8.2.0
+    vscode-languageserver-types: 3.17.5
+  checksum: dfb42d276df5dfea728267885b99872ecff62f6c20448b8539fae71bb196b420f5351c5aca7c1047bf8fb1f89fa94a961dce2bc5bf7e726198f4be0bb86a1e71
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:3.17.5":
+  version: 3.17.5
+  resolution: "vscode-languageserver-types@npm:3.17.5"
+  checksum: 79b420e7576398d396579ca3a461c9ed70e78db4403cd28bbdf4d3ed2b66a2b4114031172e51fad49f0baa60a2180132d7cb2ea35aa3157d7af3c325528210ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a `BundleLSPClient` that spawns `databricks experimental bundle-lsp` via stdio, providing autocomplete, go-to-definition, hover, document links, and diagnostics for bundle YAML files. Restarts the LSP when the bundle target changes.

Gated behind experimental flag: users must opt in via `databricks.experiments.optInto` with `"features.bundleLsp"`.

**Error handling:** Custom error handler suppresses crash notification popups when the CLI doesn't support the command. No restart storms — immediately gives up on server failure. `revealOutputChannelOn` set to `Never`.

Depends on: databricks/cli#4714

## Test plan
- [x] Extension compiles
- [x] Manual testing with Extension Development Host
- [x] Tested with real deployed bundle (3 targets)

This pull request was AI-assisted by Isaac.