### PR TITLE
 fix: Preserve profile name in Databricks CLI auth provider

### DIFF
--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -78,6 +78,15 @@ export abstract class AuthProvider {
             return true;
         }
 
+        // TODO: Temporary workaround until the JS SDK supports passing a profile
+        // directly to auth types. Once supported, remove this env mutation.
+        const profile = this.toJSON()["profile"];
+        if (profile !== undefined) {
+            process.env["DATABRICKS_CONFIG_PROFILE"] = profile;
+        } else {
+            delete process.env["DATABRICKS_CONFIG_PROFILE"];
+        }
+
         const checkFn = async (token?: CancellationToken) => {
             this.checked = await this._check(token);
         };

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -165,7 +165,8 @@ export abstract class AuthProvider {
                 return new DatabricksCliAuthProvider(
                     host,
                     json.databricksPath ?? cli.cliPath,
-                    cli
+                    cli,
+                    json.profile
                 );
 
             case "profile":
@@ -198,7 +199,8 @@ export abstract class AuthProvider {
                 return new DatabricksCliAuthProvider(
                     host,
                     config.databricksCliPath ?? cli.cliPath,
-                    cli
+                    cli,
+                    config.profile
                 );
 
             default:
@@ -308,7 +310,8 @@ export class DatabricksCliAuthProvider extends AuthProvider {
     constructor(
         host: URL,
         readonly cliPath: string,
-        cli: CliWrapper
+        cli: CliWrapper,
+        readonly profile?: string
     ) {
         super(host, "databricks-cli", cli);
     }
@@ -322,6 +325,7 @@ export class DatabricksCliAuthProvider extends AuthProvider {
             host: this.host.toString(),
             authType: this.authType,
             databricksPath: this.cliPath,
+            ...(this.profile ? {profile: this.profile} : {}),
         };
     }
 
@@ -330,14 +334,19 @@ export class DatabricksCliAuthProvider extends AuthProvider {
             host: this.host.toString(),
             authType: "databricks-cli",
             databricksCliPath: this.cliPath,
+            ...(this.profile ? {profile: this.profile} : {}),
         });
     }
 
     toEnv(): Record<string, string> {
-        return {
+        const env: Record<string, string> = {
             DATABRICKS_HOST: this.host.toString(),
             DATABRICKS_AUTH_TYPE: "databricks-cli",
         };
+        if (this.profile) {
+            env["DATABRICKS_CONFIG_PROFILE"] = this.profile;
+        }
+        return env;
     }
 
     toIni() {

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -92,15 +92,6 @@ export class DatabricksCliCheck implements Disposable {
             }
         );
 
-        // TODO: Temporary workaround until the JS SDK supports passing a profile
-        // directly to the databricks-cli auth type. Once supported, remove process.env mutation
-        const profile = this.authProvider.profile;
-        if (profile) {
-            process.env["DATABRICKS_CONFIG_PROFILE"] = profile;
-        } else {
-            delete process.env["DATABRICKS_CONFIG_PROFILE"];
-        }
-
         try {
             await workspaceClient.currentUser.me(
                 new Context({cancellationToken})

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -84,12 +84,22 @@ export class DatabricksCliCheck implements Disposable {
                 host: this.authProvider.host.toString(),
                 authType: "databricks-cli",
                 databricksCliPath: this.authProvider.cliPath,
+                profile: this.authProvider.profile,
             },
             {
                 product: "databricks-vscode",
                 productVersion: extensionVersion,
             }
         );
+
+        // TODO: Temporary workaround until the JS SDK supports passing a profile
+        // directly to the databricks-cli auth type. Once supported, remove process.env mutation
+        const profile = this.authProvider.profile;
+        if (profile) {
+            process.env["DATABRICKS_CONFIG_PROFILE"] = profile;
+        } else {
+            delete process.env["DATABRICKS_CONFIG_PROFILE"];
+        }
 
         try {
             await workspaceClient.currentUser.me(
@@ -105,9 +115,16 @@ export class DatabricksCliCheck implements Disposable {
     private async login(cancellationToken?: CancellationToken): Promise<void> {
         try {
             const host = this.authProvider.host.toString().replace(/\/+$/, "");
+            const profile = this.authProvider.profile;
+            const args = ["auth", "login"];
+            if (profile) {
+                args.push("--profile", profile);
+            } else {
+                args.push("--host", host);
+            }
             await execFile(
                 this.authProvider.cliPath,
-                ["auth", "login", "--host", host],
+                args,
                 {},
                 cancellationToken
             );


### PR DESCRIPTION
## Changes

When the databricks-cli auth type is used with a named profile (e.g. from ~/.databrickscfg), the profile name was not being threaded through to DatabricksCliAuthProvider. As a result `auth login` always used --host, causing issues with new databricks cli when same host exists under multiple profiles.

AuthProvider.ts
- Added optional profile parameter to DatabricksCliAuthProvider constructor
- Threads json.profile / config.profile through both deserialization paths (fromJSON, fromConfig)
- toEnv() now sets DATABRICKS_CONFIG_PROFILE when a profile is present
- toJSON() / toConfig() now persist the profile name so round-trips are lossless

DatabricksCliCheck.ts
- Passes profile in the workspace client config object
- Adds a temporary process.env mutation workaround for the JS SDK not yet supporting profile passthrough to the databricks-cli auth type (marked with a
TODO to remove once the SDK adds support)
- login() now calls auth login --profile <name> when a profile is set, falling back to --host otherwise

Notes:
The process.env["DATABRICKS_CONFIG_PROFILE"] mutation in DatabricksCliCheck is a workaround and should be revisited once the upstream JS SDK exposes a proper API for this.

## Tests

Manually
