### PR TITLE
Pass DATABRICKS_CLI_PATH to subprocess environment in DatabricksCliAuthProvider

### DIFF
--- a/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AuthProvider.ts
@@ -355,6 +355,7 @@ export class DatabricksCliAuthProvider extends AuthProvider {
         const env: Record<string, string> = {
             DATABRICKS_HOST: this.host.toString(),
             DATABRICKS_AUTH_TYPE: "databricks-cli",
+            DATABRICKS_CLI_PATH: this.cliPath,
         };
         if (this.profile) {
             env["DATABRICKS_CONFIG_PROFILE"] = this.profile;


### PR DESCRIPTION
## Summary

Fixes #1896

Bundle operations (deploy, validate) fail with `databricks CLI not found` since v2.10.7 because the spawned CLI subprocess cannot locate itself for token refresh.

## Root cause

The CLI bump from v0.286.0 to v0.297.2 brought Go SDK v0.126.0, which changed the `databricks-cli` auth strategy to invoke the CLI binary (via `cli_token_source.go` → `findDatabricksCli()`) instead of refreshing tokens in-process.

`DatabricksCliAuthProvider.toEnv()` sets `DATABRICKS_AUTH_TYPE=databricks-cli` but never sets `DATABRICKS_CLI_PATH`. The spawned CLI sees an empty `DatabricksCliPath`, falls back to searching `PATH`, and fails because the extension's `bin/` directory isn't on the system PATH.

The in-process SDK config (`_getSdkConfig()`) already passes `databricksCliPath: this.cliPath` correctly — the subprocess environment just needs the same treatment.

## Changes

- Add `DATABRICKS_CLI_PATH: this.cliPath` to `toEnv()` in `DatabricksCliAuthProvider`

## Test plan

- [ ] Untested — submitting based on code analysis only
- [ ] Existing unit tests pass
- [ ] Bundle deploy no longer errors with "databricks CLI not found"