### PR TITLE
fix(bundle): match modern CLI run URL in JobRunStatus.parseId

### DIFF
--- a/packages/databricks-vscode/src/bundle/run/JobRunStatus.test.ts
+++ b/packages/databricks-vscode/src/bundle/run/JobRunStatus.test.ts
@@ -1,0 +1,100 @@
+import {expect} from "chai";
+import {mock, instance, when} from "ts-mockito";
+import {install, Clock} from "@sinonjs/fake-timers";
+import {JobRunStatus} from "./JobRunStatus";
+import {AuthProvider} from "../../configuration/auth/AuthProvider";
+
+// These tests pin the CLI-output contract that JobRunStatus.parseId depends on.
+// The run id is scraped from the run URL the `databricks bundle run` CLI prints
+// to the terminal. When the CLI changed the URL format from the legacy
+// "#job/<id>/run/<id>" fragment to the modern "/jobs/<id>/runs/<id>?o=.." path
+// (databricks/cli), the old singular-"/run/" regex silently stopped matching and
+// the extension showed a permanent false "Timeout while fetching run status" for
+// jobs that actually succeeded. These tests guard against that class of drift.
+describe("JobRunStatus.parseId", () => {
+    let clock: Clock;
+    let authProvider: AuthProvider;
+
+    beforeEach(() => {
+        // The BundleRunStatus base class arms a 60s "no run id -> timeout" timer
+        // in its constructor; fake timers keep it from leaking past the test.
+        clock = install();
+        authProvider = mock<AuthProvider>();
+        // parseId calls startPolling() on a successful match, which awaits
+        // getWorkspaceClient(). Return a never-resolving promise so no real
+        // network happens and polling never advances runState past what we
+        // assert. startPolling is wrapped in @onError({throw:false}), so this
+        // can never reject into the test.
+        when(authProvider.getWorkspaceClient()).thenReturn(
+            new Promise(() => {}) as any
+        );
+    });
+
+    afterEach(() => {
+        clock.uninstall();
+    });
+
+    function newStatus() {
+        return new JobRunStatus(instance(authProvider));
+    }
+
+    it("extracts the run id from the modern '/jobs/<id>/runs/<id>' URL", () => {
+        const status = newStatus();
+        status.parseId(
+            "Run URL: https://adb-123.azuredatabricks.net/jobs/600749519600807/runs/931844287868435?o=2059256957719798"
+        );
+        expect(status.runId).to.equal("931844287868435");
+    });
+
+    it("extracts the run id from the 'Run available at ...' modern URL", () => {
+        const status = newStatus();
+        status.parseId(
+            "Run available at https://adb-123.azuredatabricks.net/jobs/600749519600807/runs/931844287868435?o=2059256957719798"
+        );
+        expect(status.runId).to.equal("931844287868435");
+    });
+
+    it("extracts the run id from the legacy '#job/<id>/run/<id>' fragment URL", () => {
+        const status = newStatus();
+        status.parseId(
+            "https://adb-123.azuredatabricks.net/?o=2059256957719798#job/600749519600807/run/931844287868435"
+        );
+        expect(status.runId).to.equal("931844287868435");
+    });
+
+    it("does not capture the job id from a '/jobs/<id>' URL without a run segment", () => {
+        const status = newStatus();
+        status.parseId(
+            "https://adb-123.azuredatabricks.net/jobs/600749519600807"
+        );
+        expect(status.runId).to.be.undefined;
+    });
+
+    it("does not set an empty run id when a chunk splits right after '/runs/'", () => {
+        // The CLI output arrives in stdout chunks. A split immediately after
+        // "/runs/" must not produce an empty capture (parseInt("") === NaN).
+        const status = newStatus();
+        status.parseId(
+            "Run URL: https://adb-123.azuredatabricks.net/jobs/1/runs/"
+        );
+        expect(status.runId).to.be.undefined;
+    });
+
+    it("ignores output that contains no run URL", () => {
+        const status = newStatus();
+        status.parseId("Deploying resources...");
+        expect(status.runId).to.be.undefined;
+    });
+
+    it("keeps the first run id it sees and ignores later output", () => {
+        const status = newStatus();
+        status.parseId(
+            "Run URL: https://adb-123.azuredatabricks.net/jobs/1/runs/111"
+        );
+        expect(status.runId).to.equal("111");
+        status.parseId(
+            "Run URL: https://adb-123.azuredatabricks.net/jobs/2/runs/222"
+        );
+        expect(status.runId).to.equal("111");
+    });
+});

--- a/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
+++ b/packages/databricks-vscode/src/bundle/run/JobRunStatus.ts
@@ -24,7 +24,13 @@ export class JobRunStatus extends BundleRunStatus {
         if (this.runId !== undefined || this.runState !== "unknown") {
             return;
         }
-        const match = output.match(/.*\/run\/(\d*).*/);
+        // The CLI prints a run URL to the terminal, from which we extract the
+        // run id. CLI >= v1.5.0 prints the modern "/jobs/<id>/runs/<id>?o=.."
+        // URL, while older CLIs printed the legacy "#job/<id>/run/<id>"
+        // fragment. `runs?` matches both. `\d+` (not `\d*`) requires at least
+        // one digit, so a stdout chunk that splits right after "/run(s)/" does
+        // not produce an empty capture (parseInt("") === NaN).
+        const match = output.match(/\/runs?\/(\d+)/);
         if (match === null) {
             return;
         }


### PR DESCRIPTION
## Summary
Fixes a product bug where the Bundle Resource Explorer shows a permanent, **false** "Timeout while fetching run status" for a job that actually **succeeded**.

The databricks CLI changed the run URL it prints from the legacy `#job/<id>/run/<id>` fragment to the modern `/jobs/<id>/runs/<id>?o=..` path. `JobRunStatus.parseId` only matched the singular `/run/` form, so with a current CLI the extension never captures the run id — `startPolling()` never runs, and the 60s no-run-id timer flips the tree item to a timeout state even though the run completed fine.

## Fix
- Match both `/run/` and `/runs/` with `/\/runs?\/(\d+)/`.
- Use `\d+` instead of `\d*` so a stdout chunk that splits right after `/run(s)/` can't yield an empty capture (`parseInt("") === NaN`).
- Add `JobRunStatus.test.ts` pinning the CLI-output contract for both the modern and legacy URL forms (there was no unit coverage on this parser, which is how the regression shipped).

## Evidence
Found via the vscode nightly e2e run ([https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909](https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909)). The CLI `--debug` log shows `POST /api/2.2/jobs/run-now` succeeding and the run reaching `SUCCESS`/`TERMINATED`, with the CLI printing `Run available at https://.../jobs/<id>/runs/<id>?o=...`, while the extension tree item stayed at "Timeout while fetching run status" for the full window. Verified in node that the new regex captures the id from the modern URL, the `Run available at` form, and the legacy fragment, and does not mis-capture the job id from `/jobs/<id>`.

## Impact
Affects every user whose bundled CLI prints the modern run URL — candidate for a point release.

This pull request and its description were written by Isaac.
