### PR TITLE
Bump glob from 10.3.10 to 10.5.0

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1591,7 +1591,7 @@
         "eslint-plugin-local-rules": "^2.0.1",
         "extract-zip": "^2.0.1",
         "fs-extra": "^11.2.0",
-        "glob": "^10.3.10",
+        "glob": "^10.5.0",
         "mocha": "^10.2.0",
         "mock-require": "^3.0.3",
         "nyc": "^15.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,7 +4340,7 @@ __metadata:
     eslint-plugin-local-rules: ^2.0.1
     extract-zip: ^2.0.1
     fs-extra: ^11.2.0
-    glob: ^10.3.10
+    glob: ^10.5.0
     highlight.js: ^11.10.0
     lodash: ^4.17.21
     markdown-it: ^14.2.0
@@ -6166,7 +6166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.10, glob@npm:^10.3.4":
+"glob@npm:^10.3.4":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -6194,6 +6194,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 0bc725de5e4862f9f387fd0f2b274baf16850dcd2714502ccf471ee401803997983e2c05590cb65f9675a3c6f2a58e7a53f9e365704108c6ad3cbf1d60934c4a
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^3.1.2
+    minimatch: ^9.0.4
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^1.11.1
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: cda96c074878abca9657bd984d2396945cf0d64283f6feeb40d738fe2da642be0010ad5210a1646244a5fc3511b0cab5a374569b3de5a12b8a63d392f18c6043
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Replaces Dependabot's #1808, which couldn't merge (lockfile conflicted with main after recent merges). `glob` is a direct dependency of the databricks-vscode package. Recreated cleanly against current main.

## What

- Bump `glob` to `^10.5.0` via `yarn up`; regenerated `yarn.lock` (resolves `glob@10.5.0`). Same 10.x major — no breaking changes.

## Verification

- `yarn install --immutable` passes (the CI gate).
- `glob@10.5.0` verified on public npm.
- `yarn run build` passes.

**Backward compatibility:** same-major minor bump of a build/runtime utility; no API, persisted-state, or config change.

Closes #1808.

This pull request and its description were written by Isaac.