### PR TITLE
fix: make bundle init terminal flow shell-safe on Windows

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
+++ b/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
@@ -178,11 +178,16 @@ export class BundleInitWizard {
             "--output-dir",
             escapePathArgument(parentFolder.fsPath),
         ].join(" ");
-        const initialPrompt = `clear; echo "Executing: databricks ${args}\nFollow the steps below to create your new Databricks project.\n"`;
-        const finalPrompt = `echo "\nPress any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`;
+        terminal.sendText(ShellUtils.clearCmd());
+        terminal.sendText(`echo Executing: databricks ${args}`);
         terminal.sendText(
-            `${initialPrompt}; ${this.cli.escapedCliPath} ${args}; ${finalPrompt}`
+            "echo Follow the steps below to create your new Databricks project."
         );
+        terminal.sendText(`${this.cli.escapedCliPath} ${args}`);
+        terminal.sendText("echo.");
+        terminal.sendText("echo Press any key to close the terminal and continue ...");
+        terminal.sendText(ShellUtils.readCmd());
+        terminal.sendText("exit");
         return terminalDidClosePromise;
     }
 

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -1,14 +1,35 @@
 import {env} from "vscode";
 
+function shellPath() {
+    return env.shell.toLowerCase();
+}
+
 export function isPowershell() {
-    return env.shell.toLowerCase().includes("powershell");
+    return shellPath().includes("powershell");
+}
+
+export function isCmd() {
+    return shellPath().endsWith("cmd.exe") || shellPath().includes("\\cmd");
 }
 
 export function readCmd() {
     if (isPowershell()) {
         return "Read-Host";
     }
+    if (isCmd()) {
+        return "pause";
+    }
     return "read";
+}
+
+export function clearCmd() {
+    if (isPowershell()) {
+        return "Clear-Host";
+    }
+    if (isCmd()) {
+        return "cls";
+    }
+    return "clear";
 }
 
 export function escapeExecutableForTerminal(exe: string): string {


### PR DESCRIPTION
Fixes #1822

The init flow was building one long terminal command string, which breaks depending on shell quoting and command semantics. This switches to discrete sendText calls and adds shell-aware clear/read helpers for PowerShell, cmd, and POSIX shells.

Greetings, saschabuehrle