### PR TITLE
Bundle terraform and databricks provider in VSIX used for e2e tests

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1186,7 +1186,7 @@
         "test:lint": "eslint src --ext ts && prettier . -c",
         "test:unit": "yarn run build && node ./out/test/runTest.js",
         "test:python": "DATABRICKS_EXTENSION_UNIT_TESTS=1 python -B -m unittest discover -s ./src/test/python -p '*_test.py'",
-        "test:integ:prepare": "yarn run package",
+        "test:integ:prepare": "./scripts/package-vsix-tests.sh",
         "test:integ:extension": "yarn run test:integ:prepare && wdio run src/test/e2e/wdio.conf.ts",
         "test:integ:sdk": "ts-mocha --type-check 'src/sdk-extensions/**/*.integ.ts'",
         "test:integ": "yarn run test:integ:extension && yarn run test:integ:sdk",

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1243,6 +1243,7 @@
         "esbuild": "^0.25.0",
         "eslint": "^8.55.0",
         "eslint-plugin-local-rules": "^2.0.1",
+        "extract-zip": "^2.0.1",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "mocha": "^10.2.0",

--- a/packages/databricks-vscode/scripts/package-vsix-tests.sh
+++ b/packages/databricks-vscode/scripts/package-vsix-tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+
+# Wrapper around package-vsix.sh that builds a VSIX for the host platform/arch
+# and records its filename for the e2e test runner (wdio.conf.ts) to pick up.
+# This ensures e2e tests run against a VSIX with terraform + databricks
+# provider bundled, matching what is shipped to users.
+
+cd $(dirname $(realpath $0))/..
+
+OS_RAW=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS_RAW" in
+  linux)                PLATFORM=linux;  BUILD_OS=linux ;;
+  darwin)               PLATFORM=darwin; BUILD_OS=darwin ;;
+  mingw*|msys*|cygwin*) PLATFORM=win32;  BUILD_OS=windows ;;
+  *) echo "Unsupported OS: $OS_RAW" >&2; exit 1 ;;
+esac
+
+ARCH_RAW=$(uname -m)
+case "$ARCH_RAW" in
+  x86_64|amd64)  ARCH=x64;   BUILD_ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64; BUILD_ARCH=arm64 ;;
+  *) echo "Unsupported arch: $ARCH_RAW" >&2; exit 1 ;;
+esac
+
+VSIX_ARCH="${PLATFORM}-${ARCH}"
+export BUILD_PLATFORM_ARCH="${BUILD_OS}_${BUILD_ARCH}"
+
+./scripts/package-vsix.sh "$VSIX_ARCH"
+
+VERSION=$(jq -r .version < package.json)
+NAME=$(jq -r .name < package.json)
+VSIX_FILE="${NAME}-${VSIX_ARCH}-${VERSION}.vsix"
+
+mkdir -p .build
+echo "$VSIX_FILE" > .build/test-vsix-path
+
+echo "Test VSIX: $VSIX_FILE"

