### PR TITLE
test(e2e): raise waitForWorkflowWebview timeout to 60s for Windows shard

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -295,8 +295,12 @@ export async function waitForWorkflowWebview(
             }
         },
         {
-            timeout: 5_000,
-            interval: 1_000,
+            // The workflow run must be submitted and the "Databricks Job Run"
+            // webview panel materialized before this resolves; on the Windows
+            // shard 5s is not enough and the panel intermittently misses the
+            // window ("Webview did not open"). 60s covers observed open times.
+            timeout: 60_000,
+            interval: 2_000,
             timeoutMsg: "Webview did not open",
         }
     );


### PR DESCRIPTION
## Why
`run_notebooks_ipynb :: should run a notebook.ipynb file as a workflow` flakes on the Windows e2e shard with **"Webview did not open"**. The `waitForWorkflowWebview` poll allowed only **5 s** — not enough time on Windows to submit the workflow run and materialize the "Databricks Job Run" webview panel.

## What
Raise the poll timeout **5 s → 60 s** (interval 1 s → 2 s) in the shared `waitForWorkflowWebview` helper. Its only caller is the ipynb workflow test.

Test-only change; no product code touched.

## Verification
`tsc --noEmit` exit 0; eslint + prettier clean. e2e can't run locally — the `run_notebooks_ipynb` Windows shard is exercised across ≥4 isolated CI runs.

This pull request and its description were written by Isaac.