### PR TITLE
Update README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,11 @@ Currently, we have the following packages:
 Prepare yarn:
 
 ```
-npm install -g yarn@2
+npm install -g yarn@3
 yarn install
 ```
 
-Prepare Databricks JavaScript SDK:
-
-```
-yarn run install:sdk
-```
+The Databricks JavaScript SDK (`@databricks/sdk-experimental`) is a regular npm dependency and is installed automatically by `yarn install` — no separate step is required.
 
 Prepare Databricks CLI:
 


### PR DESCRIPTION
## Why
The setup steps in the root `README.md` were stale: they pinned yarn v2 while `package.json` declares `yarn@3.2.1`, and they referenced an `install:sdk` step that no longer exists.

## What
- Bump `npm install -g yarn@2` → `yarn@3` to match `packageManager` in `package.json`.
- Drop the obsolete `yarn run install:sdk` step. `@databricks/sdk-experimental` is now a regular npm dependency installed automatically by `yarn install`.

## Verification
- Confirmed no `install:sdk` script remains in any `package.json`.
- Confirmed `@databricks/sdk-experimental` is a dependency in `packages/databricks-vscode/package.json`.
- Confirmed `packageManager` is `yarn@3.2.1`.

This pull request and its description were written by Isaac.