### PR TITLE
Security hardening: migrate CI to hardened runners + JFrog proxy (Phase 1)

### DIFF
--- a/.github/scripts/configure-npm.sh
+++ b/.github/scripts/configure-npm.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Point npm and Yarn at the internal JFrog npm registry.
+# Reads JFROG_ACCESS_TOKEN from the environment (set by jfrog-oidc-token.sh).
+set -euo pipefail
+
+JFROG_NPM_REGISTRY="https://databricks.jfrog.io/artifactory/api/npm/db-npm/"
+
+# Configure npm CLI
+cat > ~/.npmrc << EOF
+registry=${JFROG_NPM_REGISTRY}
+//databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+always-auth=true
+EOF
+
+# Configure Yarn Berry (v2+) — does not read ~/.npmrc for registry
+{
+  echo "YARN_NPM_REGISTRY_SERVER=${JFROG_NPM_REGISTRY}"
+  echo "YARN_NPM_AUTH_TOKEN=${JFROG_ACCESS_TOKEN}"
+} >> "$GITHUB_ENV"
+
+echo "npm/yarn configured to use JFrog registry (db-npm)"

--- a/.github/scripts/configure-npm.sh
+++ b/.github/scripts/configure-npm.sh
@@ -12,10 +12,17 @@ registry=${JFROG_NPM_REGISTRY}
 always-auth=true
 EOF
 
-# Configure Yarn Berry (v2+) — does not read ~/.npmrc for registry
-{
-  echo "YARN_NPM_REGISTRY_SERVER=${JFROG_NPM_REGISTRY}"
-  echo "YARN_NPM_AUTH_TOKEN=${JFROG_ACCESS_TOKEN}"
-} >> "$GITHUB_ENV"
+# Configure Yarn Berry (v2+).
+# YARN_NPM_AUTH_TOKEN env var is not reliably scoped to a custom
+# YARN_NPM_REGISTRY_SERVER in Yarn 3 — write ~/.yarnrc.yml directly so the
+# auth token is co-located with the registry entry, which is how Yarn Berry
+# handles scoped registry auth.
+cat >> ~/.yarnrc.yml << EOF
+npmRegistryServer: "${JFROG_NPM_REGISTRY}"
+npmRegistries:
+  "${JFROG_NPM_REGISTRY}":
+    npmAuthToken: "${JFROG_ACCESS_TOKEN}"
+    npmAlwaysAuth: true
+EOF
 
 echo "npm/yarn configured to use JFrog registry (db-npm)"

--- a/.github/scripts/configure-pip.sh
+++ b/.github/scripts/configure-pip.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Point pip at the internal JFrog PyPI registry.
+# Reads JFROG_ACCESS_TOKEN from the environment (set by jfrog-oidc-token.sh).
+set -euo pipefail
+
+echo "PIP_INDEX_URL=https://gha-service-account:${JFROG_ACCESS_TOKEN}@databricks.jfrog.io/artifactory/api/pypi/db-pypi/simple" >> "$GITHUB_ENV"
+
+echo "pip configured to use JFrog registry (db-pypi)"

