### PR TITLE
Fix write permissions in release workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -23,7 +23,8 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- PR #1873 added explicit `permissions` blocks with `contents: read` to all jobs for JFrog OIDC support. This inadvertently revoked the implicit `contents: write` that release operations require.
- `create-release.yml`: `contents: read` → `write` (needed for `gh release create`)
- `nightly-release.yml`: `contents: read` → `write` (needed for `softprops/action-gh-release`)
- `release-pr.yml`: `contents: read` → `write` + added `pull-requests: write` (needed for `git push` + `gh pr create`)

## Test plan
- [ ] Merge and trigger nightly release (push to main) — verify `create-build-artifacts` + `create-release` both succeed
- [ ] Trigger `release-pr.yml` manually with a test version — verify branch creation + PR creation succeed
- [ ] Trigger `create-release.yml` manually — verify draft GitHub Release is created with VSIX artifacts

This pull request and its description were written by Isaac.