### PR TITLE
test(e2e): retry opening the bundlevars editor in bundle_variables

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/bundle_variables.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/bundle_variables.e2e.ts
@@ -126,14 +126,39 @@ describe("Bundle Variables", async function () {
     });
 
     it("should override default variable", async function () {
-        await browser.executeWorkbench((vscode) => {
+        // Drain notifications so a toast can't steal focus while the editor opens.
+        await dismissNotifications();
+        // Await the command so the open request is issued before we look for the
+        // tab (the arrow fn must RETURN the Thenable).
+        await browser.executeWorkbench((vscode) =>
             vscode.commands.executeCommand(
                 "databricks.bundle.variable.openFile"
-            );
-        });
-        const editor = (await workbench
-            .getEditorView()
-            .openEditor("vscode.bundlevars.json")) as TextEditor;
+            )
+        );
+        // openEditor enumerates the open tabs once and throws if the tab isn't
+        // there yet; on the slower Windows shard the just-opened tab hasn't
+        // rendered when we first look. Retry until it appears (re-fetching each
+        // pass — do NOT cache the throwing result), failing closed if it never
+        // opens so a genuinely broken command can't pass silently.
+        let editor: TextEditor | undefined;
+        await browser.waitUntil(
+            async () => {
+                try {
+                    editor = (await workbench
+                        .getEditorView()
+                        .openEditor("vscode.bundlevars.json")) as TextEditor;
+                    return editor !== undefined;
+                } catch {
+                    return false;
+                }
+            },
+            {
+                timeout: 10_000,
+                interval: 500,
+                timeoutMsg:
+                    "vscode.bundlevars.json editor did not open within 10s",
+            }
+        );
         assert(editor);
 
         // Write the override file through the VS Code filesystem API rather


### PR DESCRIPTION
## Summary
De-flakes `bundle_variables`'s "should override default variable" on the Windows shard, which failed with `No editor with title 'vscode.bundlevars.json' found`.

## Root cause
The test fired the `databricks.bundle.variable.openFile` command **fire-and-forget** (the arrow fn didn't return the Thenable), then called `openEditor` once. `openEditor` enumerates the open tabs a single time and throws if the tab isn't present — so on the slower Windows shard it failed before the just-opened tab had rendered. The product works; this is a pure test-side race (the failure video shows the tab opening a moment later).

## Fix
- Await the open command so the request is issued before we look for the tab.
- Wrap `openEditor` in a `browser.waitUntil` that re-fetches the editor each pass (must not cache the throwing result).
- Dismiss notifications first.

Fails closed if the editor genuinely never opens, so a real regression still surfaces.

Found via the nightly run ([https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909](https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/29475140909)).

This pull request and its description were written by Isaac.
