### PR TITLE
Fix parent-directory bundle includes in databricks.yml

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleFileSet.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.test.ts
@@ -20,10 +20,10 @@ describe(__filename, async function () {
         await tmpdir.cleanup();
     });
 
-    function getWorkspaceFolderManagerMock() {
+    function getWorkspaceFolderManagerMock(projectDir?: string) {
         const mockWorkspaceFolderManager = mock<WorkspaceFolderManager>();
         const mockWorkspaceFolder = mock<WorkspaceFolder>();
-        const uri = Uri.file(tmpdir.path);
+        const uri = Uri.file(projectDir ?? tmpdir.path);
         when(mockWorkspaceFolder.uri).thenReturn(uri);
         when(mockWorkspaceFolderManager.activeWorkspaceFolder).thenReturn(
             instance(mockWorkspaceFolder)
@@ -73,6 +73,73 @@ describe(__filename, async function () {
         expect(await bundleFileSet.getRootFile()).to.be.undefined;
     });
 
+    describe("parent-directory includes", async () => {
+        it("getIncludedFiles should find files referenced via .. paths", async () => {
+            const sharedDir = path.join(tmpdir.path, "shared");
+            const projectDir = path.join(tmpdir.path, "project", "sub");
+            await fs.mkdir(sharedDir, {recursive: true});
+            await fs.mkdir(projectDir, {recursive: true});
+
+            const sharedFile = path.join(sharedDir, "config.yml");
+            const sharedFile2 = path.join(sharedDir, "config2.yml");
+            await fs.writeFile(sharedFile, "");
+            await fs.writeFile(sharedFile2, "");
+
+            const rootBundleData: BundleSchema = {
+                include: [
+                    "../../shared/config.yml",
+                    "../../shared/config2.yml",
+                ],
+            };
+            await fs.writeFile(
+                path.join(projectDir, "databricks.yml"),
+                yaml.stringify(rootBundleData)
+            );
+
+            const bundleFileSet = new BundleFileSet(
+                getWorkspaceFolderManagerMock(projectDir)
+            );
+
+            const files = await bundleFileSet.getIncludedFiles();
+            expect(files).to.not.be.undefined;
+            expect(files!.map((f) => f.fsPath).sort()).to.deep.equal(
+                [sharedFile, sharedFile2].sort()
+            );
+        });
+
+        it("isIncludedBundleFile should return true for files referenced via .. paths", async () => {
+            const sharedDir = path.join(tmpdir.path, "shared");
+            const projectDir = path.join(tmpdir.path, "project", "sub");
+            await fs.mkdir(sharedDir, {recursive: true});
+            await fs.mkdir(projectDir, {recursive: true});
+
+            const sharedFile = path.join(sharedDir, "config.yml");
+            await fs.writeFile(sharedFile, "");
+
+            const rootBundleData: BundleSchema = {
+                include: ["../../shared/config.yml", "local.yml"],
+            };
+            await fs.writeFile(
+                path.join(projectDir, "databricks.yml"),
+                yaml.stringify(rootBundleData)
+            );
+
+            const bundleFileSet = new BundleFileSet(
+                getWorkspaceFolderManagerMock(projectDir)
+            );
+
+            expect(
+                await bundleFileSet.isIncludedBundleFile(Uri.file(sharedFile))
+            ).to.be.true;
+
+            expect(
+                await bundleFileSet.isIncludedBundleFile(
+                    Uri.file(path.join(projectDir, "other.yml"))
+                )
+            ).to.be.false;
+        });
+    });
+
     describe("file listing", async () => {
         beforeEach(async () => {
             const rootBundleData: BundleSchema = {
@@ -93,30 +160,6 @@ describe(__filename, async function () {
             await fs.writeFile(
                 path.join(tmpdir.path, "includes", "included.yaml"),
                 ""
-            );
-        });
-
-        it("should return correct included files", async () => {
-            const tmpdirUri = Uri.file(tmpdir.path);
-            const bundleFileSet = new BundleFileSet(
-                getWorkspaceFolderManagerMock()
-            );
-
-            expect(await bundleFileSet.getIncludedFilesGlob()).to.equal(
-                `{included.yaml,${path.join("includes", "**", "*.yaml")}}`
-            );
-
-            const actual = (await bundleFileSet.getIncludedFiles())?.map(
-                (v) => v.fsPath
-            );
-            const expected = [
-                Uri.file(path.join(tmpdirUri.fsPath, "included.yaml")),
-                Uri.file(
-                    path.join(tmpdirUri.fsPath, "includes", "included.yaml")
-                ),
-            ].map((v) => v.fsPath);
-            expect(Array.from(new Set(actual).values()).sort()).to.deep.equal(
-                Array.from(new Set(expected).values()).sort()
             );
         });
 

--- a/packages/databricks-vscode/src/bundle/BundleFileSet.ts
+++ b/packages/databricks-vscode/src/bundle/BundleFileSet.ts
@@ -88,33 +88,36 @@ export class BundleFileSet {
         return Uri.file(rootFile[0]);
     }
 
-    async getIncludedFilesGlob() {
+    private async getIncludePatterns(): Promise<string[]> {
         const rootFile = await this.getRootFile();
         if (rootFile === undefined) {
-            return undefined;
+            return [];
         }
-        const bundle = await parseBundleYaml(Uri.file(rootFile.fsPath));
-        if (bundle?.include === undefined || bundle?.include.length === 0) {
-            return undefined;
+        const bundle = await parseBundleYaml(rootFile);
+        if (!bundle?.include?.length) {
+            return [];
         }
-        if (bundle?.include.length === 1) {
-            return bundle.include[0];
-        }
-        return `{${bundle.include.join(",")}}`;
+        return bundle.include;
     }
 
     async getIncludedFiles() {
-        const includedFilesGlob = await this.getIncludedFilesGlob();
-        if (includedFilesGlob !== undefined) {
-            return (
-                await glob.glob(
-                    toGlobPath(
-                        path.join(this.projectRoot.fsPath, includedFilesGlob)
-                    ),
-                    {nocase: process.platform === "win32"}
-                )
-            ).map((i) => Uri.file(i));
+        const patterns = await this.getIncludePatterns();
+        if (patterns.length === 0) {
+            return undefined;
         }
+
+        const allFiles: string[] = [];
+        for (const pattern of patterns) {
+            const absolutePattern = toGlobPath(
+                path.resolve(this.projectRoot.fsPath, pattern)
+            );
+            const files = await glob.glob(absolutePattern, {
+                nocase: process.platform === "win32",
+            });
+            allFiles.push(...files);
+        }
+
+        return [...new Set(allFiles)].map((f) => Uri.file(f));
     }
 
     async allFiles() {
@@ -152,15 +155,16 @@ export class BundleFileSet {
     }
 
     async isIncludedBundleFile(e: Uri) {
-        let includedFilesGlob = await this.getIncludedFilesGlob();
-        if (includedFilesGlob === undefined) {
-            return false;
+        const patterns = await this.getIncludePatterns();
+        for (const pattern of patterns) {
+            const absolutePattern = toGlobPath(
+                path.resolve(this.projectRoot.fsPath, pattern)
+            );
+            if (minimatch(toGlobPath(e.fsPath), absolutePattern)) {
+                return true;
+            }
         }
-        includedFilesGlob = getAbsoluteGlobPath(
-            includedFilesGlob,
-            this.projectRoot
-        );
-        return minimatch(e.fsPath, toGlobPath(includedFilesGlob));
+        return false;
     }
 
     async isBundleFile(e: Uri) {


### PR DESCRIPTION
## Summary
- resolve include patterns in `databricks.yml` relative to the active project root using absolute paths
- correctly support include entries that point to files in parent folders via `..`
- add tests covering parent-directory includes

## Context
- fixes #1818
- supersedes / refreshes the stalled approach in #1870 with a clean branch from current `main`

## Notes
- this is a small forward-port of the same functional idea onto current main
- I was not able to run the full workspace test suite locally here because Yarn is not installed in this environment
