### PR TITLE
Fix update-cli-version startup_failure (bump create-pull-request to v8.1.1)

### DIFF
--- a/.github/workflows/update-cli-version.yml
+++ b/.github/workflows/update-cli-version.yml
@@ -33,7 +33,7 @@ jobs:
         run: jq '.cli.version = "${{ github.event.inputs.version }}"' packages/databricks-vscode/package.json --indent 4 > tmp.json && mv tmp.json packages/databricks-vscode/package.json
 
       - name: Create a pull request
-        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.DECO_GITHUB_TOKEN }}
           commit-message: Update Databricks CLI to v${{ github.event.inputs.version }}


### PR DESCRIPTION
## Summary

The `update-cli-version` workflow has failed with **`startup_failure`** (0 jobs, no logs) on **every dispatch since 2026-04-08** — GitHub rejects the workflow file before any job runs. This PR fixes it by bumping `peter-evans/create-pull-request` to the v8.1.1 SHA used across the rest of the databricks org.

## Root cause

Bisecting the workflow's run history:

| Date | Result | `create-pull-request` ref |
|---|---|---|
| 2026-03-18 | ✅ success | `peter-evans/create-pull-request@v5` |
| **2026-03-23 (#1865)** | *pin commit* | → `@4e1beaa… # v5.0.3` |
| 2026-04-08 → now | ❌ startup_failure (every run) | `@4e1beaa… # v5.0.3` |

- The last success used the floating `@v5` tag. Failures began immediately after #1865 "Pin GitHub action references" replaced it with the v5.0.3 commit SHA.
- `peter-evans/create-pull-request` is the **only third-party (non-`actions/*`) action in the repo**. Every other databricks org repo (`cli`, `setup-cli`, `databricks-jdbc`, `homebrew-tap`, `environments`, …) pins it to the **v8.1.1** SHA `5f6978fa…`; this repo was the lone outlier on the older **v5.0.3** SHA — the signature of a reference the org Actions allowlist does not permit.
- Ruled out: `actions/checkout@<sha>` (SHA-pinned identically in 7 sibling workflows that start fine) and the runner-hardening migration (#1873, 2026-04-16) — failures predate it and started on the old runner group.

## Change

Bump `peter-evans/create-pull-request` from `4e1beaa` (v5.0.3) to `5f6978fa` (v8.1.1).

## Verification

- Confirmed SHA `5f6978fa` resolves to tag `v8.1.1` via the GitHub git-refs API.
- Confirmed all inputs this workflow uses (`token`, `commit-message`, `body`, `committer`, `branch`, `title`, `draft`) remain valid in the v8.1.1 `action.yml` — no breaking input changes across the v5→v8 bump.
- Post-merge: re-dispatch the workflow to confirm it starts and creates a PR (cannot be exercised pre-merge since `workflow_dispatch` runs the file from the default branch).