### PR TITLE
Upgrade TypeScript 5.9.3 → 6.0.3 (all packages)

### DIFF
--- a/packages/databricks-vscode-types/package.json
+++ b/packages/databricks-vscode-types/package.json
@@ -26,7 +26,7 @@
         "@types/vscode": "1.86.0",
         "eslint": "^8.57.0",
         "prettier": "^3.1.1",
-        "typescript": "^5.3.3"
+        "typescript": "^6.0.3"
     },
     "dependencies": {
         "@databricks/sdk-experimental": "^0.18.0",

--- a/packages/databricks-vscode-types/tsconfig.json
+++ b/packages/databricks-vscode-types/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig_base.json",
     "compilerOptions": {
-        "rootDir": "."
+        "rootDir": ".",
+        "types": ["node"]
     },
     "include": ["*.ts"]
 }

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1600,7 +1600,7 @@
         "ts-mocha": "^11.1.0",
         "ts-mockito": "^2.6.1",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vsce": "^2.15.0",
         "wdio-video-reporter": "^6.2.0",
         "wdio-vscode-service": "^8.0.0",

--- a/packages/databricks-vscode/scripts/tsconfig.json
+++ b/packages/databricks-vscode/scripts/tsconfig.json
@@ -10,6 +10,7 @@
         "strict": true /* enable all strict type-checking options */,
         "forceConsistentCasingInFileNames": true,
         "experimentalDecorators": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["node"]
     }
 }

