### PR TITLE
Gate WSFS and docs panels on extension activation

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -532,7 +532,7 @@
                 {
                     "id": "workspaceFsView",
                     "name": "Workspace file system",
-                    "when": "!databricks.context.remoteMode"
+                    "when": "databricks.context.activated && !databricks.context.remoteMode"
                 },
                 {
                     "id": "unityCatalogView",
@@ -542,7 +542,7 @@
                 {
                     "id": "databricksDocsView",
                     "name": "Documentation",
-                    "when": "!databricks.context.remoteMode"
+                    "when": "databricks.context.activated && !databricks.context.remoteMode"
                 }
             ]
         },


### PR DESCRIPTION
## Changes

Both views used `!databricks.context.remoteMode` which is always true on startup, causing VSCode to render them before data providers were registered and leak "There is no data provider registered that can provide view data" to users.

## Tests

Manually
