### PR TITLE
test(e2e): stop Jedi crash toasts from breaking output-channel clicks

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/refresh_resource_explorer_on_yml_change.e2e.ts
@@ -54,6 +54,9 @@ describe("Automatically refresh resource explorer", async function () {
 
     it("should wait for connection", async () => {
         await waitForLogin("DEFAULT");
+        // Drain any post-login notifications so a lingering toast can't overlay
+        // the Output-channel dropdown we click below (mirrors deploy_and_run_job).
+        await dismissNotifications();
     });
 
     it("should find resource explorer view", async function () {
@@ -78,7 +81,26 @@ describe("Automatically refresh resource explorer", async function () {
         const outputView = await (await browser.getWorkbench())
             .getBottomBar()
             .openOutputView();
-        await outputView.selectChannel("Databricks Bundle Logs");
+        // A late notification toast can overlay the channel <select> and
+        // intercept the click. Re-dismiss and retry rather than failing on the
+        // first interception.
+        await browser.waitUntil(
+            async () => {
+                try {
+                    await outputView.selectChannel("Databricks Bundle Logs");
+                    return true;
+                } catch {
+                    await dismissNotifications();
+                    return false;
+                }
+            },
+            {
+                timeout: 20_000,
+                interval: 2_000,
+                timeoutMsg:
+                    "Could not select the 'Databricks Bundle Logs' output channel",
+            }
+        );
 
         const jobDef = await createProjectWithJob(
             projectName,

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -198,6 +198,15 @@ export const config: WebdriverIO.Config = {
                         "window.openFoldersInNewWindow": "off",
                         "extensions.autoCheckUpdates": false,
                         "extensions.autoUpdate": false,
+                        // ms-python.python is a hard extensionDependency, so its
+                        // language server always loads. In the headless CI display
+                        // the Jedi server repeatedly fails to connect and crashes,
+                        // and its "Python Jedi server crashed" toasts overlay UI
+                        // targets (e.g. the Output-channel <select title="Tasks">),
+                        // intercepting clicks. We don't need language features in
+                        // e2e, so disable the server (and experiments) at the source.
+                        "python.languageServer": "None",
+                        "python.experiments.enabled": false,
                     },
                 },
             },


### PR DESCRIPTION
## Summary
De-flakes `refresh_resource_explorer_on_yml_change`'s "should pickup changes to jobs resource" on the Windows shard.

## Root cause
`ms-python.python` is a hard `extensionDependency`, so its Jedi language server always loads. In the headless CI display it repeatedly fails to connect and crashes, and the resulting "Python Jedi server crashed" toasts overlay the Output-channel `<select title="Tasks">` element, intercepting the click (`element click intercepted`). Confirmed from the failure video and logs in the nightly run ([https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909](https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909)).

## Fix
- **Root fix:** disable the Python language server and experiments in the e2e `userSettings` (`wdio.conf.ts`) so the crash toasts never appear. This hardens every spec against this overlay class, not just this one.
- **Defense in depth:** drain notifications after login and retry `selectChannel` with a re-dismiss on interception in the refresh_resource test (mirrors the pattern already used in `deploy_and_run_job`).

We don't exercise Python language features in the e2e suite, so disabling Jedi has no test-coverage cost.

This pull request and its description were written by Isaac.
