### PR TITLE
Fix Volume "Open in Databricks" routing to volume URL

### DIFF
--- a/packages/databricks-vscode/src/ui/unity-catalog/UnityCatalogTreeDataProvider.test.ts
+++ b/packages/databricks-vscode/src/ui/unity-catalog/UnityCatalogTreeDataProvider.test.ts
@@ -352,6 +352,36 @@ describe(__filename, () => {
         assert.strictEqual(item.copyText, "cat");
     });
 
+    it("getTreeItem sets volume url with volumes path segment", async () => {
+        const stubManager = {
+            onDidChangeState: () => ({dispose() {}}),
+            databricksWorkspace: {
+                host: new URL("https://adb-123.azuredatabricks.net/"),
+            },
+        } as unknown as ConnectionManager;
+
+        const provider = new UnityCatalogTreeDataProvider(
+            stubManager,
+            stubStateStorage
+        );
+        disposables.push(provider);
+
+        const volume: UnityCatalogTreeNode = {
+            kind: "volume",
+            catalogName: "cat",
+            schemaName: "sch",
+            name: "ev",
+            fullName: "cat.sch.ev",
+        };
+        const item = provider.getTreeItem(volume) as UnityCatalogTreeItem;
+
+        assert(item.url, "url should be set");
+        assert(
+            item.url!.includes("explore/data/volumes/cat/sch/ev"),
+            `url should contain explore/data/volumes/cat/sch/ev, got: ${item.url}`
+        );
+    });
+
     it("getTreeItem omits url when no host", async () => {
         const provider = new UnityCatalogTreeDataProvider(
             instance(mockConnectionManager),

--- a/packages/databricks-vscode/src/ui/unity-catalog/UnityCatalogTreeDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/unity-catalog/UnityCatalogTreeDataProvider.ts
@@ -118,6 +118,9 @@ export class UnityCatalogTreeDataProvider
             case "function":
                 path = `functions/${fullNamePath}`;
                 break;
+            case "volume":
+                path = `volumes/${fullNamePath}`;
+                break;
         }
         return this.getExploreUrl(path);
     }


### PR DESCRIPTION
## Changes

When opening a Volume from the Unity Catalog explorer, the "Open in Databricks" action routed to a table-style URL
(/explore/data/<catalog>/<schema>/<name>), which points at a non-existent table rather than the volume.

getNodeExploreUrl() special-cased models and functions by prefixing their path segment but had no case for volumes, so volumes fell through to the default (table) path. Add a "volume" case that prefixes the path with "volumes/", producing the correct
/explore/data/volumes/<catalog>/<schema>/<name> URL.


## Tests

UnityCatalogTreeDataProvider.test.ts