### PR TITLE
Update minimal python and dbconnect versions for serverless

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1131,6 +1131,11 @@
                         "default": true,
                         "markdownDescription": "Show PySpark progress bar when using Databricks Connect. Requires `ipywidgets` package and `pyspark@3.5.0+`."
                     },
+                    "databricks.connect.serverlessDbconnectVersion": {
+                        "type": "string",
+                        "default": "17.3",
+                        "markdownDescription": "Default `databricks-connect` version for serverless compute. Determines required Python version and suggested package version. Minimum supported value is `15.4`."
+                    },
                     "databricks.ipythonDir": {
                         "type": "string",
                         "description": "Absolute path to a directory for storing IPython files. Defaults to IPYTHONDIR environment variable (if set) or ~/.ipython."

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
@@ -4,6 +4,7 @@ import {Disposable} from "vscode";
 import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
 import {ConnectionManager} from "../configuration/ConnectionManager";
 import {DATABRICKS_CONNECT_VERSION as DATABRICKS_CONNECT_MINIMAL_VERSION} from "../utils/constants";
+import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 export class EnvironmentDependenciesInstaller implements Disposable {
     private disposables: Disposable[] = [];
@@ -67,7 +68,12 @@ export class EnvironmentDependenciesInstaller implements Disposable {
 
     async getSuggestedVersion() {
         if (this.connectionManager.serverless) {
-            return "15.1.*";
+            const serverlessVersion =
+                workspaceConfigs.serverlessDbconnectVersion;
+            const parts = serverlessVersion.split(".");
+            const major = parts[0];
+            const minor = parts[1] ?? "3";
+            return `${major}.${minor}.*`;
         }
         const dbrVersionParts =
             this.connectionManager.cluster?.dbrVersion || [];

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
@@ -9,6 +9,7 @@ import {FeatureStepState} from "../feature-manager/FeatureManager";
 import {ResolvedEnvironment} from "./MsPythonExtensionApi";
 import {NamedLogger} from "@databricks/sdk-experimental/dist/logging";
 import {ConfigureAutocomplete} from "./ConfigureAutocomplete";
+import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
     private readonly logger = NamedLogger.getOrCreate(Loggers.Extension);
@@ -217,10 +218,20 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
                 (env.version.major !== 3 || env.version.minor < 10);
             let dbrVersion = this.connectionManager.cluster?.dbrVersion || [];
             if (this.connectionManager.serverless) {
-                dbrVersion = [15, 1];
+                const serverlessVersion =
+                    workspaceConfigs.serverlessDbconnectVersion;
+                const serverlessVersionParts = serverlessVersion.split(".");
+                const serverlessMajor = parseInt(serverlessVersionParts[0], 10);
+                const serverlessMinor = parseInt(
+                    serverlessVersionParts[1] ?? "0",
+                    10
+                );
+                dbrVersion = [serverlessMajor, serverlessMinor];
+                const minPythonMinor = serverlessMajor >= 16 ? 12 : 11;
                 envVersionTooLow =
                     env?.version &&
-                    (env.version.major !== 3 || env.version.minor < 11);
+                    (env.version.major !== 3 ||
+                        env.version.minor < minPythonMinor);
             }
             const expectedPythonVersion =
                 this.getExpectedPythonVersionMessage(dbrVersion);
@@ -275,12 +286,12 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
         if (
             this.connectionManager.serverless &&
             (dbconnectMajor < 15 ||
-                (dbconnectMajor === 15 && dbconnectMinor < 1))
+                (dbconnectMajor === 15 && dbconnectMinor < 4))
         ) {
             return this.rejectStep(
                 "checkEnvironmentDependencies",
                 "Update databricks-connect",
-                `Databricks Connect ${version} doesn't support serverless, please update to 15.1.0 or higher.`,
+                `Databricks Connect ${version} doesn't support serverless, please update to 15.4.0 or higher.`,
                 this.reinstallDbConnect.bind(this)
             );
         }

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -123,6 +123,14 @@ export const workspaceConfigs = {
         return dir;
     },
 
+    get serverlessDbconnectVersion(): string {
+        return (
+            workspace
+                .getConfiguration("databricks")
+                .get<string>("connect.serverlessDbconnectVersion") ?? "17.3"
+        );
+    },
+
     get bundleRemoteStateRefreshInterval(): number {
         const config =
             workspace


### PR DESCRIPTION
## Changes
- package.json — Added databricks.connect.serverlessDbconnectVersion setting (default "17.3")
- WorkspaceConfigs.ts — Added serverlessDbconnectVersion getter reading the new setting
- EnvironmentDependenciesVerifier.ts:
    - checkPythonEnvironment: replaces hardcoded [15, 1] with DBR version derived from serverlessDbconnectVersion; min Python minor is 12 for major ≥ 16, else 11
    - checkDatabricksConnectVersion: bumps min serverless version from < 15.1 to < 15.4 and updates the error message
EnvironmentDependenciesInstaller.ts:
    - getSuggestedVersion: replaces hardcoded "15.1.*" with "<major>.<minor>.*" derived from serverlessDbconnectVersion

## Tests

Manual
