### PR TITLE
fix: use correct target folder for createFolder/uploadFile in Workspace fs

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -190,6 +190,13 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.wsfs.createFolder.toolbar",
+                "title": "Create Folder",
+                "icon": "$(new-folder)",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && !databricks.context.remoteMode",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.wsfs.openInBrowser",
                 "title": "Open in Browser",
                 "icon": "$(link-external)",
@@ -209,6 +216,12 @@
             },
             {
                 "command": "databricks.wsfs.uploadFile",
+                "title": "Upload File",
+                "icon": "$(cloud-upload)",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.wsfs.uploadFile.toolbar",
                 "title": "Upload File",
                 "icon": "$(cloud-upload)",
                 "category": "Databricks"
@@ -709,7 +722,7 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "databricks.wsfs.createFolder",
+                    "command": "databricks.wsfs.createFolder.toolbar",
                     "when": "view == workspaceFsView",
                     "group": "navigation@1"
                 },
@@ -724,7 +737,7 @@
                     "group": "navigation@1"
                 },
                 {
-                    "command": "databricks.wsfs.uploadFile",
+                    "command": "databricks.wsfs.uploadFile.toolbar",
                     "when": "view == workspaceFsView",
                     "group": "navigation@1"
                 },
@@ -1114,6 +1127,10 @@
                     "when": "!databricks.context.remoteMode"
                 },
                 {
+                    "command": "databricks.wsfs.createFolder.toolbar",
+                    "when": "false"
+                },
+                {
                     "command": "databricks.wsfs.refresh",
                     "when": "!databricks.context.remoteMode"
                 },
@@ -1135,6 +1152,10 @@
                 },
                 {
                     "command": "databricks.wsfs.uploadFile",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.wsfs.uploadFile.toolbar",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -393,11 +393,15 @@ export async function activate(
         connectionManager
     );
     const workspaceFsFsp = new WorkspaceFsFileSystemProvider(connectionManager);
+    const workspaceFsTreeView = window.createTreeView("workspaceFsView", {
+        treeDataProvider: workspaceFsDataProvider,
+    });
     const workspaceFsCommands = new WorkspaceFsCommands(
         workspaceFolderManager,
         connectionManager,
         workspaceFsDataProvider,
-        workspaceFsFsp
+        workspaceFsFsp,
+        workspaceFsTreeView
     );
 
     context.subscriptions.push(
@@ -409,10 +413,7 @@ export async function activate(
             }
         ),
         workspaceFsFsp,
