### PR TITLE
Replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -33,10 +33,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: nightly-${{ github.ref_name }}
         run: |
-          if gh release view "$TAG" &>/dev/null; then
-            gh release upload "$TAG" --clobber packages/databricks-vscode/databricks*/*.vsix
+          REPO=databricks/databricks-vscode
+          if gh release view "$TAG" --repo "$REPO" &>/dev/null; then
+            gh release upload "$TAG" --repo "$REPO" --clobber packages/databricks-vscode/databricks*/*.vsix
           else
             gh release create "$TAG" \
+              --repo "$REPO" \
               --title "Nightly - ${{ github.ref_name }}" \
               --prerelease \
               --target "${{ github.sha }}" \

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,10 +29,17 @@ jobs:
       - run: ls -lR packages/databricks-vscode
 
       - name: Update nightly release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          name: Nightly - ${{ github.ref_name }}
-          prerelease: true
-          tag_name: nightly-${{ github.ref_name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: "packages/databricks-vscode/databricks*/*.vsix"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: nightly-${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" &>/dev/null; then
+            gh release upload "$TAG" --clobber packages/databricks-vscode/databricks*/*.vsix
+          else
+            gh release create "$TAG" \
+              --title "Nightly - ${{ github.ref_name }}" \
+              --prerelease \
+              --target "${{ github.sha }}" \
+              --notes "Nightly build from ${{ github.ref_name }}" \
+              packages/databricks-vscode/databricks*/*.vsix
+          fi


### PR DESCRIPTION
## Summary
- `softprops/action-gh-release` is not allowed in the org's action registry
- Replace with equivalent `gh release` CLI commands in the nightly release workflow
- If the nightly release already exists: `gh release upload --clobber` (replaces VSIX assets in-place)
- If it doesn't exist: `gh release create --prerelease`

## Test plan
- [ ] Merge and verify nightly release triggers on push to main
- [ ] Verify VSIX files are uploaded to the `nightly-main` GitHub release

This pull request and its description were written by Isaac.