### PR TITLE
chore: ignore IntelliJ/JetBrains IDE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ tsconfig.tsbuildinfo
 
 # Local docs (not for version control)
 docs/
+
+# IntelliJ IDEA / JetBrains IDEs
+.idea/
+*.iml
+*.ipr
+*.iws
+.idea_modules/


### PR DESCRIPTION
## Changes

Contributors using JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.) generate a `.idea/` directory and `*.iml` project files locally. These are editor-specific and should never be committed. This adds them to the root `.gitignore`:

- `.idea/`
- `*.iml`, `*.ipr`, `*.iws`
- `.idea_modules/`

## Tests

- [x] `git status` no longer reports the untracked `.idea/` directory.

This pull request and its description were written by Isaac.