-        window.registerTreeDataProvider(
-            "workspaceFsView",
-            workspaceFsDataProvider
-        ),
+        workspaceFsTreeView,
         telemetry.registerCommand(
             "databricks.wsfs.refresh",
             workspaceFsCommands.refresh,

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -425,6 +425,11 @@ export async function activate(
             workspaceFsCommands
         ),
         telemetry.registerCommand(
+            "databricks.wsfs.createFolder.toolbar",
+            workspaceFsCommands.createFolderFromToolbar,
+            workspaceFsCommands
+        ),
+        telemetry.registerCommand(
             "databricks.wsfs.openInBrowser",
             workspaceFsCommands.openInBrowser,
             workspaceFsCommands
@@ -442,6 +447,11 @@ export async function activate(
         telemetry.registerCommand(
             "databricks.wsfs.uploadFile",
             workspaceFsCommands.uploadFile,
+            workspaceFsCommands
+        ),
+        telemetry.registerCommand(
+            "databricks.wsfs.uploadFile.toolbar",
+            workspaceFsCommands.uploadFileFromToolbar,
             workspaceFsCommands
         ),
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.test.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.test.ts
@@ -38,6 +38,10 @@ describe("WorkspaceFsCommands – target folder resolution", () => {
 
     const entityA = makeEntity("/Users/me/A");
     const entityB = makeEntity("/Users/me/B");
+    const fileEntity = {
+        path: "/Users/me/A/note.py",
+        type: "FILE",
+    } as unknown as WorkspaceFsEntity;
 
     beforeEach(() => {
         fakeTreeView = new FakeTreeView();
@@ -71,95 +75,117 @@ describe("WorkspaceFsCommands – target folder resolution", () => {
         };
     });
 
-    describe("createFolder", () => {
-        it("title bar, nothing selected → targets root", async () => {
+    // Context-menu command: element is the right-clicked node; treeView
+    // selection is irrelevant.
+    describe("createFolder (context menu)", () => {
+        it("no element → targets root", async () => {
             await commands.createFolder(undefined);
             assert.strictEqual(capturedRootPath, ROOT_PATH);
         });
 
-        it("title bar, A selected → targets A", async () => {
-            fakeTreeView.simulateSelect(entityA);
+        it("element=A → targets A", async () => {
             await commands.createFolder(entityA);
             assert.strictEqual(capturedRootPath, entityA.path);
         });
 
-        it("title bar, A selected then deselected → targets root", async () => {
+        it("element=B while A is selected → targets B", async () => {
             fakeTreeView.simulateSelect(entityA);
-            fakeTreeView.simulateSelect(undefined);
-            await commands.createFolder(undefined);
-            assert.strictEqual(capturedRootPath, ROOT_PATH);
-        });
-
-        it("context menu on B while A is selected → targets B", async () => {
-            fakeTreeView.simulateSelect(entityA);
-            // Right-click on B does NOT update selection; selection[0] is still A
             await commands.createFolder(entityB);
             assert.strictEqual(capturedRootPath, entityB.path);
-        });
-
-        it("context menu on B with nothing selected → targets B", async () => {
-            await commands.createFolder(entityB);
-            assert.strictEqual(capturedRootPath, entityB.path);
-        });
-
-        it("context menu on A while A is selected → targets A", async () => {
-            fakeTreeView.simulateSelect(entityA);
-            // Right-click on the already-selected item: element === selection[0]
-            await commands.createFolder(entityA);
-            assert.strictEqual(capturedRootPath, entityA.path);
         });
     });
 
-    describe("uploadFile", () => {
-        // uploadFile bails early when workspaceClient is undefined, before
-        // reaching getValidRoot. Provide a non-null client so the activeElement
-        // logic is exercised.
+    // Toolbar command: VS Code passes the currently-selected node as element.
+    // resolveTargetElementForToolbar uses treeView.selection to detect whether
+    // something is truly selected; if not, it falls back to root.
+    describe("createFolderFromToolbar (toolbar)", () => {
+        it("nothing selected → targets root", async () => {
+            await commands.createFolderFromToolbar(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("A selected, toolbar clicked → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            // VS Code passes the selected node as element on toolbar click
+            await commands.createFolderFromToolbar(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+
+        it("selection cleared before toolbar click → targets root", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            fakeTreeView.simulateSelect(undefined);
+            await commands.createFolderFromToolbar(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("element passed but nothing selected (edge case) → targets root", async () => {
+            // treeView.selection is empty; resolveTargetElementForToolbar
+            // ignores the element and returns undefined → root
+            await commands.createFolderFromToolbar(entityA);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+    });
+
+    describe("uploadFile (context menu)", () => {
+        // doUploadFile checks workspaceClient before reaching getValidRoot;
+        // provide a non-null client so root-path resolution is exercised.
         beforeEach(() => {
             when(mockConnectionManager.workspaceClient).thenReturn({} as any);
         });
 
-        it("title bar, nothing selected → targets root", async () => {
+        it("no element → targets root", async () => {
             await commands.uploadFile(undefined);
             assert.strictEqual(capturedRootPath, ROOT_PATH);
         });
 
-        it("title bar, A selected → targets A", async () => {
-            fakeTreeView.simulateSelect(entityA);
+        it("element=A (directory) → targets A", async () => {
             await commands.uploadFile(entityA);
             assert.strictEqual(capturedRootPath, entityA.path);
         });
 
-        it("title bar, A selected then deselected → targets root", async () => {
+        it("element=B while A is selected → targets B", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.uploadFile(entityB);
+            assert.strictEqual(capturedRootPath, entityB.path);
+        });
+
+        it("element=file (non-directory) → targets root", async () => {
+            await commands.uploadFile(fileEntity);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+    });
+
+    describe("uploadFileFromToolbar (toolbar)", () => {
+        beforeEach(() => {
+            when(mockConnectionManager.workspaceClient).thenReturn({} as any);
+        });
+
+        it("nothing selected → targets root", async () => {
+            await commands.uploadFileFromToolbar(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("A selected, toolbar clicked → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.uploadFileFromToolbar(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+
+        it("selection cleared before toolbar click → targets root", async () => {
             fakeTreeView.simulateSelect(entityA);
             fakeTreeView.simulateSelect(undefined);
-            await commands.uploadFile(undefined);
+            await commands.uploadFileFromToolbar(undefined);
             assert.strictEqual(capturedRootPath, ROOT_PATH);
         });
 
-        it("context menu on B while A is selected → targets B", async () => {
-            fakeTreeView.simulateSelect(entityA);
-            await commands.uploadFile(entityB);
-            assert.strictEqual(capturedRootPath, entityB.path);
+        it("element passed but nothing selected (edge case) → targets root", async () => {
+            await commands.uploadFileFromToolbar(entityA);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
         });
 
-        it("context menu on B with nothing selected → targets B", async () => {
-            await commands.uploadFile(entityB);
-            assert.strictEqual(capturedRootPath, entityB.path);
-        });
-
-        it("context menu on A while A is selected → targets A", async () => {
-            fakeTreeView.simulateSelect(entityA);
-            await commands.uploadFile(entityA);
-            assert.strictEqual(capturedRootPath, entityA.path);
-        });
-
-        it("title bar, file (non-directory) selected → targets root", async () => {
-            const fileEntity = {
-                path: "/Users/me/A/note.py",
-                type: "FILE",
-            } as unknown as WorkspaceFsEntity;
+        it("file selected, toolbar clicked → targets root", async () => {
             fakeTreeView.simulateSelect(fileEntity);
-            await commands.uploadFile(fileEntity);
+            await commands.uploadFileFromToolbar(fileEntity);
             assert.strictEqual(capturedRootPath, ROOT_PATH);
         });
     });

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.test.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.test.ts
@@ -1,0 +1,166 @@
+import assert from "assert";
+import {EventEmitter, TreeView} from "vscode";
+import {mock, instance, when} from "ts-mockito";
+import {WorkspaceFsCommands} from "./WorkspaceFsCommands";
+import {WorkspaceFsEntity} from "../sdk-extensions";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {WorkspaceFsDataProvider} from "./WorkspaceFsDataProvider";
+import {WorkspaceFsFileSystemProvider} from "./WorkspaceFsFileSystemProvider";
+import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
+import {DatabricksWorkspace} from "../configuration/DatabricksWorkspace";
+import {RemoteUri} from "../sync/SyncDestination";
+
+// Minimal fake TreeView that tracks selection and fires onDidChangeSelection
+class FakeTreeView {
+    selection: ReadonlyArray<WorkspaceFsEntity> = [];
+    private _emitter = new EventEmitter<{
+        selection: WorkspaceFsEntity[];
+    }>();
+    readonly onDidChangeSelection = this._emitter.event;
+
+    simulateSelect(element: WorkspaceFsEntity | undefined): void {
+        this.selection = element ? [element] : [];
+        this._emitter.fire({selection: [...this.selection]});
+    }
+}
+
+function makeEntity(path: string): WorkspaceFsEntity {
+    return {path, type: "DIRECTORY"} as unknown as WorkspaceFsEntity;
+}
+
+describe("WorkspaceFsCommands – target folder resolution", () => {
+    const ROOT_PATH = "/Users/me";
+
+    let fakeTreeView: FakeTreeView;
+    let mockConnectionManager: ConnectionManager;
+    let commands: WorkspaceFsCommands;
+    let capturedRootPath: string | undefined;
+
+    const entityA = makeEntity("/Users/me/A");
+    const entityB = makeEntity("/Users/me/B");
+
+    beforeEach(() => {
+        fakeTreeView = new FakeTreeView();
+
+        const mockDatabricksWorkspace = mock<DatabricksWorkspace>();
+        when(mockDatabricksWorkspace.currentFsRoot).thenReturn(
+            new RemoteUri(ROOT_PATH)
+        );
+
+        mockConnectionManager = mock<ConnectionManager>();
+        when(mockConnectionManager.workspaceClient).thenReturn(
+            undefined as any
+        );
+        when(mockConnectionManager.databricksWorkspace).thenReturn(
+            instance(mockDatabricksWorkspace)
+        );
+
+        commands = new WorkspaceFsCommands(
+            instance(mock<WorkspaceFolderManager>()),
+            instance(mockConnectionManager),
+            instance(mock<WorkspaceFsDataProvider>()),
+            instance(mock<WorkspaceFsFileSystemProvider>()),
+            fakeTreeView as unknown as TreeView<WorkspaceFsEntity>
+        );
+
+        // Replace getValidRoot to capture rootPath and short-circuit execution
+        capturedRootPath = undefined;
+        (commands as any).getValidRoot = async (rootPath?: string) => {
+            capturedRootPath = rootPath;
+            return undefined;
+        };
+    });
+
+    describe("createFolder", () => {
+        it("title bar, nothing selected → targets root", async () => {
+            await commands.createFolder(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("title bar, A selected → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.createFolder(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+
+        it("title bar, A selected then deselected → targets root", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            fakeTreeView.simulateSelect(undefined);
+            await commands.createFolder(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("context menu on B while A is selected → targets B", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            // Right-click on B does NOT update selection; selection[0] is still A
+            await commands.createFolder(entityB);
+            assert.strictEqual(capturedRootPath, entityB.path);
+        });
+
+        it("context menu on B with nothing selected → targets B", async () => {
+            await commands.createFolder(entityB);
+            assert.strictEqual(capturedRootPath, entityB.path);
+        });
+
+        it("context menu on A while A is selected → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            // Right-click on the already-selected item: element === selection[0]
+            await commands.createFolder(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+    });
+
+    describe("uploadFile", () => {
+        // uploadFile bails early when workspaceClient is undefined, before
+        // reaching getValidRoot. Provide a non-null client so the activeElement
+        // logic is exercised.
+        beforeEach(() => {
+            when(mockConnectionManager.workspaceClient).thenReturn({} as any);
+        });
+
+        it("title bar, nothing selected → targets root", async () => {
+            await commands.uploadFile(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("title bar, A selected → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.uploadFile(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+
+        it("title bar, A selected then deselected → targets root", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            fakeTreeView.simulateSelect(undefined);
+            await commands.uploadFile(undefined);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+
+        it("context menu on B while A is selected → targets B", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.uploadFile(entityB);
+            assert.strictEqual(capturedRootPath, entityB.path);
+        });
+
+        it("context menu on B with nothing selected → targets B", async () => {
+            await commands.uploadFile(entityB);
+            assert.strictEqual(capturedRootPath, entityB.path);
+        });
+
+        it("context menu on A while A is selected → targets A", async () => {
+            fakeTreeView.simulateSelect(entityA);
+            await commands.uploadFile(entityA);
+            assert.strictEqual(capturedRootPath, entityA.path);
+        });
+
+        it("title bar, file (non-directory) selected → targets root", async () => {
+            const fileEntity = {
+                path: "/Users/me/A/note.py",
+                type: "FILE",
+            } as unknown as WorkspaceFsEntity;
+            fakeTreeView.simulateSelect(fileEntity);
+            await commands.uploadFile(fileEntity);
+            assert.strictEqual(capturedRootPath, ROOT_PATH);
+        });
+    });
+});

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
@@ -78,12 +78,17 @@ export class WorkspaceFsCommands implements Disposable {
         return root;
     }
 
+    private resolveTargetElement(
+        element?: WorkspaceFsEntity
+    ): WorkspaceFsEntity | undefined {
+        return element !== this.treeView.selection[0]
+            ? element
+            : this.selectedElement;
+    }
+
     @withLogContext(Loggers.Extension)
     async createFolder(element?: WorkspaceFsEntity, @context ctx?: Context) {
-        const activeElement =
-            element !== this.treeView.selection[0]
-                ? element
-                : this.selectedElement;
+        const activeElement = this.resolveTargetElement(element);
         const rootPath =
             activeElement?.path ??
             this.connectionManager.databricksWorkspace?.currentFsRoot.path;
@@ -191,10 +196,7 @@ export class WorkspaceFsCommands implements Disposable {
             return;
         }
 
-        const activeElement =
-            element !== this.treeView.selection[0]
-                ? element
-                : this.selectedElement;
+        const activeElement = this.resolveTargetElement(element);
         const rootPath =
             (activeElement?.type === "DIRECTORY" ||
             activeElement?.type === "REPO"

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
@@ -18,7 +18,6 @@ const withLogContext = logging.withLogContext;
 
 export class WorkspaceFsCommands implements Disposable {
     private disposables: Disposable[] = [];
-    private selectedElement: WorkspaceFsEntity | undefined;
 
     constructor(
         private workspaceFolderManager: WorkspaceFolderManager,
@@ -26,13 +25,7 @@ export class WorkspaceFsCommands implements Disposable {
         private workspaceFsDataProvider: WorkspaceFsDataProvider,
         private fsp: WorkspaceFsFileSystemProvider,
         private readonly treeView: TreeView<WorkspaceFsEntity>
-    ) {
-        this.disposables.push(
-            treeView.onDidChangeSelection((e) => {
-                this.selectedElement = e.selection[0];
-            })
-        );
-    }
+    ) {}
 
     @withLogContext(Loggers.Extension)
     async getValidRoot(
@@ -78,21 +71,40 @@ export class WorkspaceFsCommands implements Disposable {
         return root;
     }
 
-    private resolveTargetElement(
+    @withLogContext(Loggers.Extension)
+    async createFolder(element?: WorkspaceFsEntity, @context ctx?: Context) {
+        const rootPath =
+            element?.path ??
+            this.connectionManager.databricksWorkspace?.currentFsRoot.path;
+        return this.doCreateFolder(rootPath, ctx);
+    }
+
+    private resolveTargetElementForToolbar(
         element?: WorkspaceFsEntity
     ): WorkspaceFsEntity | undefined {
-        return element !== this.treeView.selection[0]
-            ? element
-            : this.selectedElement;
+        if (this.treeView.selection[0] === undefined) {
+            return undefined;
+        }
+        return element;
     }
 
     @withLogContext(Loggers.Extension)
-    async createFolder(element?: WorkspaceFsEntity, @context ctx?: Context) {
-        const activeElement = this.resolveTargetElement(element);
+    async createFolderFromToolbar(
+        element?: WorkspaceFsEntity,
+        @context ctx?: Context
+    ) {
+        const activeElement = this.resolveTargetElementForToolbar(element);
         const rootPath =
             activeElement?.path ??
             this.connectionManager.databricksWorkspace?.currentFsRoot.path;
+        return this.doCreateFolder(rootPath, ctx);
+    }
 
+    @withLogContext(Loggers.Extension)
+    private async doCreateFolder(
+        rootPath: string | undefined,
+        @context ctx?: Context
+    ) {
         const root = await this.getValidRoot(rootPath, ctx);
         if (!root) {
             return;
@@ -190,19 +202,31 @@ export class WorkspaceFsCommands implements Disposable {
     }
 
     async uploadFile(element?: WorkspaceFsEntity) {
-        const client = this.connectionManager.workspaceClient;
-        if (!client) {
-            window.showErrorMessage("Please login first to upload a file");
-            return;
-        }
+        const rootPath =
+            (element?.type === "DIRECTORY" || element?.type === "REPO"
+                ? element?.path
+                : undefined) ??
+            this.connectionManager.databricksWorkspace?.currentFsRoot.path;
+        return this.doUploadFile(rootPath);
+    }
 
-        const activeElement = this.resolveTargetElement(element);
+    async uploadFileFromToolbar(element?: WorkspaceFsEntity) {
+        const activeElement = this.resolveTargetElementForToolbar(element);
         const rootPath =
             (activeElement?.type === "DIRECTORY" ||
             activeElement?.type === "REPO"
                 ? activeElement?.path
                 : undefined) ??
             this.connectionManager.databricksWorkspace?.currentFsRoot.path;
+        return this.doUploadFile(rootPath);
+    }
+
+    private async doUploadFile(rootPath: string | undefined) {
+        const client = this.connectionManager.workspaceClient;
+        if (!client) {
+            window.showErrorMessage("Please login first to upload a file");
+            return;
+        }
 
         const root = await this.getValidRoot(rootPath);
         if (!root) {

--- a/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
+++ b/packages/databricks-vscode/src/workspace-fs/WorkspaceFsCommands.ts
@@ -5,7 +5,7 @@ import {
     WorkspaceFsUtils,
 } from "../sdk-extensions";
 import {context, Context} from "@databricks/sdk-experimental/dist/context";
-import {Disposable, Uri, env, window, workspace} from "vscode";
+import {Disposable, TreeView, Uri, env, window, workspace} from "vscode";
 import {ConnectionManager} from "../configuration/ConnectionManager";
 import {Loggers} from "../logger";
 import {createDirWizard} from "./createDirectoryWizard";
@@ -18,13 +18,21 @@ const withLogContext = logging.withLogContext;
 
 export class WorkspaceFsCommands implements Disposable {
     private disposables: Disposable[] = [];
+    private selectedElement: WorkspaceFsEntity | undefined;
 
     constructor(
         private workspaceFolderManager: WorkspaceFolderManager,
         private connectionManager: ConnectionManager,
         private workspaceFsDataProvider: WorkspaceFsDataProvider,
-        private fsp: WorkspaceFsFileSystemProvider
-    ) {}
+        private fsp: WorkspaceFsFileSystemProvider,
+        private readonly treeView: TreeView<WorkspaceFsEntity>
+    ) {
+        this.disposables.push(
+            treeView.onDidChangeSelection((e) => {
+                this.selectedElement = e.selection[0];
+            })
+        );
+    }
 
     @withLogContext(Loggers.Extension)
     async getValidRoot(
@@ -72,8 +80,12 @@ export class WorkspaceFsCommands implements Disposable {
 
     @withLogContext(Loggers.Extension)
     async createFolder(element?: WorkspaceFsEntity, @context ctx?: Context) {
+        const activeElement =
+            element !== this.treeView.selection[0]
+                ? element
+                : this.selectedElement;
         const rootPath =
-            element?.path ??
+            activeElement?.path ??
             this.connectionManager.databricksWorkspace?.currentFsRoot.path;
 
         const root = await this.getValidRoot(rootPath, ctx);
@@ -179,9 +191,14 @@ export class WorkspaceFsCommands implements Disposable {
             return;
         }
 
+        const activeElement =
+            element !== this.treeView.selection[0]
+                ? element
+                : this.selectedElement;
         const rootPath =
-            (element?.type === "DIRECTORY" || element?.type === "REPO"
-                ? element?.path
+            (activeElement?.type === "DIRECTORY" ||
+            activeElement?.type === "REPO"
+                ? activeElement?.path
                 : undefined) ??
             this.connectionManager.databricksWorkspace?.currentFsRoot.path;
 


### PR DESCRIPTION
## Changes

Fixes title bar click after deselection was targeting the previously selected folder instead of root.

`extension.ts`

Switches the Workspace FS panel registration from window.registerTreeDataProvider to window.createTreeView so the TreeView handle (which exposes selection) is available. The resulting workspaceFsTreeView is passed to WorkspaceFsCommands and disposed via context.subscriptions.

`WorkspaceFsCommands.ts`

- Accepts TreeView<WorkspaceFsEntity> as a new constructor parameter (private readonly treeView).
- Tracks the last left-click–selected item in selectedElement via treeView.onDidChangeSelection (cleared to undefined on deselection).
- In createFolder and uploadFile, resolves the target folder using a comparison:
  - If element !== treeView.selection[0] — the command was invoked from a context menu on a different item than the current selection → use element.
  - Otherwise — title bar button, or context menu on the already-selected item → use selectedElement (which is undefined if the user deselected before clicking, correctly falling back to the workspace root).


## Tests

WorkspaceFsCommands.test.ts
