### PR TITLE
Bump markdown-it from 12.3.2 to 14.2.0

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1553,7 +1553,7 @@
         "bcryptjs": "^2.4.3",
         "highlight.js": "^11.10.0",
         "lodash": "^4.17.21",
-        "markdown-it": "^12.3.2",
+        "markdown-it": "^14.2.0",
         "minimatch": "^10.0.1",
         "shell-quote": "^1.8.1",
         "triple-beam": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4343,7 +4343,7 @@ __metadata:
     glob: ^10.3.10
     highlight.js: ^11.10.0
     lodash: ^4.17.21
-    markdown-it: ^12.3.2
+    markdown-it: ^14.2.0
     minimatch: ^10.0.1
     mocha: ^10.2.0
     mock-require: ^3.0.3
@@ -7490,6 +7490,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "linkify-it@npm:5.0.1"
+  dependencies:
+    uc.micro: ^2.0.0
+  checksum: bd5b4ebaca5495d5c2f41d284f0c8c42bffaa9e38223628f6b17038256302e4cba1e5161cf3e336a13963430cb2b37eca5ad0a595195bb5e54d051d73539210f
+  languageName: node
+  linkType: hard
+
 "locate-app@npm:^2.2.24":
   version: 2.5.0
   resolution: "locate-app@npm:2.5.0"
@@ -7744,6 +7753,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-it@npm:^14.2.0":
+  version: 14.2.0
+  resolution: "markdown-it@npm:14.2.0"
+  dependencies:
+    argparse: ^2.0.1
+    entities: ^4.4.0
+    linkify-it: ^5.0.1
+    mdurl: ^2.0.0
+    punycode.js: ^2.3.1
+    uc.micro: ^2.1.0
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 693269ccf502a461f13ffed54f6d47c05e1a2ceb0c31bfb0edcba5e54cb1e6000444b712fab1857493e43cfdded5d5d91f05dcb63a4db7a6990788340266b749
+  languageName: node
+  linkType: hard
+
 "md5@npm:^2.3.0":
   version: 2.3.0
   resolution: "md5@npm:2.3.0"
@@ -7759,6 +7784,13 @@ __metadata:
   version: 1.0.1
   resolution: "mdurl@npm:1.0.1"
   checksum: 71731ecba943926bfbf9f9b51e28b5945f9411c4eda80894221b47cc105afa43ba2da820732b436f0798fd3edbbffcd1fc1415843c41a87fea08a41cc1e3d02b
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 880bc289ef668df0bb34c5b2b5aaa7b6ea755052108cdaf4a5e5968ad01cf27e74927334acc9ebcc50a8628b65272ae6b1fd51fae1330c130e261c0466e1a3b2
   languageName: node
   linkType: hard
 
@@ -9066,6 +9098,13 @@ __metadata:
     end-of-stream: ^1.1.0
     once: ^1.3.1
   checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
+  languageName: node
+  linkType: hard
+
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 13466d7ed5e8dacdab8c4cc03837e7dd14218a59a40eb14a837f1f53ca396e18ef2c4ee6d7766b8ed2fc391d6a3ac489eebf2de83b3596f5a54e86df4a251b72
   languageName: node
   linkType: hard
 
@@ -10725,6 +10764,13 @@ __metadata:
   version: 1.0.6
   resolution: "uc.micro@npm:1.0.6"
   checksum: 6898bb556319a38e9cf175e3628689347bd26fec15fc6b29fa38e0045af63075ff3fea4cf1fdba9db46c9f0cbf07f2348cd8844889dd31ebd288c29fe0d27e7a
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 37197358242eb9afe367502d4638ac8c5838b78792ab218eafe48287b0ed28aaca268ec0392cc5729f6c90266744de32c06ae938549aee041fc93b0f9672d6b2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Replaces Dependabot's #1946, which couldn't merge: its lockfile pinned `linkify-it@5.0.2` — a version that **doesn't exist** on the public npm registry (latest is `5.0.1`) — so `yarn install --immutable` failed in CI with a JFrog 403 (nothing upstream to serve). This PR regenerates the lockfile against real, published versions and takes the markdown-it major upgrade deliberately.

## What

- Bump `markdown-it` to `^14.2.0`.
- Regenerated `yarn.lock` resolves to real versions: markdown-it 14.2.0, linkify-it **5.0.1**, mdurl 2.0.0, punycode.js 2.3.1, uc.micro 2.1.0.
- markdown-it is consumed **only** as the prebuilt UMD bundle (`dist/markdown-it.min.js`) loaded by the Unity Catalog detail webview (`resources/webview-ui/uc-detail.js`):
  ```js
  const md = window.markdownit({html: false, linkify: true, typographer: false});
  md.render(text)
  ```
  That constructor + `render` API is unchanged across v12→v14, and v14 still exposes the `window.markdownit` UMD global — no call-site changes needed. There's no TypeScript import of markdown-it and no `@types/markdown-it` dependency.

## Verification

- `yarn install` regenerates cleanly; every resolved dep verified to exist on public npm (no phantom versions).
- `yarn run build` passes; `package:copy-markdown-it` ships the v14 `markdown-it.min.js` into `out/`.
- Webview usage reviewed against the v14 API (constructor + render + linkify) — compatible.

**Backward compatibility:** only the bundled markdown renderer version changes; webview API usage is identical. No persisted state, config, or public API change.

Closes #1946.

This pull request and its description were written by Isaac.