### PR TITLE
Ignore @types/node major bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
       # See PR #1933.
       - dependency-name: "@types/vscode"
         versions: [">=1.87"]
+      # @types/node must track the runtime we ship on (engines.node ">=22"; the
+      # VS Code extension host runs Node 18), not the latest release. Newer types
+      # would type-check against APIs absent at runtime. Bump only when the Node
+      # floor is deliberately raised. See PR #1988.
+      - dependency-name: "@types/node"
+        versions: [">=23"]
   - package-ecosystem: "npm"
     directory: "/packages/databricks-vscode-types"
     ignore:


### PR DESCRIPTION
## Why

`@types/node` should track the runtime we ship on, not the latest release.

- `engines.node` is `">=22"` (root + `packages/databricks-vscode`)
- All CI workflows run on `node-version: 22.x`
- The VS Code extension host (engine `^1.86.0`) runs Node 18

Pulling in `@types/node >=23` would let the type-checker accept Node 23+ APIs that don't exist at runtime on Node 18/22 — a silent path to runtime failures TS can't catch. Dependabot PR #1988 (`^22.0.0 → ^26.0.0`) had no upside and carried exactly this risk, so it's being closed in favor of this guard.

## What

Add an `ignore` entry for `@types/node` versions `">=23"` to the `/packages/databricks-vscode` update block — the only package that declares `@types/node` as a direct dependency. This mirrors the existing `@types/vscode` pattern (track the target, bump deliberately) and allows 22.x type patches through while blocking the major jump.

```yaml
# @types/node must track the runtime we ship on (engines.node ">=22"; the
# VS Code extension host runs Node 18), not the latest release. Newer types
# would type-check against APIs absent at runtime. Bump only when the Node
# floor is deliberately raised. See PR #1988.
- dependency-name: "@types/node"
  versions: [">=23"]
```

Bump only when the Node floor is deliberately raised.

## Verification

- Confirmed `engines.node ">=22"` and CI `node-version: 22.x` across all workflows
- `@types/node` is a direct dep only in `packages/databricks-vscode`
- Diff is the 6 added lines only; YAML indentation matches sibling `ignore` entries

This pull request and its description were written by Isaac.