--- a/packages/databricks-vscode/scripts/setupCLIDependencies.ts
+++ b/packages/databricks-vscode/scripts/setupCLIDependencies.ts
@@ -60,11 +60,11 @@ async function main() {
     const arch = argv.arch!;
     const terraformZip = `terraform_${terraform.version}_${arch}.zip`;
     const terraformUrl = `https://releases.hashicorp.com/terraform/${terraform.version}/${terraformZip}`;
-    spawn("curl", ["-sLO", terraformUrl], {cwd: tempDir});
+    spawn("curl", ["-sLO", "--fail", terraformUrl], {cwd: tempDir});
     // Check sha of the archive
     const shasumsFile = `terraform_${terraform.version}_SHA256SUMS`;
     const shasumsUrl = `https://releases.hashicorp.com/terraform/${terraform.version}/${shasumsFile}`;
-    spawn("curl", ["-sLO", shasumsUrl], {cwd: tempDir});
+    spawn("curl", ["-sLO", "--fail", shasumsUrl], {cwd: tempDir});
     await verifySha256(
         path.join(tempDir, terraformZip),
         path.join(tempDir, shasumsFile),
@@ -79,19 +79,8 @@ async function main() {
 
     // Download databricks provider archive for the selected arch
     const providerZip = `terraform-provider-databricks_${terraform.providerVersion}_${arch}.zip`;
-    spawn(
-        "gh",
-        [
-            "release",
-            "download",
-            `v${terraform.providerVersion}`,
-            "--pattern",
-            providerZip,
-            "--repo",
-            "databricks/terraform-provider-databricks",
-        ],
-        {cwd: tempDir}
-    );
+    const providerUrl = `https://github.com/databricks/terraform-provider-databricks/releases/download/v${terraform.providerVersion}/${providerZip}`;
+    spawn("curl", ["-sLO", "--fail", providerUrl], {cwd: tempDir});
     const providersMirrorRelPath = path.join(depsDir, "providers");
     const databricksProviderDir = path.join(
         providersMirrorRelPath,

--- a/packages/databricks-vscode/scripts/setupCLIDependencies.ts
+++ b/packages/databricks-vscode/scripts/setupCLIDependencies.ts
@@ -1,10 +1,13 @@
 import {mkdirp} from "fs-extra";
 import assert from "node:assert";
 import {spawnSync} from "node:child_process";
+import {createHash} from "node:crypto";
+import {createReadStream} from "node:fs";
 import {cp, readFile, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import path from "node:path";
 import yargs from "yargs";
+import extract from "extract-zip";
 import type {
     TerraformMetadata,
     TerraformMetadataFromCli,
@@ -62,16 +65,12 @@ async function main() {
     const shasumsFile = `terraform_${terraform.version}_SHA256SUMS`;
     const shasumsUrl = `https://releases.hashicorp.com/terraform/${terraform.version}/${shasumsFile}`;
     spawn("curl", ["-sLO", shasumsUrl], {cwd: tempDir});
-    const shasumRes = spawn(
-        "shasum",
-        ["--algorithm", "256", "--check", shasumsFile],
-        {cwd: tempDir}
+    await verifySha256(
+        path.join(tempDir, terraformZip),
+        path.join(tempDir, shasumsFile),
+        terraformZip
     );
-    assert(
-        shasumRes.output.toString().includes(`${terraformZip}: OK`),
-        "sha256sum check failed"
-    );
-    spawn("unzip", ["-q", terraformZip], {cwd: tempDir});
+    await extract(path.join(tempDir, terraformZip), {dir: tempDir});
     const fileExt = arch.includes("windows") ? ".exe" : "";
     const terraformBinRelPath = path.join(depsDir, `terraform${fileExt}`);
     await cp(`${tempDir}/terraform${fileExt}`, terraformBinRelPath);
@@ -121,6 +120,37 @@ async function main() {
     await writeFile(argv.package!, JSON.stringify(jsonData, null, 4), {
         encoding: "utf-8",
     });
+}
+
+async function sha256OfFile(filePath: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const hash = createHash("sha256");
+        const stream = createReadStream(filePath);
+        stream.on("error", reject);
+        stream.on("data", (chunk) => hash.update(chunk));
+        stream.on("end", () => resolve(hash.digest("hex")));
+    });
+}
+
+async function verifySha256(
+    filePath: string,
+    sumsFile: string,
+    expectedFilename: string
+) {
+    const sumsContent = await readFile(sumsFile, {encoding: "utf-8"});
+    const line = sumsContent
+        .split("\n")
+        .find((l) => l.trim().endsWith(expectedFilename));
+    assert(
+        line,
+        `Could not find ${expectedFilename} in ${path.basename(sumsFile)}`
+    );
+    const expected = line.trim().split(/\s+/)[0];
+    const actual = await sha256OfFile(filePath);
+    assert(
+        actual === expected,
+        `SHA256 mismatch for ${expectedFilename}: expected ${expected}, got ${actual}`
+    );
 }
 
 function spawn(command: string, args: string[], options: any = {}) {

--- a/packages/databricks-vscode/scripts/setupCLIDependencies.ts
+++ b/packages/databricks-vscode/scripts/setupCLIDependencies.ts
@@ -127,9 +127,15 @@ function spawn(command: string, args: string[], options: any = {}) {
     const child = spawnSync(command, args, options);
     if (child.error) {
         throw child.error;
-    } else {
-        return child;
     }
+    if (child.status !== 0) {
+        throw new Error(
+            `${command} ${args.join(" ")} exited with status ${child.status}\n` +
+                `stdout: ${child.stdout?.toString() ?? ""}\n` +
+                `stderr: ${child.stderr?.toString() ?? ""}`
+        );
+    }
+    return child;
 }
 
 main();

--- a/packages/databricks-vscode/scripts/setupCLIDependencies.ts
+++ b/packages/databricks-vscode/scripts/setupCLIDependencies.ts
@@ -149,7 +149,9 @@ function spawn(command: string, args: string[], options: any = {}) {
     }
     if (child.status !== 0) {
         throw new Error(
-            `${command} ${args.join(" ")} exited with status ${child.status}\n` +
+            `${command} ${args.join(" ")} exited with status ${
+                child.status
+            }\n` +
                 `stdout: ${child.stdout?.toString() ?? ""}\n` +
                 `stderr: ${child.stderr?.toString() ?? ""}`
         );

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -11,7 +11,7 @@ import fs from "fs/promises";
 import {Config, WorkspaceClient} from "@databricks/sdk-experimental";
 import * as ElementCustomCommands from "./customCommands/elementCustomCommands.ts";
 import {execFile as execFileCb} from "node:child_process";
-import {cpSync, mkdirSync, readdirSync, rmSync} from "node:fs";
+import {cpSync, mkdirSync, readdirSync, readFileSync, rmSync} from "node:fs";
 import {tmpdir} from "node:os";
 import packageJson from "../../../package.json" assert {type: "json"};
 import {sleep} from "wdio-vscode-service";
@@ -23,15 +23,16 @@ const WORKSPACE_PATH = path.resolve(tmpdir(), "test-root");
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const {version, name, engines} = packageJson;
+const {engines} = packageJson;
 
 const EXTENSIONS_DIR = path.resolve(tmpdir(), "extension test", "extension");
+const PACKAGE_ROOT = path.resolve(__dirname, "..", "..", "..");
 const VSIX_PATH = path.resolve(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    `${name}-${version}.vsix`
+    PACKAGE_ROOT,
+    readFileSync(
+        path.resolve(PACKAGE_ROOT, ".build", "test-vsix-path"),
+        "utf-8"
+    ).trim()
 );
 const VSCODE_STORAGE_DIR = path.resolve(tmpdir(), "user-data-dir");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3782,6 +3782,7 @@ __metadata:
     esbuild: ^0.25.0
     eslint: ^8.55.0
     eslint-plugin-local-rules: ^2.0.1
+    extract-zip: ^2.0.1
     fs-extra: ^11.2.0
     glob: ^10.3.10
     lodash: ^4.17.21
@@ -4863,7 +4864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1":
+"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:


### PR DESCRIPTION
## Summary
- E2E tests were running against a plain `vsce package` build, which omits the bundled terraform binary and databricks provider. When the eng-dev-ecosystem runners can't reach `registry.terraform.io`, `bundle deploy` fails with `terraform init: ... could not connect to registry.terraform.io`.
- Make `test:integ:prepare` produce the same kind of bundled VSIX that ships to users, via a host-arch wrapper around `package-vsix.sh`. wdio reads the produced VSIX filename from a sidecar (`.build/test-vsix-path`) so naming logic isn't duplicated.
- Make `setupCLIDependencies.ts` cross-platform and robust:
  - Replace shell `shasum` with Node `crypto` (Windows runners don't have `shasum`; on Linux/macOS, `shasum --check` against the full SHA256SUMS file exited non-zero because un-downloaded entries failed to open).
  - Replace shell `unzip` with `extract-zip` (already present transitively).
  - Switch the databricks provider download from `gh release download` to `curl` against the public releases URL (`gh` issued GraphQL API calls that hit the databricks org's IP allow list and got blocked — the asset URL itself is on the public github.com CDN and works fine, same as we already do for the terraform binary).
  - Surface non-zero exit codes from the `spawn` helper (it was only throwing on spawn failures, masking real exec failures).
- Pairs with databricks-eng/eng-dev-ecosystem#1268 which drops the now-redundant `Fetching Databricks CLI` workflow step (`package-vsix.sh` re-fetches the CLI itself).

## Test plan
- [x] Verified locally on darwin-arm64: \`yarn run test:integ:prepare\` produces \`databricks-darwin-arm64-2.10.6.vsix\` with \`terraformMetadata\` populated and \`extension/bin/dependencies/{terraform,providers/...}\` bundled.
- [x] wdio resolves the VSIX path correctly from the sidecar.
- [x] \`tsc --noEmit\` and \`yarn run test:lint\` pass.
- [ ] CI: trigger \`vscode-isolated-test-main.yml\` against this branch (with the matching eng-dev-ecosystem PR); confirm linux_amd64 and windows_amd64 jobs both pass the \`bundle deploy\` step that previously failed with \`registry.terraform.io: EOF\`.

This pull request and its description were written by Isaac.