--- a/.github/scripts/jfrog-oidc-token.sh
+++ b/.github/scripts/jfrog-oidc-token.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exchange a GitHub Actions OIDC token for a JFrog access token and
+# write JFROG_ACCESS_TOKEN to $GITHUB_ENV so subsequent steps can use it.
+
+# Get GitHub OIDC ID token
+ID_TOKEN=$(curl -sLS \
+  -H "User-Agent: actions/oidc-client" \
+  -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+  "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+echo "::add-mask::${ID_TOKEN}"
+
+# Exchange for JFrog access token
+ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+  "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+  -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+echo "::add-mask::${ACCESS_TOKEN}"
+
+if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+  echo "FAIL: Could not extract JFrog access token"
+  exit 1
+fi
+
+echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+
+echo "JFrog OIDC token obtained successfully"

--- a/.github/scripts/jfrog-oidc-token.sh
+++ b/.github/scripts/jfrog-oidc-token.sh
@@ -9,13 +9,11 @@ ID_TOKEN=$(curl -sLS \
   -H "User-Agent: actions/oidc-client" \
   -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
   "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-echo "::add-mask::${ID_TOKEN}"
 
 # Exchange for JFrog access token
 ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
   "https://databricks.jfrog.io/access/api/v1/oidc/token" \
   -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-echo "::add-mask::${ACCESS_TOKEN}"
 
 if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
   echo "FAIL: Could not extract JFrog access token"

--- a/.github/workflows/create-build-artifacts.yml
+++ b/.github/workflows/create-build-artifacts.yml
@@ -6,8 +6,12 @@ on:
 jobs:
   create-build-artifacts:
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     defaults:
       run:
@@ -15,6 +19,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Obtain JFrog OIDC token
+        run: bash .github/scripts/jfrog-oidc-token.sh
+
+      - name: Configure JFrog npm registry
+        run: bash .github/scripts/configure-npm.sh
 
       - name: Use Node.js 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,8 +17,12 @@ jobs:
     needs: ["create-build-artifacts"]
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/external-message.yml
+++ b/.github/workflows/external-message.yml
@@ -14,8 +14,8 @@ on:
 jobs:
   comment-on-pr:
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     permissions:
       pull-requests: write

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,8 +11,12 @@ jobs:
     name: Check secrets access
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     environment: "test-trigger-is"
     outputs:
@@ -33,8 +37,12 @@ jobs:
     name: Trigger Tests
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     needs: check-token
     if: github.event_name == 'pull_request'  && needs.check-token.outputs.has_token == 'true'
@@ -92,10 +100,11 @@ jobs:
     if: github.event_name == 'merge_group'
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     permissions:
+      id-token: write
       checks: write
       contents: read
 

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,8 +14,12 @@ jobs:
     needs: "create-build-artifacts"
 
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/publish-to-openvsx.yml
+++ b/.github/workflows/publish-to-openvsx.yml
@@ -13,9 +13,10 @@ on:
 
 jobs:
   publish-to-openvsx:
+    if: false # Temporarily disabled — pending secure release repo migration
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     environment: Production
 

--- a/.github/workflows/publish-to-vscode.yml
+++ b/.github/workflows/publish-to-vscode.yml
@@ -13,9 +13,10 @@ on:
 
 jobs:
   publish-to-vscode:
+    if: false # Temporarily disabled — pending secure release repo migration
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
 
     environment: Production
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,9 +9,22 @@ on:
 jobs:
   package:
     name: Package Arm64 VSIX
-    runs-on: "macos-latest"
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Obtain JFrog OIDC token
+        run: bash .github/scripts/jfrog-oidc-token.sh
+
+      - name: Configure JFrog npm registry
+        run: bash .github/scripts/configure-npm.sh
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -18,8 +18,12 @@ on:
 jobs:
   release-pr:
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     strategy:
       matrix:
@@ -43,6 +47,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
+
+      - name: Obtain JFrog OIDC token
+        run: bash .github/scripts/jfrog-oidc-token.sh
+
+      - name: Configure JFrog npm registry
+        run: bash .github/scripts/configure-npm.sh
 
       - run: yarn install --immutable
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: yarn run build
 
       - name: Unit Tests with Coverage
-        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+        uses: coactions/setup-xvfb@v1
         with:
           run: yarn run test:cov
           working-directory: packages/databricks-vscode

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,19 +12,17 @@ jobs:
       matrix:
         arch:
           - cli_arch: linux_amd64
-            os: linux-ubuntu-latest
-            runner:
-              group: databricks-protected-runner-group
-              labels: linux-ubuntu-latest
+            runner_group: databricks-protected-runner-group
+            runner_labels: linux-ubuntu-latest
           - cli_arch: windows_amd64
-            os: windows-server-latest-large
-            runner:
-              group: databricks-protected-runner-group-large
-              labels: windows-server-latest-large
+            runner_group: databricks-protected-runner-group-large
+            runner_labels: windows-server-latest-large
         node-version: [22.x]
         vscode-version: [stable]
 
-    runs-on: ${{ matrix.arch.runner }}
+    runs-on:
+      group: ${{ matrix.arch.runner_group }}
+      labels: ${{ matrix.arch.runner_labels }}
 
     permissions:
       id-token: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,14 +11,24 @@ jobs:
       fail-fast: false
       matrix:
         arch:
-          - cli_arch: darwin_amd64
-            os: macos-latest
+          - cli_arch: linux_amd64
+            os: linux-ubuntu-latest
+            runner:
+              group: databricks-protected-runner-group
+              labels: linux-ubuntu-latest
           - cli_arch: windows_amd64
-            os: windows-latest
+            os: windows-server-latest-large
+            runner:
+              group: databricks-protected-runner-group-large
+              labels: windows-server-latest-large
         node-version: [22.x]
         vscode-version: [stable]
 
-    runs-on: ${{ matrix.arch.os }}
+    runs-on: ${{ matrix.arch.runner }}
+
+    permissions:
+      id-token: write
+      contents: read
 
     env:
       VSCODE_TEST_VERSION: ${{ matrix.vscode-version }}
@@ -30,6 +40,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Obtain JFrog OIDC token
+        run: bash .github/scripts/jfrog-oidc-token.sh
+
+      - name: Configure JFrog npm registry
+        run: bash .github/scripts/configure-npm.sh
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -68,6 +84,9 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12" # 3.13+ is not yet supported by the latest DBR
+
+      - name: Configure JFrog pip registry
+        run: bash .github/scripts/configure-pip.sh
 
       - name: Install Python dependencies
         run: pip install ipython==9.11.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,8 @@ jobs:
             runner_group: databricks-protected-runner-group
             runner_labels: linux-ubuntu-latest
           - cli_arch: windows_amd64
-            runner_group: databricks-protected-runner-group-large
-            runner_labels: windows-server-latest-large
+            runner_group: databricks-protected-runner-group
+            runner_labels: windows-server-latest
         node-version: [22.x]
         vscode-version: [stable]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -73,10 +73,13 @@ jobs:
         run: yarn run build
 
       - name: Unit Tests with Coverage
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: yarn run test:cov
-          working-directory: packages/databricks-vscode
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            Xvfb :99 -screen 0 1024x768x24 >/dev/null 2>&1 &
+            export DISPLAY=:99
+          fi
+          yarn run test:cov
+        working-directory: packages/databricks-vscode
 
       - name: Install Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -10,8 +10,12 @@ on:
 jobs:
   update-cli-version:
     runs-on:
-      group: databricks-deco-testing-runner-group
-      labels: ubuntu-latest-deco
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
 
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ packages/databricks-sdk-js/src/config/testdata/azure/Library
 *.d.ts.map
 *.js.map
 tsconfig.tsbuildinfo
+
+# Local docs (not for version control)
+docs/


### PR DESCRIPTION

- Migrate all Linux workflows to hardened runners (`databricks-protected-runner-group`)
- Migrate Windows job in `unit-tests.yml` to `databricks-protected-runner-group-large`
- Move `push.yml` and `unit-tests.yml` off `macos-latest` to Linux hardened runners
- Add OIDC permissions + JFrog proxy scripts for npm/yarn and pip
- Temporarily disable `publish-to-vscode` and `publish-to-openvsx` pending Phase 3

This pull request was AI-assisted by Isaac.