### PR TITLE
Ignore ESM-only and VS Code engine-coupled major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,27 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "@databricks/*"
+      # ESM-only majors — blocked until the build/test tooling is migrated off
+      # ts-node (CommonJS) to an ESM runner (tsx). See PRs #1934, #1932.
+      - dependency-name: "yargs"
+        versions: [">=18"]
+      - dependency-name: "chai"
+        versions: [">=5"]
+      - dependency-name: "@types/chai"
+        versions: [">=5"]
+      # @types/vscode must track engines.vscode (^1.86.0); bump both together
+      # only when the minimum supported VS Code version is deliberately raised.
+      # See PR #1933.
+      - dependency-name: "@types/vscode"
+        versions: [">=1.87"]
   - package-ecosystem: "npm"
     directory: "/packages/databricks-vscode-types"
     ignore:
       - dependency-name: "@databricks/*"
+      # @types/vscode must track engines.vscode (^1.86.0); bump both together
+      # only when the minimum supported VS Code version is deliberately raised.
+      # See PR #1933.
+      - dependency-name: "@types/vscode"
+        versions: [">=1.87"]
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Why

Several Dependabot major-version PRs are blocked on prerequisite work and aren't ready to merge. Left as open PRs (or closed), Dependabot keeps re-raising them under new version numbers. Scoped `ignore` rules park them until the prerequisite work is done — keeping the PR queue clean without losing the rationale.

This directly answers "if I close these, will the bot reopen them?" — **yes, under new versions**, unless we add these ignore rules.

## What

In `.github/dependabot.yml`, add `ignore` rules (scoped to the packages that declare each dep):

**ESM-only majors** — blocked until the build/test tooling migrates off `ts-node` (CommonJS) to an ESM runner (`tsx`):
- `yargs >=18` (see #1934)
- `chai >=5`, `@types/chai >=5` (see #1932)

**VS Code engine-coupled** — `@types/vscode` must track `engines.vscode` (`^1.86.0`); bump both together only when the minimum supported VS Code is deliberately raised (see #1933):
- `@types/vscode >=1.87` (in both `/packages/databricks-vscode` and `/packages/databricks-vscode-types`)

Each rule carries an inline comment pointing to its tracking PR and unblock condition, so the ignore can be removed intentionally later.

## Verification

- `.github/dependabot.yml` parses as valid YAML; ignore rules confirmed on both affected directory entries.

**Backward compatibility:** dependency-automation config only; no runtime, API, or build-output change.

Once this merges, PRs #1932 / #1933 / #1934 can be closed without Dependabot re-raising those major lines. (#1931 typescript and #1935 eslint are **not** ignored — those aren't version-availability issues, they're migrations we may still want prompts for.)

This pull request and its description were written by Isaac.