### PR TITLE
test(e2e): gate bundle_init wizard keystrokes on tab readiness

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/bundle_init.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/bundle_init.e2e.ts
@@ -76,15 +76,33 @@ describe("Bundle Init", async function () {
         const initTab = await getTabByTitle(title);
         assert(initTab, "Can't find a tab for project-init terminal wizard");
         await initTab.select();
-        await sleep(1000);
+
+        // The init wizard runs inside an editor-hosted terminal. Keystrokes sent
+        // before the terminal prompt is ready land in the wrong place and desync
+        // the wizard ("Can't complete cli bundle init wizard") on the slow
+        // Windows shard. The terminal buffer text isn't reliably readable via the
+        // wdio API, but the active-tab title is — gate on the init tab being
+        // active before typing, then use longer settle waits between keystrokes.
+        await browser.waitUntil(
+            async () => {
+                const activeTab = await editorView.getActiveTab();
+                return (await activeTab?.getTitle()) === title;
+            },
+            {
+                timeout: 20_000,
+                interval: 1_000,
+                timeoutMsg: "Init wizard terminal tab did not become active",
+            }
+        );
+        await sleep(3000);
 
         //select temaplate type
         await browser.keys("default-python".split(""));
-        await sleep(1000);
+        await sleep(3000);
         await browser.keys([Key.Enter]);
         //enter project name temaplate type
         await browser.keys(projectName.split(""));
-        await sleep(1000);
+        await sleep(3000);
         await browser.keys([Key.Enter]);
         await browser.waitUntil(
             async () => {
@@ -95,7 +113,7 @@ describe("Bundle Init", async function () {
                 await browser.keys([Key.Enter]);
             },
             {
-                timeout: 20_000,
+                timeout: 40_000,
                 interval: 2_000,
                 timeoutMsg: "Can't complete cli bundle init wizard",
             }


### PR DESCRIPTION
## Why
`bundle_init :: should initialize new project` flakes on the Windows shard with **"Can't complete cli bundle init wizard"** (its two follow-on tests then fail as cascades). The test drives an interactive **editor-hosted terminal** wizard by firing `browser.keys()` with fixed `sleep(1000)` gaps; on the slow Windows shard the keystrokes race the terminal prompt's readiness and desync the wizard.

## What
- Before typing, gate on the **"Databricks Project Init" tab being the active editor tab** (bounded `waitUntil`) instead of a bare `sleep`.
- Widen the keystroke settle sleeps **1 s → 3 s** and the completion `waitUntil` **20 s → 40 s**.

**Caveat:** the terminal buffer text isn't reliably readable via the wdio API, so the keystroke steps remain timing-based. This **reduces rather than provably eliminates** the race. If it still recurs, a non-interactive init path would be the follow-up.

Test-only change; no product code touched.

## Verification
`tsc --noEmit` exit 0; eslint + prettier clean. e2e can't run locally — the `bundle_init` Windows shard is exercised across ≥4 isolated CI runs (more if any residual failure appears).

This pull request and its description were written by Isaac.