### PR TITLE
Fix TS6 compile regressions in e2e/SDK test tooling

### DIFF
--- a/packages/databricks-vscode/scripts/setArchInPackage.ts
+++ b/packages/databricks-vscode/scripts/setArchInPackage.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import yargs from "yargs";
 
 async function main() {
-    const argv = await yargs
+    const argv = await yargs(process.argv.slice(2))
         .option("cliArch", {
             description: "Architecture of databricks cli.",
             type: "string",

--- a/packages/databricks-vscode/scripts/setupCLIDependencies.ts
+++ b/packages/databricks-vscode/scripts/setupCLIDependencies.ts
@@ -14,7 +14,7 @@ import type {
 } from "../src/utils/terraformUtils";
 
 async function main() {
-    const argv = await yargs
+    const argv = await yargs(process.argv.slice(2))
         .option("cli", {
             description: "Path to the Databricks CLI",
             type: "string",

--- a/packages/databricks-vscode/tsconfig.json
+++ b/packages/databricks-vscode/tsconfig.json
@@ -4,7 +4,7 @@
         "outDir": "out",
         "lib": ["ES2022", "DOM"],
         "rootDir": "src",
-        "types": ["node"]
+        "types": ["node", "mocha"]
     },
     "references": [{"path": "../databricks-vscode-types"}],
     "include": ["src"],


### PR DESCRIPTION
## Why

The TypeScript 5.9.3 → 6.0.3 upgrade (#1981) left two test-tooling code paths broken that `yarn build` and unit tests don't exercise. They only run in the e2e workflow (`vscode-isolated-pr`), so the breakage surfaced when cutting the **v2.12.2** release (#1990): **all 34 e2e/SDK shards failed to compile** on both Linux and Windows.

## What broke

1. **`scripts/setArchInPackage.ts` + `scripts/setupCLIDependencies.ts`** still used the pre-TS6 `await yargs.option(...)` pattern. Under TS6, `import yargs from "yargs"` (which uses `export =`) resolves to the callable factory type, not the `Argv` interface, so chaining `.option()` fails with:
   ```
   scripts/setArchInPackage.ts(6,10): error TS2339: Property 'option' does not exist on type '(processArgs?: ...) => Argv<{}>'.
   ```
   `setArchInPackage.ts` runs in the e2e **test-setup** step, which is why every e2e shard died before any spec ran. #1981 already fixed this exact pattern in `writeIpynbWrapper.ts` but missed these two.

2. **`packages/databricks-vscode/tsconfig.json`** got `"types": ["node"]` in #1981, which dropped the mocha ambient globals the SDK integration tests (`src/sdk-extensions/**/*.integ.ts`) rely on:
   ```
   src/sdk-extensions/Cluster.integ.ts: error TS2593: Cannot find name 'describe' / 'it' / 'before'.
   ```

## Fix

- Call `yargs(process.argv.slice(2))` first in both scripts (same fix #1981 applied to `writeIpynbWrapper.ts`).
- Add `"mocha"` to the `types` array (mirrors how `src/test/e2e/tsconfig.json` declares its test-framework types).

## Verification

- `yarn run build` — 0 errors
- `tsc --noEmit --project tsconfig.json` — 0 errors
- `ts-node ./scripts/setArchInPackage.ts …` — runs (was exit 1)
- `Cluster.integ.ts` — `describe`/`it`/`before` resolve
- `yarn fix` — clean

## Follow-up

Once merged, the **v2.12.2** release PR (#1990, currently in draft) will be re-cut so its e2e run can actually execute. Tracked in DECO-27584.
