### PR TITLE
Upgrade @sinonjs/fake-timers 11.2.2 → 15.4.0

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1562,7 +1562,7 @@
     },
     "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@sinonjs/fake-timers": "^11.2.2",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/chai": "^4.3.11",
         "@types/eslint": "^8.44.9",
         "@types/fs-extra": "^11.0.4",
@@ -1571,7 +1571,6 @@
         "@types/mock-require": "^2.0.3",
         "@types/node": "^22.0.0",
         "@types/semver": "^7.5.0",
-        "@types/sinonjs__fake-timers": "^8.1.5",
         "@types/tmp": "^0.2.6",
         "@types/triple-beam": "^1.3.5",
         "@types/vscode": "1.86.0",

--- a/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundlePipelinesManager.test.ts
@@ -4,7 +4,7 @@ import {ConfigModel} from "../configuration/models/ConfigModel";
 import {mock, instance, when} from "ts-mockito";
 import assert from "assert";
 import {EventEmitter, Uri} from "vscode";
-import {install, InstalledClock} from "@sinonjs/fake-timers";
+import {install, Clock} from "@sinonjs/fake-timers";
 import {ConnectionManager} from "../configuration/ConnectionManager";
 import {locationToRange} from "./BundlePipelinesManager";
 import path from "node:path";
@@ -17,7 +17,7 @@ describe("BundlePipelinesManager", () => {
     let configModel: ConfigModel;
     let manager: BundlePipelinesManager;
     let eventEmitter: EventEmitter<void>;
-    let clock: InstalledClock;
+    let clock: Clock;
 
     beforeEach(() => {
         clock = install();

--- a/packages/databricks-vscode/src/sdk-extensions/Cluster.test.ts
+++ b/packages/databricks-vscode/src/sdk-extensions/Cluster.test.ts
@@ -26,13 +26,16 @@ describe(__filename, function () {
     let mockedClient: ApiClient;
     let mockedCluster: Cluster;
     let testClusterDetails: compute.ClusterDetails;
-    let fakeTimer: FakeTimers.InstalledClock;
+    let fakeTimer: FakeTimers.Clock;
 
     beforeEach(async () => {
         ({mockedCluster, mockedClient, testClusterDetails} =
             await getMockTestCluster());
 
-        fakeTimer = FakeTimers.install();
+        // fake-timers v13+ fakes all timers by default and warns when a native
+        // timer is cleared through the faked clock; opt into auto-cleanup so the
+        // clock silently tolerates native timers created outside the test.
+        fakeTimer = FakeTimers.install({shouldClearNativeTimers: true});
     });
 
     afterEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,21 +1761,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@sinonjs/commons@npm:3.0.0"
+"@sinonjs/commons@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
     type-detect: 4.0.8
-  checksum: b4b5b73d4df4560fb8c0c7b38c7ad4aeabedd362f3373859d804c988c725889cde33550e4bcc7cd316a30f5152a2d1d43db71b6d0c38f5feef71fd8d016763f8
+  checksum: a7c3e7cc612352f4004873747d9d8b2d4d90b13a6d483f685598c945a70e734e255f1ca5dc49702515533c403b32725defff148177453b3f3915bcb60e9d4601
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^11.2.2":
-  version: 11.2.2
-  resolution: "@sinonjs/fake-timers@npm:11.2.2"
+"@sinonjs/fake-timers@npm:^15.4.0":
+  version: 15.4.0
+  resolution: "@sinonjs/fake-timers@npm:15.4.0"
   dependencies:
-    "@sinonjs/commons": ^3.0.0
-  checksum: 68c29b0e1856fdc280df03ddbf57c726420b78e9f943a241b471edc018fb14ff36fdc1daafd6026cba08c3c7f50c976fb7ae11b88ff44cd7f609692ca7d25158
+    "@sinonjs/commons": ^3.0.1
+  checksum: 89714334b84c0dd5ef84cc01ec99d7d16529297fc32a68c28e4793b89bac0de7b373310b736ed4a57697de92eca4e7cc62c2ec4fae1e651787345e2564b707f4
   languageName: node
   linkType: hard
 
@@ -4297,7 +4297,7 @@ __metadata:
     "@databricks/databricks-vscode-types": "workspace:^"
     "@databricks/sdk-experimental": ^0.18.0
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@sinonjs/fake-timers": ^11.2.2
+    "@sinonjs/fake-timers": ^15.4.0
     "@types/chai": ^4.3.11
     "@types/eslint": ^8.44.9
     "@types/fs-extra": ^11.0.4
@@ -4308,7 +4308,6 @@ __metadata:
     "@types/node": ^22.0.0
     "@types/semver": ^7.5.0
     "@types/shell-quote": ^1.7.5
-    "@types/sinonjs__fake-timers": ^8.1.5
     "@types/tmp": ^0.2.6
     "@types/triple-beam": ^1.3.5
     "@types/vscode": 1.86.0


### PR DESCRIPTION
## Why

Dependabot #1973 bumped `@sinonjs/fake-timers` (test-only) across 4 majors, but the one-line `package.json` change **breaks the build**: v15 ships its own bundled types and **removed the `InstalledClock` export** (the clock type is now `Clock`), so the two timer-based test files fail to compile. The bump also leaves `yarn.lock` out of sync. This supersedes #1973 with the code migration + regenerated lock.

The upgrade pulls in the v12–v15 fixes to the timer engine these tests rely on: a memory-leak/security fix (v15.2.0 #534), `setInterval`/`setTimeout` starvation and `clearTimeout` heap fixes, and `Intl` prototype-pollution resilience (v14).

## What

- Bump `@sinonjs/fake-timers` `^11.2.2` → `^15.4.0`.
- Remove the now-redundant `@types/sinonjs__fake-timers` devDependency — v15 bundles its own types (the separate stub would conflict).
- Rename the removed `InstalledClock` type → `Clock` in the two consumers (`BundlePipelinesManager.test.ts`, `Cluster.test.ts`).
- Pass `shouldClearNativeTimers: true` to `install()` in `Cluster.test.ts`: v13+ fakes all timers by default and warns when a native timer is cleared through the faked clock; this opts into auto-cleanup so the test output stays clean.
- Regenerate `yarn.lock`.

Test-only devDependency — no product/user-facing change.

## Verification

- `yarn install --immutable` passes (no `YN0028`, no `YN0060`).
- `yarn run build` (`tsc --build`) succeeds with 0 errors.
- `yarn run test:unit`: **268 passing, 0 failing** — including both timer-based suites (`Cluster.test` and all `BundlePipelinesManager` cases using `runToLastAsync`). The fake-timers native-timer warning is gone after the `shouldClearNativeTimers` change (0 occurrences).

Supersedes #1973.

This pull request and its description were written by Isaac.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._