### PR TITLE
Bump Databricks JS SDK to 0.17.0

### DIFF
--- a/packages/databricks-vscode-types/package.json
+++ b/packages/databricks-vscode-types/package.json
@@ -29,7 +29,7 @@
         "typescript": "^5.3.3"
     },
     "dependencies": {
-        "@databricks/sdk-experimental": "^0.16.0",
+        "@databricks/sdk-experimental": "^0.17.0",
         "databricks": "workspace:^"
     }
 }

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1198,7 +1198,7 @@
     },
     "dependencies": {
         "@databricks/databricks-vscode-types": "workspace:^",
-        "@databricks/sdk-experimental": "^0.16.0",
+        "@databricks/sdk-experimental": "^0.17.0",
         "@types/lodash": "^4.14.202",
         "@types/shell-quote": "^1.7.5",
         "@vscode/debugadapter": "^1.64.0",

--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -78,15 +78,6 @@ export abstract class AuthProvider {
             return true;
         }
 
-        // TODO: Temporary workaround until the JS SDK supports passing a profile
-        // directly to auth types. Once supported, remove this env mutation.
-        const profile = this.toJSON()["profile"];
-        if (profile !== undefined) {
-            process.env["DATABRICKS_CONFIG_PROFILE"] = profile;
-        } else {
-            delete process.env["DATABRICKS_CONFIG_PROFILE"];
-        }
-
         const checkFn = async (token?: CancellationToken) => {
             this.checked = await this._check(token);
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@databricks/sdk-experimental@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "@databricks/sdk-experimental@npm:0.17.0"
+  dependencies:
+    google-auth-library: ^10.5.0
+    ini: ^6.0.0
+    reflect-metadata: ^0.2.2
+    semver: ^7.7.3
+  checksum: 34de7d8708de12bf1fa44ae5ced7f8886a26d3ef9f072b47955c63dd7c3ae32db7c0b243074907b371026ee352d76c90d02faa9df0e95ad5d9e8aa22dc53d0b5
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/aix-ppc64@npm:0.25.0"
@@ -3745,7 +3757,7 @@ __metadata:
   resolution: "databricks@workspace:packages/databricks-vscode"
   dependencies:
     "@databricks/databricks-vscode-types": "workspace:^"
-    "@databricks/sdk-experimental": ^0.16.0
+    "@databricks/sdk-experimental": ^0.17.0
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@sinonjs/fake-timers": ^11.2.2
     "@types/bcryptjs": ^2.4.6

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,7 +343,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@databricks/databricks-vscode-types@workspace:packages/databricks-vscode-types"
   dependencies:
-    "@databricks/sdk-experimental": ^0.16.0
+    "@databricks/sdk-experimental": ^0.17.0
     "@types/vscode": 1.86.0
     databricks: "workspace:^"
     eslint: ^8.55.0
@@ -367,18 +367,6 @@ __metadata:
     typescript: ^5.5.0
   languageName: unknown
   linkType: soft
-
-"@databricks/sdk-experimental@npm:^0.16.0":
-  version: 0.16.0
-  resolution: "@databricks/sdk-experimental@npm:0.16.0"
-  dependencies:
-    google-auth-library: ^10.5.0
-    ini: ^6.0.0
-    reflect-metadata: ^0.2.2
-    semver: ^7.7.3
-  checksum: 621cbb34e260a902b46c67ae88a00184985679d10ee450dfaa297d4fb7baccca70d14af3fca2e66d333edd5d0304497fbb2219de231162e62b3293c5bd162933
-  languageName: node
-  linkType: hard
 
 "@databricks/sdk-experimental@npm:^0.17.0":
   version: 0.17.0


### PR DESCRIPTION
## Changes

Bump Databricks JS SDK to 0.17.0

## Tests

Manually