--- a/packages/databricks-vscode/scripts/writeIpynbWrapper.ts
+++ b/packages/databricks-vscode/scripts/writeIpynbWrapper.ts
@@ -24,7 +24,7 @@ const nbCell: INbCell = {
 };
 
 async function main() {
-    const args = await yargs
+    const args = await yargs(process.argv.slice(2))
         .option("srcFile", {
             alias: "s",
             description: "The source code to be wrapped into a notebook cell",

--- a/packages/databricks-vscode/tsconfig.json
+++ b/packages/databricks-vscode/tsconfig.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "out",
         "lib": ["ES2022", "DOM"],
-        "rootDir": "src"
+        "rootDir": "src",
+        "types": ["node"]
     },
     "references": [{"path": "../databricks-vscode-types"}],
     "include": ["src"],

--- a/tsconfig_base.json
+++ b/tsconfig_base.json
@@ -8,12 +8,14 @@
         "module": "CommonJS",
         "target": "ES2022",
         "lib": ["ES2022"],
-        "moduleResolution": "node",
+        "moduleResolution": "node10",
+        "ignoreDeprecations": "6.0",
         "esModuleInterop": true,
         "isolatedModules": true,
         "strict": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,7 +264,7 @@ __metadata:
     databricks: "workspace:^"
     eslint: ^8.57.0
     prettier: ^3.1.1
-    typescript: ^5.3.3
+    typescript: ^6.0.3
   languageName: unknown
   linkType: soft
 
@@ -10619,16 +10619,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
-  version: 5.3.3
-  resolution: "typescript@npm:5.3.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 2007ccb6e51bbbf6fde0a78099efe04dc1c3dfbdff04ca3b6a8bc717991862b39fd6126c0c3ebf2d2d98ac5e960bcaa873826bb2bb241f14277034148f41f6a2
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^5.5.0":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
@@ -10646,16 +10636,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: c1182dfadf8a8cb22a4e32442715afef1af1b950ae635b1c52c27e0d7fb7a5e2607ed7c7c4079bba4163579250e02445fd8d46b09cbceda71ff72a5b7d69db61
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^5.3.3#~builtin<compat/typescript>":
-  version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=7ad353"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4244,7 +4244,7 @@ __metadata:
     ts-mocha: ^11.1.0
     ts-mockito: ^2.6.1
     ts-node: ^10.9.2
-    typescript: ^5.9.3
+    typescript: ^6.0.3
     vsce: ^2.15.0
     wdio-video-reporter: ^6.2.0
     wdio-vscode-service: ^8.0.0
@@ -10629,13 +10629,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.5.0, typescript@npm:^5.9.3":
+"typescript@npm:^5.5.0":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 0d0ffb84f2cd072c3e164c79a2e5a1a1f4f168e84cb2882ff8967b92afe1def6c2a91f6838fb58b168428f9458c57a2ba06a6737711fdd87a256bbe83e9a217f
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: c1182dfadf8a8cb22a4e32442715afef1af1b950ae635b1c52c27e0d7fb7a5e2607ed7c7c4079bba4163579250e02445fd8d46b09cbceda71ff72a5b7d69db61
   languageName: node
   linkType: hard
 
@@ -10649,13 +10659,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.5.0#~builtin<compat/typescript>, typescript@patch:typescript@^5.9.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.5.0#~builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#~builtin<compat/typescript>::version=5.9.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 8bb8d86819ac86a498eada254cad7fb69c5f74778506c700c2a712daeaff21d3a6f51fd0d534fe16903cb010d1b74f89437a3d02d4d0ff5ca2ba9a4660de8497
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^6.0.3#~builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#~builtin<compat/typescript>::version=6.0.3&hash=7ad353"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 8ed159a81ab4901a620c19fda539632cee610f8ec34dde57a3acc6b6df72894ad0b50bdd1946b763313d9b73dedb019d2e81c03eff06c0f2c785cde30a537d15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

Dependabot opened two PRs for this bump: #1975 (`databricks-vscode`) and #1931 (`databricks-vscode-types`). Both fail as one-liners — `yarn run build` emits 41 type errors across 3 categories introduced by TS 6's stricter ambient type resolution, deprecated `moduleResolution: "node"`, and the `module` keyword becoming an error in `.d.ts` files.

## What

### `tsconfig_base.json`
- `moduleResolution: "node"` → `"node10"` (TS6 renamed it; same semantics, suppresses `TS5107` via `ignoreDeprecations: "6.0"`).
- `skipLibCheck: true` — `@vscode/debugprotocol@1.64.0` (pinned by `@vscode/debugadapter@1.64.0`) uses `export declare module` in its `.d.ts`, which TS6 flags as `TS1540`. Neither `1.64.0` nor `1.68.0` has fixed this upstream and we cannot independently bump the pinned transitive dep. `skipLibCheck` is the standard practice for third-party `.d.ts` files with deprecated syntax we don't control.

### `packages/databricks-vscode/tsconfig.json`, `packages/databricks-vscode-types/tsconfig.json`, `packages/databricks-vscode/scripts/tsconfig.json`
- Add `"types": ["node"]` — TS6's stricter ambient type resolution requires explicit opt-in for node globals (`path`, `Buffer`, `URL`, `setTimeout`, `process`, `node:*` specifiers). Without this, our source files and `@databricks/sdk-experimental`'s `.d.ts` files lose access to node globals they rely on.

### `packages/databricks-vscode/scripts/writeIpynbWrapper.ts`
- `await yargs.option(...)` → `await yargs(process.argv.slice(2)).option(...)`. Under TS6, `import yargs from "yargs"` (which uses `export =`) gives the callable function type, not the static `Argv` interface; chaining `.option()` on the import fails. Calling `yargs(process.argv.slice(2))` is the correct API.

### `packages/databricks-vscode/package.json`, `packages/databricks-vscode-types/package.json`
- Both bumped to `typescript: ^6.0.3`.

## Verification

- `yarn install --immutable` passes (no `YN0028`, no `YN0060`).
- `yarn run build` (`tsc --build --force`) succeeds with **0 errors** across both packages.
- `ts-node ./scripts/writeIpynbWrapper.ts --help` works correctly.
- `eslint src --ext ts` clean.
- `ts-mocha --type-check` SDK integ suite type-checks.
- `yarn run test:unit`: **268 passing, 0 failing**.

Supersedes #1975 (`databricks-vscode`) and #1931 (`databricks-vscode-types`).

This pull request and its description were written by Isaac.