### PR TITLE
Bump bcryptjs from 2.4.3 to 3.0.3

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1550,7 +1550,7 @@
         "@vscode/webview-ui-toolkit": "^1.4.0",
         "add": "^2.0.6",
         "ansi-to-html": "^0.7.2",
-        "bcryptjs": "^2.4.3",
+        "bcryptjs": "^3.0.3",
         "highlight.js": "^11.10.0",
         "lodash": "^4.17.21",
         "markdown-it": "^14.2.0",
@@ -1563,7 +1563,6 @@
     "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@sinonjs/fake-timers": "^11.2.2",
-        "@types/bcryptjs": "^2.4.6",
         "@types/chai": "^4.3.11",
         "@types/eslint": "^8.44.9",
         "@types/fs-extra": "^11.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,13 +1871,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bcryptjs@npm:^2.4.6":
-  version: 2.4.6
-  resolution: "@types/bcryptjs@npm:2.4.6"
-  checksum: 25ae1fd1e8a9bd688e22a8de905581d6d7bf26e823b797f895d2c488100b1f15d3c12a7d1a94f553087b010d316bf3978106df860e8e58fd13f52b4c708df5fd
-  languageName: node
-  linkType: hard
-
 "@types/chai@npm:^4.3.11":
   version: 4.3.11
   resolution: "@types/chai@npm:4.3.11"
@@ -3339,10 +3332,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcryptjs@npm:^2.4.3":
-  version: 2.4.3
-  resolution: "bcryptjs@npm:2.4.3"
-  checksum: 0e80ed852a41f5dfb1853f53ee14a7390b0ef263ce05dba6e2ef3cd919dfad025a7c21ebcfe5bc7fa04b100990edf90c7a877ff7fe623d3e479753253131b629
+"bcryptjs@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "bcryptjs@npm:3.0.3"
+  bin:
+    bcrypt: bin/bcrypt
+  checksum: 326dfbd0e2e397cf2f85abcf8b523f098a804a76303c983e86a4554462b8a5db930c06fd71148e060160bcfc1165676f917dc78c15bd68af8dcd0ef4a208ba20
   languageName: node
   linkType: hard
 
@@ -4336,7 +4331,6 @@ __metadata:
     "@databricks/sdk-experimental": ^0.18.0
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@sinonjs/fake-timers": ^11.2.2
-    "@types/bcryptjs": ^2.4.6
     "@types/chai": ^4.3.11
     "@types/eslint": ^8.44.9
     "@types/fs-extra": ^11.0.4
@@ -4366,7 +4360,7 @@ __metadata:
     "@wdio/types": ^9.29.0
     add: ^2.0.6
     ansi-to-html: ^0.7.2
-    bcryptjs: ^2.4.3
+    bcryptjs: ^3.0.3
     chai: ^4.3.10
     esbuild: ^0.25.0
     eslint: ^8.57.0


### PR DESCRIPTION
## Why

Replaces Dependabot's #1937, which bumped `package.json` without regenerating the lockfile (Yarn Berry `YN0028` failure). bcryptjs is used at **runtime** in telemetry (`src/telemetry/index.ts`) to hash the username into `user.hashedUserName`, so the critical requirement is that v3 produces the **same hash** as v2 for a given `(input, salt)` — otherwise telemetry identity would silently change.

## What

- Bump `bcryptjs` → `^3.0.3` via `yarn up`; regenerated `yarn.lock`.
- Remove the now-redundant `@types/bcryptjs` devDependency — bcryptjs 3 ships its own type definitions (`umd/index.d.ts`), so the separate `@types` package is obsolete. Build type-checks cleanly on the bundled types.

## Verification

- **Hash stability confirmed**: `bcrypt.hash("testuser@example.com", "$2b$07$" + salt)` produces the **byte-identical** output under v2 and v3.
- **Telemetry unit test passes** — `src/telemetry/index.test.ts` asserts an exact hardcoded `user.hashedUserName` bcrypt hash; full unit suite green (**274 passing**).
- `require("bcryptjs")` resolves fine — v3 is ESM-only but ships a UMD entry, so the esbuild CJS bundle is unaffected.
- `yarn install --immutable`, `yarn run build`, and `eslint` all pass.

**Backward compatibility:** hash output is identical to v2, so existing `user.hashedUserName` telemetry values remain consistent. No API/state/config change.

Closes #1937.

This pull request and its description were written by Isaac.