### PR TITLE
[telemetry] Detect Python package manager(s) at project setup

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -351,7 +351,8 @@ export async function activate(
                 return "serverless";
             }
             return connectionManager.cluster ? "cluster" : "none";
-        }
+        },
+        () => connectionManager.state === "CONNECTED"
     );
     context.subscriptions.push(
         bundleFileWatcher,

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -75,6 +75,7 @@ import {BundleVariableTreeDataProvider} from "./ui/bundle-variables/BundleVariab
 import {ConfigurationTreeViewManager} from "./ui/configuration-view/ConfigurationTreeViewManager";
 import {getCLIDependenciesEnvVars} from "./utils/envVarGenerators";
 import {EnvironmentCommands} from "./language/EnvironmentCommands";
+import {PackageManagerTelemetry} from "./language/PackageManagerTelemetry";
 import {WorkspaceFolderManager} from "./vscode-objs/WorkspaceFolderManager";
 import {SyncCommands} from "./sync/SyncCommands";
 import {CodeSynchronizer} from "./sync";
@@ -334,6 +335,23 @@ export async function activate(
         workspaceFolderManager,
         customWhenContext,
         telemetry
+    );
+    const packageManagerTelemetry = new PackageManagerTelemetry(
+        telemetry,
+        pythonExtensionWrapper,
+        () => {
+            try {
+                return workspaceFolderManager.activeProjectUri.fsPath;
+            } catch (e) {
+                return undefined;
+            }
+        },
+        () => {
+            if (connectionManager.serverless) {
+                return "serverless";
+            }
+            return connectionManager.cluster ? "cluster" : "none";
+        }
     );
     context.subscriptions.push(
         bundleFileWatcher,
@@ -609,13 +627,15 @@ export async function activate(
                 connectionManager,
                 pythonExtensionWrapper,
                 environmentDependenciesInstaller,
-                configureAutocomplete
+                configureAutocomplete,
+                packageManagerTelemetry
             )
     );
     const environmentCommands = new EnvironmentCommands(
         featureManager,
         pythonExtensionWrapper,
-        environmentDependenciesInstaller
+        environmentDependenciesInstaller,
+        packageManagerTelemetry
     );
     context.subscriptions.push(
         telemetry.registerCommand(
@@ -993,7 +1013,8 @@ export async function activate(
         featureManager,
         context,
         customWhenContext,
-        telemetry
+        telemetry,
+        packageManagerTelemetry
     );
     const debugFactory = new DatabricksDebugAdapterFactory(
         connectionManager,

--- a/packages/databricks-vscode/src/language/EnvironmentCommands.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentCommands.ts
@@ -5,16 +5,19 @@ import {Cluster} from "../sdk-extensions";
 import {EnvironmentDependenciesInstaller} from "./EnvironmentDependenciesInstaller";
 import {Environment} from "./MsPythonExtensionApi";
 import {environmentName} from "../utils/environmentUtils";
+import {PackageManagerTelemetry} from "./PackageManagerTelemetry";
 
 export class EnvironmentCommands {
     constructor(
         private featureManager: FeatureManager,
         private pythonExtension: MsPythonExtensionWrapper,
-        private installer: EnvironmentDependenciesInstaller
+        private installer: EnvironmentDependenciesInstaller,
+        private packageManagerTelemetry: PackageManagerTelemetry
     ) {}
 
     async setup(stepId?: string) {
         commands.executeCommand("configurationView.focus");
+        void this.packageManagerTelemetry.emitDetection("explicit_command");
         await window.withProgress(
             {location: {viewId: "configurationView"}},
             () => this._setup(stepId)

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
@@ -10,6 +10,7 @@ import {ResolvedEnvironment} from "./MsPythonExtensionApi";
 import {NamedLogger} from "@databricks/sdk-experimental/dist/logging";
 import {ConfigureAutocomplete} from "./ConfigureAutocomplete";
 import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
+import {PackageManagerTelemetry} from "./PackageManagerTelemetry";
 
 export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
     private readonly logger = NamedLogger.getOrCreate(Loggers.Extension);
@@ -18,7 +19,8 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
         private readonly connectionManager: ConnectionManager,
         private readonly pythonExtension: MsPythonExtensionWrapper,
         private readonly installer: EnvironmentDependenciesInstaller,
-        private readonly configureAutocomplete: ConfigureAutocomplete
+        private readonly configureAutocomplete: ConfigureAutocomplete,
+        private readonly packageManagerTelemetry: PackageManagerTelemetry
     ) {
         super([
             "checkCluster",
@@ -403,6 +405,9 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
     }
 
     override async check() {
+        // First environment check on project open: emit package-manager
+        // detection telemetry (deduplicated per session, never throws).
+        void this.packageManagerTelemetry.emitDetection("auto_open");
         await this.connectionManager.waitForConnect();
         await Promise.all([
             this.checkCluster(this.connectionManager.cluster),

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
@@ -405,10 +405,11 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
     }
 
     override async check() {
-        // First environment check on project open: emit package-manager
-        // detection telemetry (deduplicated per session, never throws).
-        void this.packageManagerTelemetry.emitDetection("auto_open");
         await this.connectionManager.waitForConnect();
+        // Emit package-manager detection only once connected (waitForConnect
+        // resolves on CONNECTED), so unauthenticated sessions are not reported.
+        // Deduplicated per session; never throws.
+        void this.packageManagerTelemetry.emitDetection("auto_open");
         await Promise.all([
             this.checkCluster(this.connectionManager.cluster),
             this.checkWorkspaceHasUc(),

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.test.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.test.ts
@@ -1,0 +1,172 @@
+import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {writeFileSync} from "node:fs";
+import {Telemetry} from "../telemetry";
+import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
+import {PackageManagerTelemetry, SetupTrigger} from "./PackageManagerTelemetry";
+
+type RecordedEvent = {
+    name: string;
+    props: Record<string, string>;
+    metrics: Record<string, number>;
+};
+
+/** A Telemetry backed by a fake reporter that captures sent events. */
+function makeTelemetry(level: "all" | "error" | "crash" | "off" = "all") {
+    const events: RecordedEvent[] = [];
+    const reporter = {
+        telemetryLevel: level,
+        sendTelemetryEvent: (
+            name: string,
+            props?: Record<string, string>,
+            metrics?: Record<string, number>
+        ) => {
+            events.push({name, props: props ?? {}, metrics: metrics ?? {}});
+        },
+        sendTelemetryErrorEvent: () => {},
+        sendDangerousTelemetryEvent: () => {},
+        sendDangerousTelemetryErrorEvent: () => {},
+        dispose: () => Promise.resolve(),
+    };
+    return {telemetry: new Telemetry(reporter as any), events};
+}
+
+describe(__filename, () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    /**
+     * Create a throwaway project dir populated with the given files, passed as
+     * [name, contents] tuples (file names aren't valid identifiers, so a tuple
+     * list avoids object-literal key lint noise).
+     */
+    function makeProject(files: Array<[string, string]>): string {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        for (const [name, contents] of files) {
+            writeFileSync(path.join(dir.name, name), contents);
+        }
+        return dir.name;
+    }
+
+    // Interpreter is irrelevant to these disk-signal tests; report none.
+    const noInterpreter = {
+        get pythonEnvironment() {
+            return Promise.resolve(undefined);
+        },
+    } as unknown as MsPythonExtensionWrapper;
+
+    function makePmt(
+        telemetry: Telemetry,
+        opts: {
+            projectRoot: string;
+            compute?: "cluster" | "serverless" | "none";
+            connected?: boolean;
+        }
+    ) {
+        return new PackageManagerTelemetry(
+            telemetry,
+            noInterpreter,
+            () => opts.projectRoot,
+            () => opts.compute ?? "none",
+            () => opts.connected ?? true
+        );
+    }
+
+    const emit = async (pmt: PackageManagerTelemetry, t: SetupTrigger) =>
+        pmt.emitDetection(t);
+
+    it("emits a detection event for a connected project (uv + pip)", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([
+            ["uv.lock", "version = 1\n"],
+            ["pyproject.toml", "[project]\nname='x'\n[tool.uv]\n"],
+            ["requirements-dev.txt", "requests\n"],
+        ]);
+        const pmt = makePmt(telemetry, {projectRoot, compute: "cluster"});
+
+        await emit(pmt, "explicit_command");
+
+        expect(events).to.have.length(1);
+        const e = events[0];
+        expect(e.name).to.equal("python_env.setup.detected");
+        expect(e.props["event.primaryManager"]).to.equal("uv");
+        expect(e.props["event.managersDetected"]).to.equal('["uv","pip"]');
+        expect(e.props["event.hasLockfile"]).to.equal("true");
+        expect(e.props["event.targetCompute"]).to.equal("cluster");
+        expect(e.props["event.setupTrigger"]).to.equal("explicit_command");
+        expect(e.props["event.interpreterSource"]).to.equal("unknown");
+    });
+
+    it("deduplicates per (trigger, projectRoot) within a session", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([["uv.lock", "version = 1\n"]]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+        await emit(pmt, "auto_open");
+
+        expect(events).to.have.length(1);
+    });
+
+    it("does not emit while disconnected, and does not burn the dedupe slot", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([["uv.lock", "version = 1\n"]]);
+
+        const disconnected = makePmt(telemetry, {
+            projectRoot,
+            connected: false,
+        });
+        await emit(disconnected, "auto_open");
+        expect(events).to.have.length(0);
+
+        // A later connected emit for the same (trigger, project) still fires --
+        // i.e. the disconnected attempt did not consume the dedupe key.
+        const connected = makePmt(telemetry, {projectRoot, connected: true});
+        await emit(connected, "auto_open");
+        expect(events).to.have.length(1);
+    });
+
+    it("does not emit when telemetry is disabled", async () => {
+        const {telemetry, events} = makeTelemetry("error");
+        const projectRoot = makeProject([["uv.lock", "version = 1\n"]]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        expect(events).to.have.length(0);
+    });
+
+    it("reports unknown for a project with no recognizable signals", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        // `requirementsfoo.txt` (no separator) is NOT a requirements file, so
+        // pip must not be attributed.
+        const projectRoot = makeProject([["requirementsfoo.txt", "x\n"]]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        expect(events).to.have.length(1);
+        expect(events[0].props["event.managersDetected"]).to.equal("[]");
+        expect(events[0].props["event.primaryManager"]).to.equal("unknown");
+    });
+
+    it("attributes pip from a separator-suffixed requirements file", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([
+            ["requirements_test.txt", "pytest\n"],
+        ]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        expect(events[0].props["event.managersDetected"]).to.equal('["pip"]');
+        expect(events[0].props["event.primaryManager"]).to.equal("pip");
+    });
+});

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.test.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.test.ts
@@ -169,4 +169,41 @@ describe(__filename, () => {
         expect(events[0].props["event.managersDetected"]).to.equal('["pip"]');
         expect(events[0].props["event.primaryManager"]).to.equal("pip");
     });
+
+    it("does not attribute pip for a tool-only pyproject", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        // Only linter config, no [project]/[build-system] -- not a pip signal.
+        const projectRoot = makeProject([
+            ["pyproject.toml", "[tool.ruff]\nline-length = 88\n"],
+        ]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        expect(events[0].props["event.managersDetected"]).to.equal("[]");
+        expect(events[0].props["event.primaryManager"]).to.equal("unknown");
+    });
+
+    it("attributes pip for a pyproject with [project] and no uv/poetry", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([
+            ["pyproject.toml", '[project]\nname = "x"\n'],
+        ]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        expect(events[0].props["event.managersDetected"]).to.equal('["pip"]');
+    });
+
+    it("omits pythonVersion from the event when the interpreter is unknown", async () => {
+        const {telemetry, events} = makeTelemetry("all");
+        const projectRoot = makeProject([["uv.lock", "version = 1\n"]]);
+        const pmt = makePmt(telemetry, {projectRoot});
+
+        await emit(pmt, "auto_open");
+
+        // The key must be absent, not the string "undefined".
+        expect(events[0].props).to.not.have.property("event.pythonVersion");
+    });
 });

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
@@ -54,6 +54,12 @@ export class PackageManagerTelemetry {
      */
     async emitDetection(trigger: SetupTrigger): Promise<void> {
         try {
+            // Bail before any disk access when telemetry is disabled, so an
+            // opted-out user gets zero telemetry-driven file reads (not just a
+            // dropped send).
+            if (!this.telemetry.isTelemetryEnabled) {
+                return;
+            }
             const projectRoot = this.getProjectRoot();
             if (projectRoot === undefined) {
                 return;
@@ -233,12 +239,18 @@ export class PackageManagerTelemetry {
         }
     }
 
-    /** True if any `requirements*.txt` file exists in the project root. */
+    /**
+     * True if any pip-style requirements file exists in the project root:
+     * `requirements.txt` or a separator-suffixed variant such as
+     * `requirements-dev.txt` / `requirements_test.txt` / `requirements.ci.txt`.
+     * Deliberately does not match `requirementsfoo.txt` (no separator), which
+     * isn't a conventional requirements file.
+     */
     private hasRequirementsTxt(projectRoot: string): boolean {
         try {
             return fs
                 .readdirSync(projectRoot)
-                .some((name) => /^requirements.*\.txt$/.test(name));
+                .some((name) => /^requirements([-_.].+)?\.txt$/.test(name));
         } catch (e) {
             this.logger.debug("Failed to list project root", e);
             return false;

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
@@ -1,0 +1,251 @@
+import fs from "node:fs";
+import path from "node:path";
+import {NamedLogger} from "@databricks/sdk-experimental/dist/logging";
+import {Loggers} from "../logger";
+import {Telemetry} from "../telemetry";
+import {ComputeType, SetupTrigger} from "../telemetry/constants";
+import "../telemetry/packageManagerExtensions";
+import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
+import {ResolvedEnvironment} from "./MsPythonExtensionApi";
+import {
+    detectPackageManagers,
+    interpreterUnderCondaPrefix,
+    InterpreterSource,
+    PackageManagerSignals,
+    pyprojectHasToolSection,
+    pyvenvCfgMarksUv,
+} from "./packageManagerDetection";
+
+export type {SetupTrigger};
+
+/**
+ * Collects package-manager signals at project-setup touchpoints and emits the
+ * {@link Events.PYTHON_ENV_SETUP_DETECTED} telemetry event.
+ *
+ * All probing is best-effort and non-blocking: any failure degrades to
+ * `unknown` and is swallowed, never thrown into the user's setup/run flow.
+ * Only categorical/enum data is emitted — no paths, package names, or other
+ * free-form content (see {@link detectPackageManagers}). Telemetry opt-out is
+ * honoured by the underlying {@link Telemetry} client.
+ */
+export class PackageManagerTelemetry {
+    private readonly logger = NamedLogger.getOrCreate(Loggers.Extension);
+
+    /**
+     * Triggers already emitted for the current `(project, trigger)` pair, to
+     * deduplicate within a session so one project open doesn't inflate counts.
+     */
+    private readonly emitted = new Set<string>();
+
+    constructor(
+        private readonly telemetry: Telemetry,
+        private readonly pythonExtension: MsPythonExtensionWrapper,
+        private readonly getProjectRoot: () => string | undefined,
+        private readonly getComputeType: () => ComputeType | "none"
+    ) {}
+
+    /**
+     * Detect the package manager(s) for the active project and emit telemetry.
+     * Deduplicated per `(project root, trigger)` within the session. Never
+     * throws.
+     */
+    async emitDetection(trigger: SetupTrigger): Promise<void> {
+        try {
+            const projectRoot = this.getProjectRoot();
+            if (projectRoot === undefined) {
+                return;
+            }
+            const dedupeKey = `${trigger}:${projectRoot}`;
+            if (this.emitted.has(dedupeKey)) {
+                return;
+            }
+            this.emitted.add(dedupeKey);
+
+            const env = await this.resolveEnvironment();
+            const signals = this.collectSignals(projectRoot, env);
+            const detection = detectPackageManagers(signals);
+
+            this.telemetry.recordPackageManagerDetection(detection, {
+                pythonVersion: this.getPythonMinorVersion(env),
+                targetCompute: this.getComputeType(),
+                trigger,
+            });
+        } catch (e) {
+            // Detection is measurement-only and must never disrupt setup.
+            this.logger.debug("Package manager detection failed", e);
+        }
+    }
+
+    private async resolveEnvironment(): Promise<
+        ResolvedEnvironment | undefined
+    > {
+        try {
+            return await this.pythonExtension.pythonEnvironment;
+        } catch (e) {
+            this.logger.debug("Failed to resolve python environment", e);
+            return undefined;
+        }
+    }
+
+    /** Detected interpreter minor version (e.g. "3.11"), if available. */
+    private getPythonMinorVersion(
+        env: ResolvedEnvironment | undefined
+    ): string | undefined {
+        const version = env?.version;
+        if (version?.major === undefined || version.minor === undefined) {
+            return undefined;
+        }
+        return `${version.major}.${version.minor}`;
+    }
+
+    /**
+     * Classify the *active interpreter's* provenance from the resolved
+     * environment alone. This is deliberately independent of project files: a
+     * project carrying `uv.lock` but running a conda/venv/system interpreter
+     * must report that interpreter's real source, so the setup-flow gap ("uv
+     * project, interpreter not uv-managed yet") stays visible. `uv.lock` is
+     * still captured as a strong *project* signal via `hasUvLock`.
+     */
+    private getInterpreterSource(
+        env: ResolvedEnvironment | undefined
+    ): InterpreterSource {
+        if (env?.environment === undefined) {
+            // No managed environment: a global/system interpreter.
+            return env ? "system" : "unknown";
+        }
+
+        const tools = env.tools ?? [];
+        if (env.environment.type === "Conda" || tools.includes("Conda")) {
+            return "conda";
+        }
+        if (
+            tools.includes("Venv") ||
+            tools.includes("VirtualEnv") ||
+            tools.includes("Poetry") ||
+            tools.includes("Pipenv") ||
+            env.environment.type === "VirtualEnvironment"
+        ) {
+            // The MS Python extension reports uv-created venvs as plain virtual
+            // environments. Distinguish a genuinely uv-provisioned interpreter
+            // by the `uv = <version>` line uv writes into pyvenv.cfg -- this is
+            // interpreter provenance, not the mere presence of uv.lock.
+            return this.isUvCreatedVenv(env) ? "uv" : "venv";
+        }
+        return "unknown";
+    }
+
+    /**
+     * True if the active venv's pyvenv.cfg marks it as uv-created. Thin fs
+     * wrapper around the pure {@link pyvenvCfgMarksUv}.
+     */
+    private isUvCreatedVenv(env: ResolvedEnvironment): boolean {
+        try {
+            const sysPrefix = env.executable.sysPrefix;
+            if (!sysPrefix) {
+                return false;
+            }
+            const cfg = path.join(sysPrefix, "pyvenv.cfg");
+            if (!fs.existsSync(cfg)) {
+                return false;
+            }
+            return pyvenvCfgMarksUv(fs.readFileSync(cfg, "utf-8"));
+        } catch (e) {
+            this.logger.debug("Failed to read pyvenv.cfg", e);
+            return false;
+        }
+    }
+
+    /**
+     * Gather raw signals from disk and the environment. Each probe is guarded
+     * so a single failure degrades that signal to absent rather than aborting.
+     */
+    private collectSignals(
+        projectRoot: string,
+        env: ResolvedEnvironment | undefined
+    ): PackageManagerSignals {
+        const exists = (file: string) => this.fileExists(projectRoot, file);
+        const interpreterSource = this.getInterpreterSource(env);
+        const pyproject = this.readPyproject(projectRoot);
+
+        const hasPyprojectToolUv = pyprojectHasToolSection(pyproject, "uv");
+        const hasPyprojectToolPoetry = pyprojectHasToolSection(
+            pyproject,
+            "poetry"
+        );
+        const hasPyprojectPipOnly =
+            pyproject !== undefined &&
+            !hasPyprojectToolUv &&
+            !hasPyprojectToolPoetry;
+
+        return {
+            hasUvLock: exists("uv.lock"),
+            hasPyprojectToolUv,
+            // uvOnPath is intentionally left unset: it is a weak signal that
+            // never attributes a project to uv, and probing it would mean
+            // executing a PATH-resolved `uv` binary purely for telemetry.
+            hasPoetryLock: exists("poetry.lock"),
+            hasPyprojectToolPoetry,
+            poetryOnPath: undefined,
+            hasRequirementsTxt: this.hasRequirementsTxt(projectRoot),
+            hasConstraintsTxt: exists("constraints.txt"),
+            hasPyprojectPipOnly,
+            hasCondaEnvFile:
+                exists("environment.yml") || exists("environment.yaml"),
+            hasCondaPrefix: this.hasActiveCondaInterpreter(env),
+            interpreterSource,
+        };
+    }
+
+    /**
+     * Whether the *active interpreter* lives under `CONDA_PREFIX`.
+     *
+     * We deliberately do NOT fire on the bare presence of `CONDA_PREFIX` /
+     * `CONDA_DEFAULT_ENV`: those are session-global in the extension host (set
+     * for every project when VS Code is launched from an activated conda
+     * shell), so using them directly would over-count conda for uv/poetry/pip
+     * projects. Requiring the active interpreter to reside under the prefix
+     * keeps this a project-scoped signal.
+     */
+    private hasActiveCondaInterpreter(
+        env: ResolvedEnvironment | undefined
+    ): boolean {
+        return interpreterUnderCondaPrefix(
+            env?.executable.sysPrefix,
+            process.env["CONDA_PREFIX"]
+        );
+    }
+
+    private fileExists(projectRoot: string, file: string): boolean {
+        try {
+            return fs.existsSync(path.join(projectRoot, file));
+        } catch (e) {
+            this.logger.debug(`Failed to stat ${file}`, e);
+            return false;
+        }
+    }
+
+    /** True if any `requirements*.txt` file exists in the project root. */
+    private hasRequirementsTxt(projectRoot: string): boolean {
+        try {
+            return fs
+                .readdirSync(projectRoot)
+                .some((name) => /^requirements.*\.txt$/.test(name));
+        } catch (e) {
+            this.logger.debug("Failed to list project root", e);
+            return false;
+        }
+    }
+
+    private readPyproject(projectRoot: string): string | undefined {
+        try {
+            const file = path.join(projectRoot, "pyproject.toml");
+            if (!fs.existsSync(file)) {
+                return undefined;
+            }
+            return fs.readFileSync(file, "utf-8");
+        } catch (e) {
+            this.logger.debug("Failed to read pyproject.toml", e);
+            return undefined;
+        }
+    }
+}

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
@@ -41,18 +41,27 @@ export class PackageManagerTelemetry {
         private readonly telemetry: Telemetry,
         private readonly pythonExtension: MsPythonExtensionWrapper,
         private readonly getProjectRoot: () => string | undefined,
-        private readonly getComputeType: () => ComputeType | "none"
+        private readonly getComputeType: () => ComputeType | "none",
+        private readonly isConnected: () => boolean
     ) {}
 
     /**
      * Detect the package manager(s) for the active project and emit telemetry.
-     * Deduplicated per `(project root, trigger)` within the session. Never
+     * Deduplicated per `(project root, trigger)` within the session. Only emits
+     * while connected to a Databricks workspace, so the data describes active
+     * users' projects (not extension installs that never authenticate). Never
      * throws.
      */
     async emitDetection(trigger: SetupTrigger): Promise<void> {
         try {
             const projectRoot = this.getProjectRoot();
             if (projectRoot === undefined) {
+                return;
+            }
+            // Only report for authenticated sessions. Checked before the dedupe
+            // bookkeeping so a pre-connect call doesn't consume the dedupe slot
+            // and suppress the real emit once connected.
+            if (!this.isConnected()) {
                 return;
             }
             const dedupeKey = `${trigger}:${projectRoot}`;

--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
@@ -12,6 +12,7 @@ import {
     interpreterUnderCondaPrefix,
     InterpreterSource,
     PackageManagerSignals,
+    pyprojectHasPackagingTable,
     pyprojectHasToolSection,
     pyvenvCfgMarksUv,
 } from "./packageManagerDetection";
@@ -133,10 +134,14 @@ export class PackageManagerTelemetry {
         if (env.environment.type === "Conda" || tools.includes("Conda")) {
             return "conda";
         }
+        // Poetry envs are venvs, but must be attributed to poetry rather than
+        // collapsed into the generic venv (which the detector reads as pip).
+        if (tools.includes("Poetry")) {
+            return "poetry";
+        }
         if (
             tools.includes("Venv") ||
             tools.includes("VirtualEnv") ||
-            tools.includes("Poetry") ||
             tools.includes("Pipenv") ||
             env.environment.type === "VirtualEnvironment"
         ) {
@@ -187,8 +192,11 @@ export class PackageManagerTelemetry {
             pyproject,
             "poetry"
         );
+        // Only attribute pip when the pyproject actually declares packaging
+        // (`[project]`/`[build-system]`); a file with only tool config such as
+        // `[tool.ruff]` is not a pip signal.
         const hasPyprojectPipOnly =
-            pyproject !== undefined &&
+            pyprojectHasPackagingTable(pyproject) &&
             !hasPyprojectToolUv &&
             !hasPyprojectToolPoetry;
 

--- a/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
@@ -3,6 +3,7 @@ import {
     detectPackageManagers,
     interpreterUnderCondaPrefix,
     PackageManagerSignals,
+    pyprojectHasPackagingTable,
     pyprojectHasToolSection,
     pyvenvCfgMarksUv,
 } from "./packageManagerDetection";
@@ -85,6 +86,14 @@ describe("detectPackageManagers", () => {
             expect(result.primary).to.equal("conda");
             expect(result.signals).to.deep.equal(["interpreter.conda"]);
             expect(result.interpreterSource).to.equal("conda");
+        });
+
+        it("attributes poetry (not pip) from a poetry interpreter", () => {
+            const result = detectPackageManagers({interpreterSource: "poetry"});
+            expect(result.managers).to.deep.equal(["poetry"]);
+            expect(result.primary).to.equal("poetry");
+            expect(result.signals).to.deep.equal(["interpreter.poetry"]);
+            expect(result.interpreterSource).to.equal("poetry");
         });
 
         it("attributes pip from a plain venv interpreter", () => {
@@ -421,6 +430,44 @@ describe("interpreterUnderCondaPrefix", () => {
                 "/opt/conda/envs/ml",
                 false
             )
+        ).to.equal(false);
+    });
+});
+
+describe("pyprojectHasPackagingTable", () => {
+    it("returns false for undefined contents", () => {
+        expect(pyprojectHasPackagingTable(undefined)).to.equal(false);
+    });
+
+    it("matches a [project] table", () => {
+        expect(pyprojectHasPackagingTable('[project]\nname = "x"\n')).to.equal(
+            true
+        );
+    });
+
+    it("matches a [build-system] table", () => {
+        const toml = '[build-system]\nrequires = ["setuptools"]\n';
+        expect(pyprojectHasPackagingTable(toml)).to.equal(true);
+    });
+
+    it("matches a [project.<subtable>] header", () => {
+        expect(
+            pyprojectHasPackagingTable("[project.optional-dependencies]\n")
+        ).to.equal(true);
+    });
+
+    it("does not match a tool-only pyproject", () => {
+        // A pyproject carrying only linter/formatter config is not packaging.
+        expect(
+            pyprojectHasPackagingTable("[tool.ruff]\nline-length = 88\n")
+        ).to.equal(false);
+        expect(pyprojectHasPackagingTable("[tool.black]\n")).to.equal(false);
+    });
+
+    it("ignores commented and in-value mentions", () => {
+        expect(pyprojectHasPackagingTable("# [project]\n")).to.equal(false);
+        expect(
+            pyprojectHasPackagingTable('desc = "see [build-system]"\n')
         ).to.equal(false);
     });
 });

--- a/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
@@ -395,4 +395,32 @@ describe("interpreterUnderCondaPrefix", () => {
             interpreterUnderCondaPrefix("C:\\conda\\envs\\ml\\x", "C:\\conda")
         ).to.equal(true);
     });
+
+    it("compares case-insensitively when requested (Windows filesystems)", () => {
+        // Differing case denotes the same folder on a case-insensitive FS.
+        expect(
+            interpreterUnderCondaPrefix(
+                "C:\\Conda\\envs\\ML",
+                "c:\\conda\\envs\\ml",
+                true
+            )
+        ).to.equal(true);
+        expect(
+            interpreterUnderCondaPrefix(
+                "C:\\Conda\\envs\\ML\\x",
+                "c:\\conda",
+                true
+            )
+        ).to.equal(true);
+    });
+
+    it("is case-sensitive when not requested (POSIX filesystems)", () => {
+        expect(
+            interpreterUnderCondaPrefix(
+                "/opt/Conda/envs/ml",
+                "/opt/conda/envs/ml",
+                false
+            )
+        ).to.equal(false);
+    });
 });

--- a/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.test.ts
@@ -1,0 +1,398 @@
+import {expect} from "chai";
+import {
+    detectPackageManagers,
+    interpreterUnderCondaPrefix,
+    PackageManagerSignals,
+    pyprojectHasToolSection,
+    pyvenvCfgMarksUv,
+} from "./packageManagerDetection";
+
+describe("detectPackageManagers", () => {
+    describe("single manager", () => {
+        it("detects uv from uv.lock", () => {
+            const result = detectPackageManagers({hasUvLock: true});
+            expect(result.managers).to.deep.equal(["uv"]);
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal(["uv.lock"]);
+            expect(result.hasLockfile).to.equal(true);
+        });
+
+        it("detects uv from [tool.uv] in pyproject", () => {
+            const result = detectPackageManagers({hasPyprojectToolUv: true});
+            expect(result.managers).to.deep.equal(["uv"]);
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal(["pyproject.tool.uv"]);
+            expect(result.hasLockfile).to.equal(false);
+        });
+
+        it("detects poetry from poetry.lock", () => {
+            const result = detectPackageManagers({hasPoetryLock: true});
+            expect(result.managers).to.deep.equal(["poetry"]);
+            expect(result.primary).to.equal("poetry");
+            expect(result.signals).to.deep.equal(["poetry.lock"]);
+            expect(result.hasLockfile).to.equal(true);
+        });
+
+        it("detects pip from requirements.txt", () => {
+            const result = detectPackageManagers({hasRequirementsTxt: true});
+            expect(result.managers).to.deep.equal(["pip"]);
+            expect(result.primary).to.equal("pip");
+            expect(result.signals).to.deep.equal(["requirements.txt"]);
+            expect(result.hasLockfile).to.equal(false);
+        });
+
+        it("detects pip from constraints.txt", () => {
+            const result = detectPackageManagers({hasConstraintsTxt: true});
+            expect(result.managers).to.deep.equal(["pip"]);
+            expect(result.primary).to.equal("pip");
+            expect(result.signals).to.deep.equal(["constraints.txt"]);
+        });
+
+        it("detects pip from a pip-only pyproject", () => {
+            const result = detectPackageManagers({hasPyprojectPipOnly: true});
+            expect(result.managers).to.deep.equal(["pip"]);
+            expect(result.primary).to.equal("pip");
+            expect(result.signals).to.deep.equal(["pyproject.pipOnly"]);
+        });
+
+        it("detects conda from environment.yml", () => {
+            const result = detectPackageManagers({hasCondaEnvFile: true});
+            expect(result.managers).to.deep.equal(["conda"]);
+            expect(result.primary).to.equal("conda");
+            expect(result.signals).to.deep.equal(["environment.yml"]);
+        });
+
+        it("detects conda from an active CONDA_PREFIX", () => {
+            const result = detectPackageManagers({hasCondaPrefix: true});
+            expect(result.managers).to.deep.equal(["conda"]);
+            expect(result.primary).to.equal("conda");
+            expect(result.signals).to.deep.equal(["conda.prefix"]);
+        });
+    });
+
+    describe("interpreter source", () => {
+        it("attributes uv from a uv-created interpreter", () => {
+            const result = detectPackageManagers({interpreterSource: "uv"});
+            expect(result.managers).to.deep.equal(["uv"]);
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal(["interpreter.uv"]);
+            expect(result.interpreterSource).to.equal("uv");
+        });
+
+        it("attributes conda from a conda interpreter", () => {
+            const result = detectPackageManagers({interpreterSource: "conda"});
+            expect(result.managers).to.deep.equal(["conda"]);
+            expect(result.primary).to.equal("conda");
+            expect(result.signals).to.deep.equal(["interpreter.conda"]);
+            expect(result.interpreterSource).to.equal("conda");
+        });
+
+        it("attributes pip from a plain venv interpreter", () => {
+            const result = detectPackageManagers({interpreterSource: "venv"});
+            expect(result.managers).to.deep.equal(["pip"]);
+            expect(result.primary).to.equal("pip");
+            expect(result.signals).to.deep.equal(["interpreter.venv"]);
+            expect(result.interpreterSource).to.equal("venv");
+        });
+
+        it("defaults interpreterSource to unknown when absent", () => {
+            const result = detectPackageManagers({hasUvLock: true});
+            expect(result.interpreterSource).to.equal("unknown");
+        });
+    });
+
+    describe("overlaps", () => {
+        it("reports both uv and pip (uv.lock + requirements.txt)", () => {
+            const result = detectPackageManagers({
+                hasUvLock: true,
+                hasRequirementsTxt: true,
+            });
+            expect(result.managers).to.deep.equal(["uv", "pip"]);
+            // uv outranks pip as primary.
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal([
+                "uv.lock",
+                "requirements.txt",
+            ]);
+            expect(result.hasLockfile).to.equal(true);
+        });
+
+        it("reports both conda and pip (environment.yml + requirements.txt)", () => {
+            const result = detectPackageManagers({
+                hasCondaEnvFile: true,
+                hasRequirementsTxt: true,
+            });
+            expect(result.managers).to.deep.equal(["conda", "pip"]);
+            // conda outranks pip as primary.
+            expect(result.primary).to.equal("conda");
+            expect(result.signals).to.deep.equal([
+                "requirements.txt",
+                "environment.yml",
+            ]);
+        });
+
+        it("reports both poetry and uv (both pyproject sections)", () => {
+            const result = detectPackageManagers({
+                hasPyprojectToolUv: true,
+                hasPyprojectToolPoetry: true,
+            });
+            expect(result.managers).to.deep.equal(["uv", "poetry"]);
+            // uv outranks poetry as primary.
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal([
+                "pyproject.tool.uv",
+                "pyproject.tool.poetry",
+            ]);
+        });
+
+        it("orders primary uv > poetry > conda > pip when all apply", () => {
+            const result = detectPackageManagers({
+                hasUvLock: true,
+                hasPoetryLock: true,
+                hasCondaEnvFile: true,
+                hasRequirementsTxt: true,
+            });
+            expect(result.managers).to.deep.equal([
+                "uv",
+                "poetry",
+                "conda",
+                "pip",
+            ]);
+            expect(result.primary).to.equal("uv");
+            expect(result.hasLockfile).to.equal(true);
+        });
+    });
+
+    describe("weak signals", () => {
+        it("records uv/poetry on PATH without attributing the project", () => {
+            const result = detectPackageManagers({
+                uvOnPath: true,
+                poetryOnPath: true,
+            });
+            // A tool merely installed on PATH is not project usage.
+            expect(result.managers).to.deep.equal([]);
+            expect(result.primary).to.equal("unknown");
+            expect(result.signals).to.deep.equal([
+                "uv.onPath",
+                "poetry.onPath",
+            ]);
+        });
+
+        it("promotes uv to a manager when PATH is joined by a lockfile", () => {
+            const result = detectPackageManagers({
+                uvOnPath: true,
+                hasUvLock: true,
+            });
+            expect(result.managers).to.deep.equal(["uv"]);
+            expect(result.primary).to.equal("uv");
+            expect(result.signals).to.deep.equal(["uv.lock", "uv.onPath"]);
+        });
+
+        it("keeps the real interpreter source for a uv project on a conda interpreter", () => {
+            // A uv.lock project where the user has not yet selected a
+            // uv-managed interpreter: uv is the project manager, but the
+            // interpreter source must reflect the actually-active conda env so
+            // the setup-flow gap stays visible (not masked as interpreter.uv).
+            const result = detectPackageManagers({
+                hasUvLock: true,
+                interpreterSource: "conda",
+            });
+            expect(result.managers).to.deep.equal(["uv", "conda"]);
+            expect(result.primary).to.equal("uv");
+            expect(result.interpreterSource).to.equal("conda");
+            expect(result.signals).to.deep.equal([
+                "uv.lock",
+                "interpreter.conda",
+            ]);
+        });
+    });
+
+    describe("none", () => {
+        it("returns unknown for empty signals", () => {
+            const result = detectPackageManagers({});
+            expect(result.managers).to.deep.equal([]);
+            expect(result.primary).to.equal("unknown");
+            expect(result.signals).to.deep.equal([]);
+            expect(result.hasLockfile).to.equal(false);
+            expect(result.interpreterSource).to.equal("unknown");
+        });
+
+        it("returns unknown when only an unknown interpreter is present", () => {
+            const signals: PackageManagerSignals = {
+                interpreterSource: "unknown",
+            };
+            const result = detectPackageManagers(signals);
+            expect(result.managers).to.deep.equal([]);
+            expect(result.primary).to.equal("unknown");
+        });
+    });
+});
+
+describe("pyprojectHasToolSection", () => {
+    it("returns false for undefined contents", () => {
+        expect(pyprojectHasToolSection(undefined, "uv")).to.equal(false);
+    });
+
+    it("matches a bare [tool.uv] header", () => {
+        expect(pyprojectHasToolSection("[tool.uv]\n", "uv")).to.equal(true);
+    });
+
+    it("matches a [tool.poetry] header", () => {
+        const toml = '[tool.poetry]\nname = "x"\n';
+        expect(pyprojectHasToolSection(toml, "poetry")).to.equal(true);
+    });
+
+    it("matches subtable-only headers (no bare [tool.uv])", () => {
+        // Real uv projects often have only subtables.
+        expect(pyprojectHasToolSection("[tool.uv.sources]\n", "uv")).to.equal(
+            true
+        );
+        expect(
+            pyprojectHasToolSection(
+                "[tool.poetry.group.dev.dependencies]\n",
+                "poetry"
+            )
+        ).to.equal(true);
+    });
+
+    it("tolerates whitespace inside the header brackets", () => {
+        expect(pyprojectHasToolSection("[ tool.uv ]\n", "uv")).to.equal(true);
+    });
+
+    it("ignores a commented-out header", () => {
+        expect(pyprojectHasToolSection("# [tool.uv]\n", "uv")).to.equal(false);
+        expect(
+            pyprojectHasToolSection("  #[tool.poetry]\n", "poetry")
+        ).to.equal(false);
+    });
+
+    it("ignores trailing comments after an unrelated header", () => {
+        const toml = "[project] # not [tool.uv]\n";
+        expect(pyprojectHasToolSection(toml, "uv")).to.equal(false);
+    });
+
+    it("does not match tool.uv mentioned inside a value or key", () => {
+        expect(
+            pyprojectHasToolSection('description = "use [tool.uv]"\n', "uv")
+        ).to.equal(false);
+        expect(
+            pyprojectHasToolSection('urls."tool.uv" = "x"\n', "uv")
+        ).to.equal(false);
+    });
+
+    it("does not match a different tool's section", () => {
+        expect(pyprojectHasToolSection("[tool.ruff]\n", "uv")).to.equal(false);
+        // Prefix collision: [tool.uvicorn] must not count as [tool.uv].
+        expect(pyprojectHasToolSection("[tool.uvicorn]\n", "uv")).to.equal(
+            false
+        );
+    });
+
+    it("matches array-of-table headers ([[...]])", () => {
+        expect(pyprojectHasToolSection("[[tool.uv.index]]\n", "uv")).to.equal(
+            true
+        );
+        expect(
+            pyprojectHasToolSection("[[tool.poetry.source]]\n", "poetry")
+        ).to.equal(true);
+        // Bare array-of-table form as well.
+        expect(pyprojectHasToolSection("[[tool.uv]]\n", "uv")).to.equal(true);
+    });
+
+    it("does not match array-of-table prefix collisions", () => {
+        expect(pyprojectHasToolSection("[[tool.uvicorn.x]]\n", "uv")).to.equal(
+            false
+        );
+    });
+});
+
+describe("pyvenvCfgMarksUv", () => {
+    it("returns false for undefined contents", () => {
+        expect(pyvenvCfgMarksUv(undefined)).to.equal(false);
+    });
+
+    it("detects a uv = <version> line", () => {
+        const cfg = "home = /usr/bin\nversion = 3.11.4\nuv = 0.4.18\n";
+        expect(pyvenvCfgMarksUv(cfg)).to.equal(true);
+    });
+
+    it("tolerates whitespace around the uv key", () => {
+        expect(pyvenvCfgMarksUv("  uv   =   0.5.0\n")).to.equal(true);
+    });
+
+    it("returns false for a plain (non-uv) venv config", () => {
+        const cfg =
+            "home = /usr/bin\ninclude-system-site-packages = false\nversion = 3.11.4\n";
+        expect(pyvenvCfgMarksUv(cfg)).to.equal(false);
+    });
+
+    it("does not match uv appearing in another key or value", () => {
+        expect(pyvenvCfgMarksUv("command = /x/uv venv\n")).to.equal(false);
+        expect(pyvenvCfgMarksUv("uv_seed = true\n")).to.equal(false);
+    });
+});
+
+describe("interpreterUnderCondaPrefix", () => {
+    it("returns false when either path is missing", () => {
+        expect(interpreterUnderCondaPrefix(undefined, "/opt/conda")).to.equal(
+            false
+        );
+        expect(interpreterUnderCondaPrefix("/opt/conda", undefined)).to.equal(
+            false
+        );
+    });
+
+    it("matches when sysPrefix equals the conda prefix", () => {
+        expect(
+            interpreterUnderCondaPrefix(
+                "/opt/conda/envs/ml",
+                "/opt/conda/envs/ml"
+            )
+        ).to.equal(true);
+    });
+
+    it("matches when the interpreter is nested under the prefix", () => {
+        expect(
+            interpreterUnderCondaPrefix("/opt/conda/envs/ml/bin", "/opt/conda")
+        ).to.equal(true);
+    });
+
+    it("tolerates a trailing separator on either path", () => {
+        expect(
+            interpreterUnderCondaPrefix(
+                "/opt/conda/envs/ml/",
+                "/opt/conda/envs/ml"
+            )
+        ).to.equal(true);
+    });
+
+    it("does not match on a shared path prefix that is not a boundary", () => {
+        // /x/envs/ab must not be treated as inside /x/envs/a.
+        expect(interpreterUnderCondaPrefix("/x/envs/ab", "/x/envs/a")).to.equal(
+            false
+        );
+    });
+
+    it("does not match an unrelated interpreter (shell-global CONDA_PREFIX)", () => {
+        // The conda env is active in the shell, but the selected interpreter
+        // is a uv/venv elsewhere -- must not be attributed to conda.
+        expect(
+            interpreterUnderCondaPrefix(
+                "/home/u/project/.venv",
+                "/opt/conda/envs/base"
+            )
+        ).to.equal(false);
+    });
+
+    it("handles Windows-style separators", () => {
+        expect(
+            interpreterUnderCondaPrefix(
+                "C:\\conda\\envs\\ml",
+                "C:\\conda\\envs\\ml"
+            )
+        ).to.equal(true);
+        expect(
+            interpreterUnderCondaPrefix("C:\\conda\\envs\\ml\\x", "C:\\conda")
+        ).to.equal(true);
+    });
+});

--- a/packages/databricks-vscode/src/language/packageManagerDetection.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.ts
@@ -74,6 +74,12 @@ export interface PackageManagerSignals {
     /**
      * A `pyproject.toml` exists but declares neither `[tool.uv]` nor
      * `[tool.poetry]` (i.e. a plain PEP 621 / pip-installable project).
+     *
+     * Caveat: uv works fine with a bare `[project]` and no `[tool.uv]`, so a uv
+     * project without a committed `uv.lock` is counted here as pip. When
+     * `uv.lock` is present uv still fires and wins primary, so the skew is
+     * limited to lockfile-less uv projects -- but this slightly over-counts pip
+     * / under-counts uv (noted for the analytics owner in the handoff doc).
      */
     hasPyprojectPipOnly?: boolean;
 
@@ -263,22 +269,30 @@ export function pyvenvCfgMarksUv(contents: string | undefined): boolean {
  * Whether an interpreter's `sysPrefix` lies inside a conda prefix -- i.e. the
  * active interpreter is that conda environment, not merely a shell that has
  * `CONDA_PREFIX` exported globally. Both inputs are expected to be absolute
- * paths; comparison is done with a trailing-separator boundary so that
- * `/x/envs/ab` is not treated as inside `/x/envs/a`.
+ * paths; comparison uses a trailing-separator boundary so that `/x/envs/ab` is
+ * not treated as inside `/x/envs/a`, and accepts both `/` and `\\` separators.
  *
- * Pure over its inputs; returns false if either is missing. Accepts both `/`
- * and `\\` separators so it is platform-agnostic and deterministic in tests.
+ * `caseInsensitive` controls case folding for the comparison; it defaults to
+ * Windows, whose filesystem is case-insensitive (so `C:\Conda` and `c:\conda`
+ * denote the same folder). Exposed as a parameter so the behaviour is
+ * deterministic in tests regardless of the host platform.
+ *
+ * Pure over its inputs; returns false if either is missing.
  */
 export function interpreterUnderCondaPrefix(
     sysPrefix: string | undefined,
-    condaPrefix: string | undefined
+    condaPrefix: string | undefined,
+    caseInsensitive: boolean = process.platform === "win32"
 ): boolean {
     if (!sysPrefix || !condaPrefix) {
         return false;
     }
-    const stripTrailingSep = (p: string) => p.replace(/[\\/]+$/, "");
-    const prefix = stripTrailingSep(sysPrefix);
-    const base = stripTrailingSep(condaPrefix);
+    const normalize = (p: string) => {
+        const stripped = p.replace(/[\\/]+$/, "");
+        return caseInsensitive ? stripped.toLowerCase() : stripped;
+    };
+    const prefix = normalize(sysPrefix);
+    const base = normalize(condaPrefix);
     return (
         prefix === base ||
         prefix.startsWith(base + "/") ||

--- a/packages/databricks-vscode/src/language/packageManagerDetection.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.ts
@@ -1,0 +1,287 @@
+/**
+ * Pure, signal-based detection of the Python package/environment manager(s) a
+ * project uses.
+ *
+ * This module is intentionally side-effect free: callers gather raw signals
+ * from disk and the environment (see {@link PackageManagerSignals}) and pass
+ * them to {@link detectPackageManagers}, which classifies them. Keeping the
+ * classification pure makes it deterministic and trivially unit-testable across
+ * the overlap cases (uv+pip, conda+pip, poetry+uv, none).
+ *
+ * The detection feeds telemetry only (see Events.PYTHON_ENV_SETUP_DETECTED). It
+ * never changes setup behaviour, and only categorical/enum data leaves this
+ * module — no paths, package names, or other free-form content.
+ */
+
+/** A package/environment manager we can attribute a project to. */
+export type PackageManager = "uv" | "poetry" | "pip" | "conda";
+
+/** The best-guess primary manager, or "unknown" when no signal fires. */
+export type PrimaryManager = PackageManager | "unknown";
+
+/**
+ * How the active interpreter was provisioned, independent of which managers the
+ * project declares on disk.
+ */
+export type InterpreterSource = "uv" | "conda" | "system" | "venv" | "unknown";
+
+/**
+ * Individual signals that fired during detection. These are the only free-form
+ * strings emitted, and they come from this closed, enumerated set — never from
+ * user content.
+ */
+export type DetectionSignal =
+    | "uv.lock"
+    | "pyproject.tool.uv"
+    | "uv.onPath"
+    | "interpreter.uv"
+    | "poetry.lock"
+    | "pyproject.tool.poetry"
+    | "poetry.onPath"
+    | "requirements.txt"
+    | "constraints.txt"
+    | "pyproject.pipOnly"
+    | "interpreter.venv"
+    | "environment.yml"
+    | "conda.prefix"
+    | "interpreter.conda";
+
+/**
+ * Raw, already-collected signals about a project. Every field is optional so
+ * callers can supply only what they could cheaply determine; missing fields are
+ * treated as "signal absent". Collecting these must never throw into the user
+ * flow — a failed probe should be reported as `false`/`undefined`.
+ */
+export interface PackageManagerSignals {
+    /** A `uv.lock` file exists in the project root. */
+    hasUvLock?: boolean;
+    /** `pyproject.toml` contains a `[tool.uv]` section. */
+    hasPyprojectToolUv?: boolean;
+    /** A `uv` executable is resolvable on PATH. */
+    uvOnPath?: boolean;
+
+    /** A `poetry.lock` file exists in the project root. */
+    hasPoetryLock?: boolean;
+    /** `pyproject.toml` contains a `[tool.poetry]` section. */
+    hasPyprojectToolPoetry?: boolean;
+    /** A `poetry` executable is resolvable on PATH. */
+    poetryOnPath?: boolean;
+
+    /** One or more `requirements*.txt` files exist. */
+    hasRequirementsTxt?: boolean;
+    /** A `constraints.txt` file exists. */
+    hasConstraintsTxt?: boolean;
+    /**
+     * A `pyproject.toml` exists but declares neither `[tool.uv]` nor
+     * `[tool.poetry]` (i.e. a plain PEP 621 / pip-installable project).
+     */
+    hasPyprojectPipOnly?: boolean;
+
+    /** An `environment.yml` / `environment.yaml` file exists. */
+    hasCondaEnvFile?: boolean;
+    /**
+     * The active interpreter resides under `CONDA_PREFIX`. Collectors must NOT
+     * set this from the bare presence of `CONDA_PREFIX` / `CONDA_DEFAULT_ENV`:
+     * those are session-global (set for every project when VS Code is launched
+     * from an activated conda shell) and would over-count conda.
+     */
+    hasCondaPrefix?: boolean;
+
+    /**
+     * How the active interpreter was provisioned, if known. Drives both the
+     * `interpreter_source` field and a corroborating manager signal.
+     */
+    interpreterSource?: InterpreterSource;
+}
+
+/** The full classification result. All fields are categorical or boolean. */
+export interface PackageManagerDetection {
+    /** Every manager with at least one firing signal, in priority order. */
+    managers: PackageManager[];
+    /** Best-guess primary manager, or "unknown" when nothing matched. */
+    primary: PrimaryManager;
+    /** The exact signals that fired, in a stable order. */
+    signals: DetectionSignal[];
+    /** True when a lockfile (uv.lock or poetry.lock) was found. */
+    hasLockfile: boolean;
+    /** How the active interpreter was provisioned. */
+    interpreterSource: InterpreterSource;
+}
+
+/**
+ * Priority order used to pick the primary manager when several apply. uv and
+ * poetry are the most specific (they own the whole workflow), conda is next
+ * (it provisions the interpreter), and pip is the fallback that almost any
+ * project can also satisfy.
+ */
+const PRIMARY_PRIORITY: PackageManager[] = ["uv", "poetry", "conda", "pip"];
+
+/**
+ * Classify a project's package manager(s) from a set of pre-collected signals.
+ *
+ * Pure and total: any input (including all-empty) yields a well-formed result,
+ * defaulting to `unknown`/`[]`. Multiple managers can be reported at once since
+ * they legitimately co-exist (e.g. a conda env that also uses pip).
+ */
+export function detectPackageManagers(
+    signals: PackageManagerSignals
+): PackageManagerDetection {
+    const interpreterSource = signals.interpreterSource ?? "unknown";
+
+    // Build the firing-signal list in a deterministic order. Each entry maps a
+    // collected boolean to the enum string emitted in telemetry.
+    const firedSignals: DetectionSignal[] = [];
+    const fire = (condition: boolean | undefined, signal: DetectionSignal) => {
+        if (condition) {
+            firedSignals.push(signal);
+        }
+    };
+
+    fire(signals.hasUvLock, "uv.lock");
+    fire(signals.hasPyprojectToolUv, "pyproject.tool.uv");
+    fire(signals.uvOnPath, "uv.onPath");
+    fire(interpreterSource === "uv", "interpreter.uv");
+
+    fire(signals.hasPoetryLock, "poetry.lock");
+    fire(signals.hasPyprojectToolPoetry, "pyproject.tool.poetry");
+    fire(signals.poetryOnPath, "poetry.onPath");
+
+    fire(signals.hasRequirementsTxt, "requirements.txt");
+    fire(signals.hasConstraintsTxt, "constraints.txt");
+    fire(signals.hasPyprojectPipOnly, "pyproject.pipOnly");
+    fire(interpreterSource === "venv", "interpreter.venv");
+
+    fire(signals.hasCondaEnvFile, "environment.yml");
+    fire(signals.hasCondaPrefix, "conda.prefix");
+    fire(interpreterSource === "conda", "interpreter.conda");
+
+    // A bare `uv`/`poetry` on PATH is a weak signal: it says the tool is
+    // installed, not that this project uses it. We still record the signal, but
+    // it alone does not attribute the project to that manager — that requires a
+    // project-local marker (lockfile, pyproject section, or interpreter).
+    const usesUv =
+        Boolean(signals.hasUvLock) ||
+        Boolean(signals.hasPyprojectToolUv) ||
+        interpreterSource === "uv";
+    const usesPoetry =
+        Boolean(signals.hasPoetryLock) ||
+        Boolean(signals.hasPyprojectToolPoetry);
+    const usesConda =
+        Boolean(signals.hasCondaEnvFile) ||
+        Boolean(signals.hasCondaPrefix) ||
+        interpreterSource === "conda";
+    const usesPip =
+        Boolean(signals.hasRequirementsTxt) ||
+        Boolean(signals.hasConstraintsTxt) ||
+        Boolean(signals.hasPyprojectPipOnly) ||
+        interpreterSource === "venv";
+
+    const managers: PackageManager[] = [];
+    if (usesUv) {
+        managers.push("uv");
+    }
+    if (usesPoetry) {
+        managers.push("poetry");
+    }
+    if (usesConda) {
+        managers.push("conda");
+    }
+    if (usesPip) {
+        managers.push("pip");
+    }
+
+    const primary: PrimaryManager =
+        PRIMARY_PRIORITY.find((m) => managers.includes(m)) ?? "unknown";
+
+    const hasLockfile =
+        Boolean(signals.hasUvLock) || Boolean(signals.hasPoetryLock);
+
+    return {
+        managers,
+        primary,
+        signals: firedSignals,
+        hasLockfile,
+        interpreterSource,
+    };
+}
+
+/**
+ * Whether a `pyproject.toml` declares a `[tool.<name>]` table (the `name`
+ * table itself or any subtable such as `[tool.uv.sources]`).
+ *
+ * A bounded, line-based scan of table headers -- deliberately not a full TOML
+ * parse (no dependency needed for this) and more robust than a substring
+ * match. It:
+ *  - ignores comments (`#`), including a commented-out header,
+ *  - ignores `tool.<name>` mentions inside string values or other keys,
+ *  - matches subtables, so projects that only have e.g. `[tool.uv.workspace]`
+ *    or `[tool.poetry.group.dev.dependencies]` are still detected,
+ *  - matches array-of-table headers too, e.g. `[[tool.uv.index]]` or
+ *    `[[tool.poetry.source]]`.
+ *
+ * Pure over the file contents; returns false for undefined input.
+ */
+export function pyprojectHasToolSection(
+    contents: string | undefined,
+    name: "uv" | "poetry"
+): boolean {
+    if (contents === undefined) {
+        return false;
+    }
+    // Matches a table header at the start of a line: `[tool.<name>]`,
+    // `[tool.<name>.<subtable>]`, or the array-of-table forms `[[tool.<name>]]`
+    // / `[[tool.<name>.<subtable>]]`. The optional second `[` covers the
+    // array-of-table case. Whitespace inside the brackets is allowed; anything
+    // after `#` on the line is a comment and never reaches here because we
+    // strip it first.
+    const header = new RegExp(`^\\[\\[?\\s*tool\\.${name}\\s*(\\.|\\])`);
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.split("#", 1)[0].trim();
+        if (header.test(line)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Whether the contents of a venv's `pyvenv.cfg` mark it as created by uv. uv
+ * writes a `uv = <version>` line into the file it generates; the MS Python
+ * extension otherwise reports such venvs as plain virtual environments, so this
+ * marker is what distinguishes a genuinely uv-provisioned interpreter.
+ *
+ * Pure over the file contents; returns false for undefined input.
+ */
+export function pyvenvCfgMarksUv(contents: string | undefined): boolean {
+    if (contents === undefined) {
+        return false;
+    }
+    return /^\s*uv\s*=/m.test(contents);
+}
+
+/**
+ * Whether an interpreter's `sysPrefix` lies inside a conda prefix -- i.e. the
+ * active interpreter is that conda environment, not merely a shell that has
+ * `CONDA_PREFIX` exported globally. Both inputs are expected to be absolute
+ * paths; comparison is done with a trailing-separator boundary so that
+ * `/x/envs/ab` is not treated as inside `/x/envs/a`.
+ *
+ * Pure over its inputs; returns false if either is missing. Accepts both `/`
+ * and `\\` separators so it is platform-agnostic and deterministic in tests.
+ */
+export function interpreterUnderCondaPrefix(
+    sysPrefix: string | undefined,
+    condaPrefix: string | undefined
+): boolean {
+    if (!sysPrefix || !condaPrefix) {
+        return false;
+    }
+    const stripTrailingSep = (p: string) => p.replace(/[\\/]+$/, "");
+    const prefix = stripTrailingSep(sysPrefix);
+    const base = stripTrailingSep(condaPrefix);
+    return (
+        prefix === base ||
+        prefix.startsWith(base + "/") ||
+        prefix.startsWith(base + "\\")
+    );
+}

--- a/packages/databricks-vscode/src/language/packageManagerDetection.ts
+++ b/packages/databricks-vscode/src/language/packageManagerDetection.ts
@@ -21,9 +21,17 @@ export type PrimaryManager = PackageManager | "unknown";
 
 /**
  * How the active interpreter was provisioned, independent of which managers the
- * project declares on disk.
+ * project declares on disk. `poetry` is distinct from `venv`: although poetry
+ * uses virtual environments, conflating it with a plain venv would attribute
+ * the interpreter to pip and undercount poetry.
  */
-export type InterpreterSource = "uv" | "conda" | "system" | "venv" | "unknown";
+export type InterpreterSource =
+    | "uv"
+    | "poetry"
+    | "conda"
+    | "system"
+    | "venv"
+    | "unknown";
 
 /**
  * Individual signals that fired during detection. These are the only free-form
@@ -38,6 +46,7 @@ export type DetectionSignal =
     | "poetry.lock"
     | "pyproject.tool.poetry"
     | "poetry.onPath"
+    | "interpreter.poetry"
     | "requirements.txt"
     | "constraints.txt"
     | "pyproject.pipOnly"
@@ -72,8 +81,10 @@ export interface PackageManagerSignals {
     /** A `constraints.txt` file exists. */
     hasConstraintsTxt?: boolean;
     /**
-     * A `pyproject.toml` exists but declares neither `[tool.uv]` nor
-     * `[tool.poetry]` (i.e. a plain PEP 621 / pip-installable project).
+     * A `pyproject.toml` declares a packaging table (`[project]` /
+     * `[build-system]`) but neither `[tool.uv]` nor `[tool.poetry]` -- i.e. a
+     * plain PEP 621 / pip-installable project. A `pyproject.toml` that only
+     * carries tool config (e.g. just `[tool.ruff]`) is NOT counted here.
      *
      * Caveat: uv works fine with a bare `[project]` and no `[tool.uv]`, so a uv
      * project without a committed `uv.lock` is counted here as pip. When
@@ -151,6 +162,7 @@ export function detectPackageManagers(
     fire(signals.hasPoetryLock, "poetry.lock");
     fire(signals.hasPyprojectToolPoetry, "pyproject.tool.poetry");
     fire(signals.poetryOnPath, "poetry.onPath");
+    fire(interpreterSource === "poetry", "interpreter.poetry");
 
     fire(signals.hasRequirementsTxt, "requirements.txt");
     fire(signals.hasConstraintsTxt, "constraints.txt");
@@ -171,7 +183,8 @@ export function detectPackageManagers(
         interpreterSource === "uv";
     const usesPoetry =
         Boolean(signals.hasPoetryLock) ||
-        Boolean(signals.hasPyprojectToolPoetry);
+        Boolean(signals.hasPyprojectToolPoetry) ||
+        interpreterSource === "poetry";
     const usesConda =
         Boolean(signals.hasCondaEnvFile) ||
         Boolean(signals.hasCondaPrefix) ||
@@ -241,6 +254,32 @@ export function pyprojectHasToolSection(
     // after `#` on the line is a comment and never reaches here because we
     // strip it first.
     const header = new RegExp(`^\\[\\[?\\s*tool\\.${name}\\s*(\\.|\\])`);
+    for (const rawLine of contents.split(/\r?\n/)) {
+        const line = rawLine.split("#", 1)[0].trim();
+        if (header.test(line)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Whether a `pyproject.toml` declares an actual packaging table -- `[project]`
+ * (PEP 621) or `[build-system]`. Used to distinguish a pip-installable project
+ * from a `pyproject.toml` that merely carries tool config (e.g. only
+ * `[tool.ruff]` / `[tool.black]`), which must NOT be attributed to pip.
+ *
+ * Same bounded, comment-aware line scan as {@link pyprojectHasToolSection}.
+ * Pure over the file contents; returns false for undefined input.
+ */
+export function pyprojectHasPackagingTable(
+    contents: string | undefined
+): boolean {
+    if (contents === undefined) {
+        return false;
+    }
+    // `[project]`, `[project.<subtable>]`, or `[build-system]` at line start.
+    const header = /^\[\s*(project|build-system)\s*(\.|\])/;
     for (const rawLine of contents.split(/\r?\n/)) {
         const line = rawLine.split("#", 1)[0].trim();
         if (header.test(line)) {

--- a/packages/databricks-vscode/src/run/RunCommands.test.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.test.ts
@@ -8,6 +8,7 @@ import {FeatureManager, FeatureState} from "../feature-manager/FeatureManager";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {Telemetry} from "../telemetry";
+import {PackageManagerTelemetry} from "../language/PackageManagerTelemetry";
 
 function featureState(available: boolean, executable?: string): FeatureState {
     return {
@@ -44,7 +45,8 @@ describe(__filename, () => {
             instance(featureManagerMock),
             {subscriptions: []} as unknown as ExtensionContext,
             instance(mock(CustomWhenContext)),
-            instance(mock(Telemetry))
+            instance(mock(Telemetry)),
+            instance(mock(PackageManagerTelemetry))
         );
     });
 

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -13,6 +13,7 @@ import {
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {Events, Telemetry} from "../telemetry";
+import {PackageManagerTelemetry} from "../language/PackageManagerTelemetry";
 
 /**
  * Run related commands
@@ -25,7 +26,8 @@ export class RunCommands {
         private readonly featureManager: FeatureManager,
         private readonly context: ExtensionContext,
         private readonly customWhenContext: CustomWhenContext,
-        private readonly telemetry: Telemetry
+        private readonly telemetry: Telemetry,
+        private readonly packageManagerTelemetry: PackageManagerTelemetry
     ) {
         this.context.subscriptions.push(
             window.onDidChangeActiveTextEditor(async () =>
@@ -227,6 +229,7 @@ export class RunCommands {
             launchType: "debug",
             computeType: this.connection.serverless ? "serverless" : "cluster",
         });
+        void this.packageManagerTelemetry.emitDetection("debug");
     }
 
     async runFileUsingDbconnect(resource?: Uri) {
@@ -251,5 +254,6 @@ export class RunCommands {
             launchType: "run",
             computeType: this.connection.serverless ? "serverless" : "cluster",
         });
+        void this.packageManagerTelemetry.emitDetection("run");
     }
 }

--- a/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
+++ b/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
@@ -80,7 +80,25 @@ once per distinct trigger (e.g. one `auto_open` and one `run`).
 Only categorical/enum data and the closed-set signal ids are emitted. No file
 paths, package names, project names, cluster names, or usernames. Detection is
 best-effort and non-blocking: any failure degrades to `unknown` and is
-swallowed, never thrown into the setup/run flow.
+swallowed, never thrown into the setup/run flow. Nothing is collected (not even
+disk reads) when the user's telemetry level is below `all`.
+
+Note that, like every event from this extension, each detection inherits the
+ambient user/workspace envelope attached by the telemetry client —
+`user.hashedUserName` (bcrypt hash), `user.host`, `workspaceId`, `authType`. So
+while the detection payload itself carries no identifiers, an emitted event does
+link the detected toolchain to a stable (hashed) user/workspace identity.
+
+## Known measurement caveats
+
+-   **`pyproject.pipOnly` slightly over-counts pip / under-counts uv.** uv works
+    with a bare `[project]` table and no `[tool.uv]` section, so a uv project
+    without a committed `uv.lock` is classified as pip. With `uv.lock` present
+    uv still fires and wins primary, so the skew is limited to lockfile-less uv
+    projects.
+-   `interpreterSource` reflects the active interpreter only; a project that
+    declares uv/poetry but runs a system/conda interpreter reports that real
+    source (this is intentional — it surfaces the setup-flow gap).
 
 ## Suggested analysis
 

--- a/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
+++ b/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
@@ -33,7 +33,7 @@ schema.
 | `primaryManager`    | enum       | `uv \| poetry \| pip \| conda \| unknown`. Priority when several apply: **uv > poetry > conda > pip**. `unknown` when no signal fires. |
 | `signals`           | `string[]` | Closed set of signal ids that fired (see below). JSON-stringified by the transport.                                                    |
 | `pythonVersion`     | `string?`  | Interpreter version, **major.minor only** (e.g. `"3.11"`). Omitted if unknown.                                                         |
-| `interpreterSource` | enum       | `uv \| conda \| system \| venv \| unknown`. How the active interpreter was provisioned.                                                |
+| `interpreterSource` | enum       | `uv \| poetry \| conda \| system \| venv \| unknown`. How the active interpreter was provisioned (`poetry` kept distinct from `venv`). |
 | `hasLockfile`       | `boolean`  | True if `uv.lock` or `poetry.lock` was found.                                                                                          |
 | `targetCompute`     | enum       | `cluster \| serverless \| none`. **No** cluster IDs/names.                                                                             |
 | `setupTrigger`      | enum       | `auto_open \| explicit_command \| run \| debug`. Which touchpoint fired it.                                                            |
@@ -41,9 +41,9 @@ schema.
 ### `signals` value domain (closed set)
 
 `uv.lock`, `pyproject.tool.uv`, `uv.onPath`, `interpreter.uv`, `poetry.lock`,
-`pyproject.tool.poetry`, `poetry.onPath`, `requirements.txt`, `constraints.txt`,
-`pyproject.pipOnly`, `interpreter.venv`, `environment.yml`, `conda.prefix`,
-`interpreter.conda`.
+`pyproject.tool.poetry`, `poetry.onPath`, `interpreter.poetry`,
+`requirements.txt`, `constraints.txt`, `pyproject.pipOnly`, `interpreter.venv`,
+`environment.yml`, `conda.prefix`, `interpreter.conda`.
 
 > `*.onPath` are **weak** signals: they record that a tool is installed, but do
 > not by themselves attribute the project to that manager. Attribution requires

--- a/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
+++ b/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
@@ -1,0 +1,86 @@
+# Telemetry: Python package-manager detection
+
+Measurement-only instrumentation that records which Python package/environment
+manager(s) a project uses, so we can size the **real** distribution of
+pip / conda / uv / poetry usage across Databricks VS Code users and prioritize
+the VPEX setup-flow investment with first-party data instead of public-survey
+estimates.
+
+This event does **not** change any setup behaviour. It is detection only.
+
+## Event
+
+|                     |                                                                   |
+| ------------------- | ----------------------------------------------------------------- |
+| **Event name**      | `python_env.setup.detected`                                       |
+| **Defined in**      | `src/telemetry/constants.ts` (`Events.PYTHON_ENV_SETUP_DETECTED`) |
+| **Emitted from**    | `src/language/PackageManagerTelemetry.ts` (`emitDetection`)       |
+| **Detection logic** | `src/language/packageManagerDetection.ts` (pure, unit-tested)     |
+
+Telemetry is transported via the existing `Telemetry` client
+(`@vscode/extension-telemetry`). As with every event, properties are prefixed
+with `event.` and the user's `telemetry.telemetryLevel` opt-out is honoured by
+the client — nothing is emitted when telemetry is disabled. Standard context
+(extension/telemetry schema version, OS, hashed/anonymized user metadata) is
+attached automatically by the client and is **not** part of this event's own
+schema.
+
+## Schema (the `event.*` fields)
+
+| Field               | Type       | Notes                                                                                                                                  |
+| ------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `managersDetected`  | `string[]` | All managers with a firing signal, e.g. `["uv","pip"]`. Subset of `uv \| poetry \| pip \| conda`. JSON-stringified by the transport.   |
+| `primaryManager`    | enum       | `uv \| poetry \| pip \| conda \| unknown`. Priority when several apply: **uv > poetry > conda > pip**. `unknown` when no signal fires. |
+| `signals`           | `string[]` | Closed set of signal ids that fired (see below). JSON-stringified by the transport.                                                    |
+| `pythonVersion`     | `string?`  | Interpreter version, **major.minor only** (e.g. `"3.11"`). Omitted if unknown.                                                         |
+| `interpreterSource` | enum       | `uv \| conda \| system \| venv \| unknown`. How the active interpreter was provisioned.                                                |
+| `hasLockfile`       | `boolean`  | True if `uv.lock` or `poetry.lock` was found.                                                                                          |
+| `targetCompute`     | enum       | `cluster \| serverless \| none`. **No** cluster IDs/names.                                                                             |
+| `setupTrigger`      | enum       | `auto_open \| explicit_command \| run \| debug`. Which touchpoint fired it.                                                            |
+
+### `signals` value domain (closed set)
+
+`uv.lock`, `pyproject.tool.uv`, `uv.onPath`, `interpreter.uv`, `poetry.lock`,
+`pyproject.tool.poetry`, `poetry.onPath`, `requirements.txt`, `constraints.txt`,
+`pyproject.pipOnly`, `interpreter.venv`, `environment.yml`, `conda.prefix`,
+`interpreter.conda`.
+
+> `*.onPath` are **weak** signals: they record that a tool is installed, but do
+> not by themselves attribute the project to that manager. Attribution requires
+> a project-local marker (lockfile, `pyproject` section, or interpreter source).
+> They are part of the closed set the classifier accepts, but are **not emitted
+> in practice**: the collector does not probe PATH (running an external `uv`/
+> `poetry` binary purely for a non-attributing signal is not worth the cost), so
+> `uv.onPath` / `poetry.onPath` will not appear in real data unless a future
+> collector populates them.
+
+## Where it fires
+
+1. **`auto_open`** — first environment check on project open
+   (`EnvironmentDependenciesVerifier.check`).
+2. **`explicit_command`** — the "set up environment" command
+   (`databricks.environment.setup` → `EnvironmentCommands.setup`).
+3. **`run` / `debug`** — first Run/Debug with Databricks Connect
+   (`RunCommands.runFileUsingDbconnect` / `debugFileUsingDbconnect`).
+
+Emissions are **deduplicated per session** on `(setupTrigger, projectRoot)`, so
+a single project open does not inflate counts. The same project can still emit
+once per distinct trigger (e.g. one `auto_open` and one `run`).
+
+## Privacy
+
+Only categorical/enum data and the closed-set signal ids are emitted. No file
+paths, package names, project names, cluster names, or usernames. Detection is
+best-effort and non-blocking: any failure degrades to `unknown` and is
+swallowed, never thrown into the setup/run flow.
+
+## Suggested analysis
+
+-   Share of projects by `primaryManager`.
+-   Co-occurrence from `managersDetected` (e.g. uv+pip, conda+pip, poetry+uv).
+-   `hasLockfile` and `pythonVersion` distributions to inform per-manager flow
+    depth.
+
+Dedupe at analysis time on the anonymized session id + `projectRoot` is not
+possible (no path is sent); rely on the in-session dedupe above and treat each
+event as one `(session, trigger)` observation.

--- a/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
+++ b/packages/databricks-vscode/src/telemetry/PACKAGE_MANAGER_DETECTION.md
@@ -56,12 +56,20 @@ schema.
 
 ## Where it fires
 
-1. **`auto_open`** — first environment check on project open
-   (`EnvironmentDependenciesVerifier.check`).
+1. **`auto_open`** — first environment check, emitted once the workspace
+   connects (`EnvironmentDependenciesVerifier.check`, after `waitForConnect`).
 2. **`explicit_command`** — the "set up environment" command
    (`databricks.environment.setup` → `EnvironmentCommands.setup`).
 3. **`run` / `debug`** — first Run/Debug with Databricks Connect
    (`RunCommands.runFileUsingDbconnect` / `debugFileUsingDbconnect`).
+
+**Connected only.** Detection is emitted exclusively while the extension is
+connected to a Databricks workspace (`ConnectionManager.state === "CONNECTED"`);
+nothing is reported for unauthenticated sessions, so the data describes active
+users' projects rather than installs that never authenticate. As a result every
+event carries user/workspace metadata (host, workspace id, auth type), and
+`target_compute` reflects the connected compute (it may still be `none` when a
+workspace is connected but no cluster/serverless compute is attached yet).
 
 Emissions are **deduplicated per session** on `(setupTrigger, projectRoot)`, so
 a single project open does not inflate counts. The same project can still emit

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -44,12 +44,17 @@ export type WorkflowTaskType = "python" | "notebook" | "unknown";
 export type LaunchType = "run" | "debug";
 export type ComputeType = "cluster" | "serverless";
 
-/** A Python package/environment manager detected for a project. */
-export type PackageManagerName = "uv" | "poetry" | "pip" | "conda";
-/** Best-guess primary manager, or "unknown" when no signal fires. */
-export type PrimaryManagerName = PackageManagerName | "unknown";
-/** How the active interpreter was provisioned. */
-export type InterpreterSource = "uv" | "conda" | "system" | "venv" | "unknown";
+// Package-manager / interpreter unions are owned by the pure detection module
+// (the single source of truth) and re-exported here so the event schema and the
+// classifier can never drift apart. The detection module has no runtime imports,
+// so this is a type-only dependency with no cycle.
+import type {
+    PackageManager,
+    PrimaryManager,
+    InterpreterSource,
+} from "../language/packageManagerDetection";
+export type {PackageManager, PrimaryManager, InterpreterSource};
+
 /** The compute targeted at the time of detection. */
 export type TargetCompute = ComputeType | "none";
 /** What triggered a package-manager detection emission. */
@@ -222,8 +227,8 @@ export class EventTypes {
         },
     };
     [Events.PYTHON_ENV_SETUP_DETECTED]: EventType<{
-        managersDetected: PackageManagerName[];
-        primaryManager: PrimaryManagerName;
+        managersDetected: PackageManager[];
+        primaryManager: PrimaryManager;
         signals: string[];
         pythonVersion?: string;
         interpreterSource: InterpreterSource;

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -24,6 +24,7 @@ export enum Events {
     WORKFLOW_RUN = "workflowRun",
     DBCONNECT_RUN = "dbconnectRun",
     OPEN_RESOURCE_EXTERNALLY = "openResourceExternally",
+    PYTHON_ENV_SETUP_DETECTED = "python_env.setup.detected",
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -42,6 +43,17 @@ export type BundleRunType =
 export type WorkflowTaskType = "python" | "notebook" | "unknown";
 export type LaunchType = "run" | "debug";
 export type ComputeType = "cluster" | "serverless";
+
+/** A Python package/environment manager detected for a project. */
+export type PackageManagerName = "uv" | "poetry" | "pip" | "conda";
+/** Best-guess primary manager, or "unknown" when no signal fires. */
+export type PrimaryManagerName = PackageManagerName | "unknown";
+/** How the active interpreter was provisioned. */
+export type InterpreterSource = "uv" | "conda" | "system" | "venv" | "unknown";
+/** The compute targeted at the time of detection. */
+export type TargetCompute = ComputeType | "none";
+/** What triggered a package-manager detection emission. */
+export type SetupTrigger = "auto_open" | "explicit_command" | "run" | "debug";
 
 /** Documentation about all of the properties and metrics of the event. */
 type EventDescription<T> = {[K in keyof T]?: {comment?: string}};
@@ -207,6 +219,50 @@ export class EventTypes {
         comment: "An external resource URL was opened",
         type: {
             comment: "The resource type",
+        },
+    };
+    [Events.PYTHON_ENV_SETUP_DETECTED]: EventType<{
+        managersDetected: PackageManagerName[];
+        primaryManager: PrimaryManagerName;
+        signals: string[];
+        pythonVersion?: string;
+        interpreterSource: InterpreterSource;
+        hasLockfile: boolean;
+        targetCompute: TargetCompute;
+        setupTrigger: SetupTrigger;
+    }> = {
+        comment:
+            "The Python package/environment manager(s) detected for a project at setup time. " +
+            "Measurement only: emits categorical data to size the real distribution of " +
+            "pip/conda/uv/poetry usage across users. Contains no paths, package names, or other PII.",
+        managersDetected: {
+            comment:
+                'All package managers with at least one firing signal, e.g. ["uv","pip"]',
+        },
+        primaryManager: {
+            comment:
+                "Best-guess primary manager (uv > poetry > conda > pip), or unknown",
+        },
+        signals: {
+            comment:
+                'The closed-set signal identifiers that fired, e.g. ["uv.lock","pyproject.tool.uv"]',
+        },
+        pythonVersion: {
+            comment:
+                'Detected interpreter version, major.minor only (e.g. "3.11"), if available',
+        },
+        interpreterSource: {
+            comment: "How the active interpreter was provisioned",
+        },
+        hasLockfile: {
+            comment: "Whether a uv.lock or poetry.lock was found",
+        },
+        targetCompute: {
+            comment:
+                "The compute targeted at detection time (no cluster IDs/names)",
+        },
+        setupTrigger: {
+            comment: "Which setup touchpoint triggered detection",
         },
     };
 }

--- a/packages/databricks-vscode/src/telemetry/index.ts
+++ b/packages/databricks-vscode/src/telemetry/index.ts
@@ -118,6 +118,17 @@ export class Telemetry {
     }
 
     /**
+     * Whether non-error events will actually be sent. The underlying reporter
+     * only emits regular events when the user's telemetry level is "all", so
+     * callers that do expensive work purely to build an event (e.g. reading
+     * project files for package-manager detection) should short-circuit on this
+     * to avoid wasted work and any disk access for opted-out users.
+     */
+    get isTelemetryEnabled(): boolean {
+        return this.reporter?.telemetryLevel === "all";
+    }
+
+    /**
      * Add additional metadata as defined in MetadataTypes to all events tracked via this Telemetry instance.
      * @param prefix The type of metadata. The string value of this is prefixed to all property keys when logged.
      * @param properties The properties to log for this metadata.

--- a/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
@@ -37,10 +37,15 @@ Telemetry.prototype.recordPackageManagerDetection = function (
         managersDetected: detection.managers,
         primaryManager: detection.primary,
         signals: detection.signals,
-        pythonVersion: context.pythonVersion,
         interpreterSource: detection.interpreterSource,
         hasLockfile: detection.hasLockfile,
         targetCompute: context.targetCompute,
         setupTrigger: context.trigger,
+        // Omit pythonVersion entirely when unknown -- recordEvent serializes an
+        // explicit `undefined` to the string "undefined", which would pollute
+        // the schema for users without a resolved interpreter.
+        ...(context.pythonVersion !== undefined
+            ? {pythonVersion: context.pythonVersion}
+            : {}),
     });
 };

--- a/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
@@ -1,10 +1,5 @@
 import {Events, Telemetry} from ".";
-import {
-    PackageManagerName,
-    InterpreterSource,
-    TargetCompute,
-    SetupTrigger,
-} from "./constants";
+import {TargetCompute, SetupTrigger} from "./constants";
 import {PackageManagerDetection} from "../language/packageManagerDetection";
 
 /**
@@ -39,11 +34,11 @@ Telemetry.prototype.recordPackageManagerDetection = function (
     context: PackageManagerDetectionContext
 ) {
     this.recordEvent(Events.PYTHON_ENV_SETUP_DETECTED, {
-        managersDetected: detection.managers as PackageManagerName[],
+        managersDetected: detection.managers,
         primaryManager: detection.primary,
         signals: detection.signals,
         pythonVersion: context.pythonVersion,
-        interpreterSource: detection.interpreterSource as InterpreterSource,
+        interpreterSource: detection.interpreterSource,
         hasLockfile: detection.hasLockfile,
         targetCompute: context.targetCompute,
         setupTrigger: context.trigger,

--- a/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/packageManagerExtensions.ts
@@ -1,0 +1,51 @@
+import {Events, Telemetry} from ".";
+import {
+    PackageManagerName,
+    InterpreterSource,
+    TargetCompute,
+    SetupTrigger,
+} from "./constants";
+import {PackageManagerDetection} from "../language/packageManagerDetection";
+
+/**
+ * Context for a package-manager detection that is not part of the detection
+ * result itself: the interpreter version, the targeted compute, and what
+ * triggered the emission.
+ */
+export interface PackageManagerDetectionContext {
+    pythonVersion?: string;
+    targetCompute: TargetCompute;
+    trigger: SetupTrigger;
+}
+
+declare module "." {
+    interface Telemetry {
+        /**
+         * Record a package-manager detection as a PYTHON_ENV_SETUP_DETECTED
+         * event. This is the emit half only: callers gather the signals and run
+         * the pure {@link detectPackageManagers} classifier, then hand the
+         * result here. Keeping the collection out of Telemetry keeps this client
+         * free of disk/Python-extension dependencies.
+         */
+        recordPackageManagerDetection(
+            detection: PackageManagerDetection,
+            context: PackageManagerDetectionContext
+        ): void;
+    }
+}
+
+Telemetry.prototype.recordPackageManagerDetection = function (
+    detection: PackageManagerDetection,
+    context: PackageManagerDetectionContext
+) {
+    this.recordEvent(Events.PYTHON_ENV_SETUP_DETECTED, {
+        managersDetected: detection.managers as PackageManagerName[],
+        primaryManager: detection.primary,
+        signals: detection.signals,
+        pythonVersion: context.pythonVersion,
+        interpreterSource: detection.interpreterSource as InterpreterSource,
+        hasLockfile: detection.hasLockfile,
+        targetCompute: context.targetCompute,
+        setupTrigger: context.trigger,
+    });
+};


### PR DESCRIPTION
## Changes

Measurement-only telemetry to learn which Python package manager(s) our users' projects actually use (pip / conda / uv / poetry), so the VPEX setup-flow investment can be prioritized from first-party data instead of public-survey estimates. No setup behavior changes — this is detection only.

The work splits cleanly into three layers so each is independently testable and the dependency direction stays correct (high-level → low-level):

- **Pure classifier** (`packageManagerDetection.ts`): given a set of already-collected signals, reports every applicable manager, a best-guess primary (priority `uv > poetry > conda > pip`), the firing signals, `hasLockfile`, and interpreter source. Side-effect free and total.
- **Emit** (`telemetry/packageManagerExtensions.ts`): adds `recordPackageManagerDetection` to the existing `Telemetry` class via the same `declare module` pattern as `commandExtensions.ts`. Keeps disk/Python-extension dependencies out of the telemetry client.
- **Collection** (`PackageManagerTelemetry.ts`): a best-effort, non-blocking collector that reads disk and already-resolved interpreter metadata, runs the pure classifier, and calls the emit method. Deduplicated per session on `(trigger, projectRoot)`; any failure degrades to `unknown` and is swallowed so it never disrupts setup.

Emission is wired into three setup touchpoints: project-open environment check (`auto_open`), the set-up-environment command (`explicit_command`), and first Run/Debug with Databricks Connect (`run`/`debug`).

A new `Events.PYTHON_ENV_SETUP_DETECTED` event carries a typed, documented schema (reuses the existing telemetry transport; opt-out honored; categorical data only — no paths, package names, or cluster names). A handoff note for the analytics/dashboard owner is included at `src/telemetry/PACKAGE_MANAGER_DETECTION.md`.

**Detection correctness** (the parts most worth reviewing):
- `interpreterSource` is derived from the active interpreter alone, never from project files. A `uv.lock` project running a conda/venv/system interpreter reports that interpreter's real source, keeping the "uv project, interpreter not uv-managed yet" setup-flow gap visible. A genuinely uv-provisioned venv is identified by the `uv =` marker in `pyvenv.cfg`, not by `uv.lock`.
- conda is attributed only when the active interpreter resides under `CONDA_PREFIX` (path-boundary checked), not on the bare env var — which is session-global in the extension host (launching VS Code from an activated conda shell) and would otherwise over-count conda for uv/poetry/pip projects.
- `pyproject` `[tool.uv]`/`[tool.poetry]` detection uses a bounded table-header scan, not substring matching: ignores comments and in-value mentions, rejects prefix collisions (e.g. `tool.uvicorn`), and matches subtable and array-of-table headers (`[tool.uv.sources]`, `[[tool.poetry.source]]`).
- No external executable is run for telemetry: the uv-on-PATH probe was removed (it spawned a PATH-resolved `uv` for a weak, non-attributing signal). Detection reads only disk and already-resolved interpreter metadata.

**Scope / privacy:** measurement only — no changes to setup behavior (the VPEX flows are a separate effort). Only enum/categorical data and a closed set of signal identifiers are emitted; the existing telemetry opt-out (`telemetry.telemetryLevel`) is respected by the transport.

## Tests

- [x] `yarn run test:unit`: 202 passing, 0 failing — includes the pure classifier (each manager, interpreter sources, overlaps like uv+pip / conda+pip / poetry+uv, weak signals, none) and pure helpers (`pyprojectHasToolSection`, `pyvenvCfgMarksUv`, `interpreterUnderCondaPrefix`), covering the conda-prefix boundary and shell-global false-positive cases.
- [x] `yarn run build` (typecheck) passes.
- [x] `eslint` clean; `prettier` formatted.

Reviewer can validate with:

```bash
cd packages/databricks-vscode
yarn run build
yarn run test:unit
npx eslint src --ext ts && npx prettier . -c
```
