### PR TITLE
fix: always pass --host on databricks-cli login so custom hosts are not redirected to the public login page

### DIFF
--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.test.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.test.ts
@@ -110,10 +110,36 @@ describe(__filename, () => {
                 assert.match(e.message, /context deadline exceeded/);
                 // Tells the user how to recover instead of leaving them stuck.
                 // The suggested command must include --host so it works even
-                // when the profile does not exist yet.
+                // when the profile does not exist yet, and the host must be
+                // single-quoted so it is copy-paste safe.
                 assert.match(
                     e.message,
-                    /databricks auth login --host \S+ --profile dev/
+                    /databricks auth login --host '\S+' --profile dev/
+                );
+                return true;
+            });
+        });
+
+        it("single-quotes the host in the recovery message so a SPOG '?w=' host is copy-paste safe in zsh/bash", async () => {
+            const check = new DatabricksCliCheck(
+                createProvider(
+                    "dev",
+                    "https://test.cloud.databricks.com",
+                    "1234567890"
+                ),
+                async () => {
+                    throw {stderr: "context deadline exceeded"};
+                }
+            );
+
+            await assert.rejects((check as any).login(), (e: Error) => {
+                // The unquoted "?" would be a glob in zsh/bash; the quoted
+                // form runs verbatim.
+                assert.ok(
+                    e.message.includes(
+                        "databricks auth login --host 'https://test.cloud.databricks.com?w=1234567890' --profile dev"
+                    ),
+                    `recovery command not shell-safe: ${e.message}`
                 );
                 return true;
             });

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.test.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.test.ts
@@ -6,21 +6,27 @@ import {DatabricksCliAuthProvider} from "./AuthProvider";
 describe(__filename, () => {
     const cliPath = "/path/to/bin/databricks";
 
-    function createProvider(profile?: string) {
+    function createProvider(
+        profile?: string,
+        host = "https://test.cloud.databricks.com",
+        workspaceId?: string
+    ) {
         const provider = mock(DatabricksCliAuthProvider);
-        when(provider.host).thenReturn(
-            new URL("https://test.cloud.databricks.com")
-        );
+        when(provider.host).thenReturn(new URL(host));
         when(provider.cliPath).thenReturn(cliPath);
         when(provider.profile).thenReturn(profile);
+        when(provider.workspaceId).thenReturn(workspaceId);
         return instance(provider);
     }
 
     describe("login", () => {
-        it("passes a bounded --timeout to auth login so it cannot hang indefinitely", async () => {
+        it("always passes --host so a new/unresolved profile does not fall back to the public login page", async () => {
+            // Regression test for the custom-host OAuth sign-in bug: creating a
+            // new profile passed only --profile, so the CLI could not resolve a
+            // host and opened login.databricks.com instead of the workspace.
             let capturedArgs: string[] | undefined;
             const check = new DatabricksCliCheck(
-                createProvider("dev"),
+                createProvider("dev", "https://customer.custom-host.com"),
                 async (_file, args) => {
                     capturedArgs = args;
                     return {stdout: "", stderr: ""};
@@ -33,6 +39,8 @@ describe(__filename, () => {
             assert.deepStrictEqual(capturedArgs, [
                 "auth",
                 "login",
+                "--host",
+                "https://customer.custom-host.com",
                 "--profile",
                 "dev",
                 "--timeout",
@@ -62,6 +70,34 @@ describe(__filename, () => {
             ]);
         });
 
+        it("preserves the SPOG workspace id on the --host so re-login keeps the workspace routing", async () => {
+            let capturedArgs: string[] | undefined;
+            const check = new DatabricksCliCheck(
+                createProvider(
+                    "dev",
+                    "https://test.cloud.databricks.com",
+                    "1234567890"
+                ),
+                async (_file, args) => {
+                    capturedArgs = args;
+                    return {stdout: "", stderr: ""};
+                }
+            );
+
+            await (check as any).login();
+
+            assert.deepStrictEqual(capturedArgs, [
+                "auth",
+                "login",
+                "--host",
+                "https://test.cloud.databricks.com?w=1234567890",
+                "--profile",
+                "dev",
+                "--timeout",
+                `${LOGIN_TIMEOUT_SECONDS}s`,
+            ]);
+        });
+
         it("surfaces an actionable message when login fails (e.g. WSL browser hang/timeout)", async () => {
             const check = new DatabricksCliCheck(
                 createProvider("dev"),
@@ -73,7 +109,12 @@ describe(__filename, () => {
             await assert.rejects((check as any).login(), (e: Error) => {
                 assert.match(e.message, /context deadline exceeded/);
                 // Tells the user how to recover instead of leaving them stuck.
-                assert.match(e.message, /databricks auth login --profile dev/);
+                // The suggested command must include --host so it works even
+                // when the profile does not exist yet.
+                assert.match(
+                    e.message,
+                    /databricks auth login --host \S+ --profile dev/
+                );
                 return true;
             });
         });

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -174,9 +174,13 @@ export class DatabricksCliCheck implements Disposable {
             // WSL). Point the user at running the same command themselves in a
             // terminal, where the browser flow can be completed (or copied to
             // the host browser), instead of surfacing only the raw CLI error.
+            // Single-quote the host: with a SPOG workspace id it contains a
+            // "?w=..." query string, and an unquoted "?" is a glob in
+            // zsh/bash, so a copy-pasted command would fail with
+            // "no matches found" before the CLI runs.
             const manualCommand = profile
-                ? `databricks auth login --host ${host} --profile ${profile}`
-                : `databricks auth login --host ${host}`;
+                ? `databricks auth login --host '${host}' --profile ${profile}`
+                : `databricks auth login --host '${host}'`;
             throw new Error(
                 `Login failed with Databricks CLI: ${e.stderr || e.message}. ` +
                     `Try running \`${manualCommand}\` in a terminal to complete the login, then reload.`

--- a/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/DatabricksCliCheck.ts
@@ -139,13 +139,24 @@ export class DatabricksCliCheck implements Disposable {
     }
 
     private async login(cancellationToken?: CancellationToken): Promise<void> {
-        const host = this.authProvider.host.toString().replace(/\/+$/, "");
+        // Always pass --host. Passing only --profile is not enough when the
+        // profile does not exist yet (the common case: creating a new OAuth
+        // profile). With no host to resolve, the CLI falls back to the public
+        // login.databricks.com page instead of the workspace the user typed.
+        // We still pass --profile when we have one so re-login targets the
+        // right profile when several profiles share a host (see #1877); the
+        // CLI accepts --host and --profile together.
+        let host = this.authProvider.host.toString().replace(/\/+$/, "");
+        // Preserve SPOG workspace routing so re-login does not drop the
+        // workspace id from an existing profile. execFile passes args verbatim
+        // (no shell), so the "?" needs no quoting here.
+        if (this.authProvider.workspaceId) {
+            host += `?w=${this.authProvider.workspaceId}`;
+        }
         const profile = this.authProvider.profile;
-        const args = ["auth", "login"];
+        const args = ["auth", "login", "--host", host];
         if (profile) {
             args.push("--profile", profile);
-        } else {
-            args.push("--host", host);
         }
         // Bound the browser challenge so a non-completing OAuth flow (e.g. WSL)
         // fails fast instead of stalling on the CLI's 1-hour default.
@@ -164,7 +175,7 @@ export class DatabricksCliCheck implements Disposable {
             // terminal, where the browser flow can be completed (or copied to
             // the host browser), instead of surfacing only the raw CLI error.
             const manualCommand = profile
-                ? `databricks auth login --profile ${profile}`
+                ? `databricks auth login --host ${host} --profile ${profile}`
                 : `databricks auth login --host ${host}`;
             throw new Error(
                 `Login failed with Databricks CLI: ${e.stderr || e.message}. ` +


### PR DESCRIPTION
## Summary

Signing in from the extension with a **custom workspace host** + OAuth redirected the browser to the public `login.databricks.com` page instead of the workspace the user typed. Reported by an AWS customer (works on v2.10.6, broken on v2.11.x+).

## Root cause

Regression from #1877 (first shipped in **v2.10.7**, still present on `main`/v2.12.2). `DatabricksCliCheck.login()` was changed to pass **either** `--profile` **or** `--host`, never both:

```ts
const args = ["auth", "login"];
if (profile) {
    args.push("--profile", profile);   // new-profile path takes this branch
} else {
    args.push("--host", host);
}
```

When creating a **new** OAuth profile, `LoginWizard.createNewProfile()` constructs the provider **with** the new profile name, so only `--profile <name>` is passed. That profile does not exist in `~/.databrickscfg` yet, so the CLI has no host to resolve and — per its own documented behavior (`databricks auth login --help`: *"If no host is provided, the CLI opens login.databricks.com"*) — falls back to the public login page.

The customer's own workaround (pre-creating the profile via `databricks auth login --host <url> --profile <name>`, after which the extension works) confirms the diagnosis.

Before the regression (v2.10.6), the extension always ran `databricks auth login --host <host>`.

## Fix

- `login()`: **always** pass `--host`, and additionally `--profile` when a profile name is present. The CLI accepts both flags together, so the multi-profile-per-host behavior #1877 intended is preserved.
- Preserve SPOG workspace routing by appending `?w=<workspaceId>` to the host when the provider has a workspace id, so re-login does not drop it.
- Fix the manual-recovery hint in the failure message to include `--host` so the suggested command works even when the profile does not exist yet.

## Tests

- Added regression coverage: new-profile + custom host must include `--host`; SPOG workspace-id preservation; updated failure-message hint. Kept the no-profile and bounded-timeout cases.
- `yarn test:unit`: **269 passing**, exit 0 (Node 22).
- `yarn build` (tsc) and `yarn test:lint` (eslint + prettier): clean.

## Affected versions

v2.10.7 → v2.12.2 (all releases since the regression landed).

This pull request and its description were written by Isaac.

Closes #2011
