### PR TITLE
 Include profiles with account_id in listProfiles results

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -169,6 +169,34 @@ nothing = true
         });
     });
 
+    it("should include profiles with account id", async () => {
+        const logFilePath = getTempLogFilePath();
+        const cli = createCliWrapper(logFilePath);
+
+        await withFile(async ({path}) => {
+            writeFileSync(
+                path,
+                `[regular-profile]
+host = https://cloud.databricks.com/
+token = dapitest1234
+
+[profile-with-accunt-id]
+host = https://accounts.cloud.databricks.com/
+account_id = 1234567890
+token = dapitest5678
+`,
+                "utf-8"
+            );
+
+            const profiles = await cli.listProfiles(path);
+
+            assert.equal(profiles.length, 2);
+            assert.equal(profiles[0].name, "regular-profile");
+            assert.equal(profiles[1].name, "profile-with-accunt-id");
+            assert.equal(profiles[1].accountId, "1234567890");
+        });
+    });
+
     it("should show error for corrupted config file and return empty profile list", async () => {
         const logFilePath = getTempLogFilePath();
         const cli = createCliWrapper(logFilePath);

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -180,7 +180,7 @@ nothing = true
 host = https://cloud.databricks.com/
 token = dapitest1234
 
-[profile-with-accunt-id]
+[profile-with-account-id]
 host = https://accounts.cloud.databricks.com/
 account_id = 1234567890
 token = dapitest5678
@@ -192,7 +192,7 @@ token = dapitest5678
 
             assert.equal(profiles.length, 2);
             assert.equal(profiles[0].name, "regular-profile");
-            assert.equal(profiles[1].name, "profile-with-accunt-id");
+            assert.equal(profiles[1].name, "profile-with-account-id");
             assert.equal(profiles[1].accountId, "1234567890");
         });
     });

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -404,10 +404,7 @@ export class CliWrapper {
             return [];
         }
 
-        let profiles = JSON.parse(res.stdout).profiles || [];
-
-        // filter out account profiles
-        profiles = profiles.filter((p: any) => !p.account_id);
+        const profiles = JSON.parse(res.stdout).profiles || [];
 
         const result = [];
         let hasError = false;


### PR DESCRIPTION


## Changes

Previously, `listProfiles` filtered out any profile with `account_id` set, using it as a signal to distinguish account-level profiles from  workspace-level ones. This assumption broke when the Databricks CLI began populating `account_id` on workspace profiles as well  causing valid workspace profiles to be silently dropped from the list.

Removing the filter restores correct behaviour: all profiles are returned
regardless of whether `account_id` is present.

## Tests

Unit test: CliWrapper.test.ts
