### PR TITLE
Update Databricks CLI to v0.297.2

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1155,7 +1155,7 @@
         "useYarn": false
     },
     "cli": {
-        "version": "0.295.0"
+        "version": "0.297.2"
     },
     "scripts": {
         "vscode:prepublish": "rm -rf out && yarn run package:compile && yarn run package:wrappers:write && yarn run package:jupyter-init-script:write && yarn run package:copy-webview-toolkit && yarn run generate-telemetry",


### PR DESCRIPTION
## Summary

Bump bundled Databricks CLI from v0.295.0 → v0.297.2.

## CLI changes since v0.295.0

### v0.297.2 (2026-04-19)
- **Fix `error downloading Terraform: unable to verify checksums signature: openpgp: key expired`** for `bundle deploy` — uses a hardcoded ArmoredPublicKey for the TF binary install ([#5019](https://github.com/databricks/cli/pull/5019)). **Highly relevant** — extension users hitting this during `bundle deploy` flows are unblocked by the upgrade.

### v0.297.1
- Dep bump only: Go toolchain to 1.25.9.

### v0.297.0
- CLI: `auth` commands accept a profile name as a positional argument ([#4840](https://github.com/databricks/cli/pull/4840)).
- CLI: new `auth logout` command to clear cached OAuth tokens / remove profiles ([#4613](https://github.com/databricks/cli/pull/4613), [#4616](https://github.com/databricks/cli/pull/4616), [#4647](https://github.com/databricks/cli/pull/4647)).
- Bundles: `lifecycle.started` option for apps ([#4672](https://github.com/databricks/cli/pull/4672)).
- Bundles: resource references now resolved correctly in apps config ([#4964](https://github.com/databricks/cli/pull/4964)).
- Bundles: allow `run_as` for dashboards with `embed_credentials: false` ([#4961](https://github.com/databricks/cli/pull/4961)).
- Direct engine: permissions fix for `resources.models` ([#4941](https://github.com/databricks/cli/pull/4941)); update mask fix for apps ([#4963](https://github.com/databricks/cli/pull/4963)); dotted map keys fix ([#4977](https://github.com/databricks/cli/pull/4977)).

### v0.296.0
- **Direct deployment engine for DABs is now in Public Preview** (`docs/direct.md`). Relevant to the extension's bundle deploy UX, though opt-in.
- CLI: `auth` commands error when `--profile` and `--host` conflict ([#4841](https://github.com/databricks/cli/pull/4841)).
- CLI: `--force-refresh` flag on `databricks auth token` ([#4767](https://github.com/databricks/cli/pull/4767)).
- Bundles: `bundle deployment bind` now pulls remote state before modifying ([#4892](https://github.com/databricks/cli/pull/4892)).
- Bundles: dedupe grant entries ([#4801](https://github.com/databricks/cli/pull/4801)).
- Direct engine: several fixes (grants reordering, ALL_PRIVILEGES, secret scope recreation/permissions, bind/unbind for non-TF resources, removed principals).

## Relevance to the extension

- **TF checksum fix (v0.297.2)** — unblocks `bundle deploy` for users hitting the expired-key error; this alone is a good reason to ship.
- **Auth CLI surface changes** — extension shells out to `databricks auth …`; `--profile` + `--host` now conflict, and `auth logout` / positional profile are new. Worth a glance at auth-related code paths to make sure we aren't passing both.
- **Direct deploy engine GA preview** — no action required today (opt-in), but worth tracking for future bundle deploy UX.

## Test plan
- [ ] CI green (unit tests, integration tests pulling the pinned CLI).
- [ ] Manually sanity-check `bundle deploy` from the extension against a simple bundle to confirm the TF download path works.
- [ ] Verify `databricks auth login` / token refresh flows still work from the extension.

This pull request and its description were written by Isaac.