### PR TITLE
Bump jws to 4.0.1 (security: GHSA-869p-cjfg-cm3x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     },
     "resolutions": {
         "json5": "2.2.2",
-        "path-scurry": "^2.0.0"
+        "path-scurry": "^2.0.0",
+        "jws": "^4.0.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-equal-constant-time@npm:1.0.1":
+"buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
   checksum: 80bb945f5d782a56f374b292770901065bad21420e34936ecbe949e57724b4a13874f735850dd1cc61f078773c4fb5493a41391e7bda40d1fa388d6bd80daaab
@@ -7373,24 +7373,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jwa@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "jwa@npm:2.0.0"
+"jwa@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
   dependencies:
-    buffer-equal-constant-time: 1.0.1
+    buffer-equal-constant-time: ^1.0.1
     ecdsa-sig-formatter: 1.0.11
     safe-buffer: ^5.0.1
-  checksum: 8f00b71ad5fe94cb55006d0d19202f8f56889109caada2f7eeb63ca81755769ce87f4f48101967f398462e3b8ae4faebfbd5a0269cb755dead5d63c77ba4d2f1
+  checksum: 6a9828c054c407f6718057089bd3d46dfcb1394e1553e3867abd4579dbec7728b4b0759e7253422ab7d824d95615a86427b35c43f94b83fc3a76470ca4bd2037
   languageName: node
   linkType: hard
 
-"jws@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jws@npm:4.0.0"
+"jws@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jws@npm:4.0.1"
   dependencies:
-    jwa: ^2.0.0
+    jwa: ^2.0.1
     safe-buffer: ^5.0.1
-  checksum: d68d07aa6d1b8cb35c363a9bd2b48f15064d342a5d9dc18a250dbbce8dc06bd7e4792516c50baa16b8d14f61167c19e851fd7f66b59ecc68b7f6a013759765f7
+  checksum: c33a060b2cce1e0e49f85054a49a951f9d52a9e2ae732d720f0fc51843c9ac07a68aacd8e9d086ef4c7c4437d42978b698b57a3e7c9bc4a91c0b74276ea85a9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Replaces Dependabot's #1816, which couldn't merge (lockfile-only bump, conflicted with main after recent merges). **jws 4.0.1 fixes advisory [GHSA-869p-cjfg-cm3x](https://github.com/advisories/GHSA-869p-cjfg-cm3x)** — `createSign`/`createVerify` now require signature headers, mitigating a JWT signature-verification flaw.

`jws` is a **transitive** dependency (via `google-auth-library` and `gtoken`, both requesting `^4.0.0`), so it can't be bumped with `yarn up` — it needs a resolution override.

## What

- Add `"jws": "^4.0.1"` to the root `resolutions` block (following the existing `json5` / `path-scurry` pattern).
- Regenerated `yarn.lock` resolves `jws@4.0.1` (and `jwa@2.0.1`).

## Verification

- `yarn install --immutable` passes (the CI gate #1816 failed on).
- Resolved versions verified on public npm (`jws@4.0.1`, `jwa@2.0.1`).
- Both dependents request `^4.0.0`, which permits 4.0.1 — no peer conflicts.

**Backward compatibility:** transitive security patch only; no direct dependency, API, persisted-state, or config change.

Closes #1816.

This pull request and its description were written by Isaac.