### PR TITLE
Install extension deps from vendored VSIX when available

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -210,7 +210,6 @@
                 "icon": "$(gear)",
                 "title": "Select a Declarative Automation Bundle target",
                 "enablement": "databricks.context.activated && !databricks.context.remoteMode",
-
                 "category": "Databricks"
             },
             {

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -433,9 +433,7 @@ export const config: Options.Testrunner = {
                             f.endsWith("-universal.vsix")
                     );
                 if (vsix) {
-                    console.log(
-                        `Using vendored VSIX for ${extId}: ${vsix}`
-                    );
+                    console.log(`Using vendored VSIX for ${extId}: ${vsix}`);
                     extensionDependencies.push(
                         "--install-extension",
                         path.resolve(vsixDir, vsix)
@@ -444,10 +442,7 @@ export const config: Options.Testrunner = {
                     console.log(
                         `WARNING: no vendored VSIX for ${extId}, falling back to marketplace`
                     );
-                    extensionDependencies.push(
-                        "--install-extension",
-                        extId
-                    );
+                    extensionDependencies.push("--install-extension", extId);
                 }
             } else {
                 extensionDependencies.push("--install-extension", extId);

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -11,7 +11,7 @@ import fs from "fs/promises";
 import {Config, WorkspaceClient} from "@databricks/sdk-experimental";
 import * as ElementCustomCommands from "./customCommands/elementCustomCommands.ts";
 import {execFile as execFileCb} from "node:child_process";
-import {cpSync, mkdirSync, rmSync} from "node:fs";
+import {cpSync, mkdirSync, readdirSync, rmSync} from "node:fs";
 import {tmpdir} from "node:os";
 import packageJson from "../../../package.json" assert {type: "json"};
 import {sleep} from "wdio-vscode-service";
@@ -412,9 +412,47 @@ export const config: Options.Testrunner = {
                 );
                 break;
         }
-        const extensionDependencies = packageJson.extensionDependencies.flatMap(
-            (item) => ["--install-extension", item]
-        );
+        // When EXTENSION_VSIX_DIR is set (CI with vendored VSIX files),
+        // resolve extensions from that directory instead of the marketplace.
+        const vsixDir = process.env.EXTENSION_VSIX_DIR;
+        const extensionDependencies: string[] = [];
+        for (const extId of packageJson.extensionDependencies) {
+            if (vsixDir) {
+                const targetPlatform = `${process.platform}-${process.arch}`;
+                const files = readdirSync(vsixDir);
+                const prefix = `${extId}-`;
+                const vsix =
+                    files.find(
+                        (f) =>
+                            f.startsWith(prefix) &&
+                            f.endsWith(`-${targetPlatform}.vsix`)
+                    ) ??
+                    files.find(
+                        (f) =>
+                            f.startsWith(prefix) &&
+                            f.endsWith("-universal.vsix")
+                    );
+                if (vsix) {
+                    console.log(
+                        `Using vendored VSIX for ${extId}: ${vsix}`
+                    );
+                    extensionDependencies.push(
+                        "--install-extension",
+                        path.resolve(vsixDir, vsix)
+                    );
+                } else {
+                    console.log(
+                        `WARNING: no vendored VSIX for ${extId}, falling back to marketplace`
+                    );
+                    extensionDependencies.push(
+                        "--install-extension",
+                        extId
+                    );
+                }
+            } else {
+                extensionDependencies.push("--install-extension", extId);
+            }
+        }
 
         console.log("running vscode cli");
         const res = await execFile(cli, [


### PR DESCRIPTION
## Summary
- When `EXTENSION_VSIX_DIR` env var is set, resolve extension dependencies from local VSIX files instead of VS Code marketplace
- Falls back to marketplace IDs when unset (local dev unchanged)
- Matches platform-specific VSIX (`-linux-x64.vsix`) then falls back to universal (`-universal.vsix`)

Companion PR: https://github.com/databricks-eng/eng-dev-ecosystem/pull/1246

## Test plan
- [ ] Local `yarn run test:integ:extension` still works without `EXTENSION_VSIX_DIR`
- [ ] CI integration tests pass with vendored VSIX files

This pull request and its description were written by Isaac.