### PR TITLE
[1/?] feat(python-setup): add setup-local CLI result contract types & golden fixtures

### DIFF
--- a/packages/databricks-vscode/src/python-setup/README.md
+++ b/packages/databricks-vscode/src/python-setup/README.md
@@ -1,0 +1,5 @@
+# python-setup
+
+Frictionless, uv-native "set up Python environment" feature: a thin wrapper over
+the `databricks environments setup-local` CLI command that matches the local
+Python environment to the selected Databricks compute target.

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
@@ -1,0 +1,105 @@
+import {expect} from "chai";
+import {
+    parsePythonSetupResult,
+    isPythonSetupSuccess,
+    PythonSetupParseError,
+} from "./PythonSetupResult";
+import {
+    SUCCESS_DEFAULT,
+    SUCCESS_CONSTRAINTS_ONLY,
+    SUCCESS_REAL_RUN,
+    ERROR_NO_TARGET,
+    ERROR_USAGE,
+} from "./fixtures/setupLocalResults";
+
+// The fixtures are typed PythonSetupResult objects; the parser takes raw CLI
+// stdout, so serialize a fixture back to JSON to exercise the parse path.
+const asStdout = (r: unknown) => JSON.stringify(r);
+
+describe("parsePythonSetupResult", () => {
+    it("parses a successful default-mode dry-run result", () => {
+        const r = parsePythonSetupResult(asStdout(SUCCESS_DEFAULT));
+        expect(r.ok).to.equal(true);
+        expect(r.command).to.equal("environments setup-local");
+        expect(r.schemaVersion).to.equal(1);
+        expect(r.mode).to.equal("default");
+        expect(r.dryRun).to.equal(true);
+        expect(r.target?.serverlessVersion).to.equal("v4");
+        expect(r.target?.envKey).to.equal("serverless/serverless-v4");
+        expect(r.resolved?.pythonVersion).to.equal("3.12");
+        expect(r.resolved?.dbconnectVersion).to.equal("17.2.0");
+        expect(r.error).to.equal(null);
+        expect(r.phases).to.have.length(6);
+        expect(r.phases[0]).to.deep.equal({phase: "preflight", status: "ok"});
+    });
+
+    it("parses a constraints-only result with dbconnectVersion absent", () => {
+        const r = parsePythonSetupResult(asStdout(SUCCESS_CONSTRAINTS_ONLY));
+        expect(r.ok).to.equal(true);
+        expect(r.mode).to.equal("constraints-only");
+        expect(r.resolved?.pythonVersion).to.equal("3.12");
+        expect(r.resolved?.dbconnectVersion).to.equal(undefined);
+    });
+
+    it("parses a real (non-dry-run) success with venvPath and backupPath", () => {
+        const r = parsePythonSetupResult(asStdout(SUCCESS_REAL_RUN));
+        expect(r.ok).to.equal(true);
+        expect(r.dryRun).to.equal(false);
+        expect(r.venvPath).to.equal("/home/user/project/.venv");
+        expect(r.backupPath).to.equal("/home/user/project/pyproject.toml.bak");
+    });
+
+    it("parses an E_NO_TARGET failure and exposes the error object", () => {
+        const r = parsePythonSetupResult(asStdout(ERROR_NO_TARGET));
+        expect(r.ok).to.equal(false);
+        expect(r.error?.code).to.equal("E_NO_TARGET");
+        expect(r.error?.failurePhase).to.equal("resolve");
+        expect(r.error?.diskMutated).to.equal(false);
+        // Downstream phases are reported "pending" after a failure.
+        const provision = r.phases.find((p) => p.phase === "provision");
+        expect(provision?.status).to.equal("pending");
+    });
+
+    it("parses an E_USAGE preflight failure", () => {
+        const r = parsePythonSetupResult(asStdout(ERROR_USAGE));
+        expect(r.ok).to.equal(false);
+        expect(r.error?.code).to.equal("E_USAGE");
+        expect(r.error?.failurePhase).to.equal("preflight");
+    });
+
+    it("throws PythonSetupParseError on non-JSON stdout", () => {
+        expect(() => parsePythonSetupResult("not json {")).to.throw(
+            PythonSetupParseError
+        );
+    });
+
+    it("throws PythonSetupParseError when the object lacks `ok`", () => {
+        expect(() => parsePythonSetupResult('{"mode":"default"}')).to.throw(
+            PythonSetupParseError
+        );
+    });
+
+    it("throws PythonSetupParseError on empty stdout", () => {
+        expect(() => parsePythonSetupResult("")).to.throw(
+            PythonSetupParseError
+        );
+    });
+});
+
+describe("isPythonSetupSuccess", () => {
+    it("is true for an ok result", () => {
+        expect(
+            isPythonSetupSuccess(
+                parsePythonSetupResult(asStdout(SUCCESS_DEFAULT))
+            )
+        ).to.equal(true);
+    });
+
+    it("is false for a failed result", () => {
+        expect(
+            isPythonSetupSuccess(
+                parsePythonSetupResult(asStdout(ERROR_NO_TARGET))
+            )
+        ).to.equal(false);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
@@ -1,0 +1,148 @@
+/**
+ * TypeScript view of the `databricks environments setup-local --output json`
+ * contract. Field names, optionality, and the phase/error shapes mirror the
+ * CLI's own Go structs in `libs/localenv/result.go` (schema version 1). The
+ * golden fixtures in `./fixtures/setupLocalResults.ts` — captured verbatim from
+ * the CLI acceptance suite — are the executable proof that this view matches.
+ *
+ * Only the fields the extension actually consumes are typed narrowly; the rest
+ * are kept faithful to the contract so a future consumer has them available.
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+/** Provisioning mode. `constraints-only` omits the databricks-connect dep. */
+export type PythonSetupMode = "default" | "constraints-only";
+
+/** Canonical execution phases, always reported in this order. */
+export type PythonSetupPhaseName =
+    | "preflight"
+    | "resolve"
+    | "fetch"
+    | "merge"
+    | "provision"
+    | "validate";
+
+/** Per-phase status in the `phases` array. */
+export type PythonSetupPhaseStatus = "ok" | "error" | "pending";
+
+/**
+ * Stable failure-class identifiers surfaced in `error.code`. Matches the CLI's
+ * ErrorCode set. `E_AUTH` / `E_PYTHON_POLICY` appear in the spec but are never
+ * emitted by the CLI (auth is handled by the shared workspace-client preflight
+ * before a result object is built), so they are intentionally absent here.
+ */
+export type PythonSetupErrorCode =
+    | "E_USAGE"
+    | "E_MANAGER_UNSUPPORTED"
+    | "E_NOT_WRITABLE"
+    | "E_UV_MISSING"
+    | "E_NO_TARGET"
+    | "E_RESOLVE"
+    | "E_ENV_UNSUPPORTED"
+    | "E_FETCH"
+    | "E_WRITE"
+    | "E_MERGE"
+    | "E_PYTHON_INSTALL"
+    | "E_PROVISION"
+    | "E_VALIDATE";
+
+export interface PythonSetupTargetInfo {
+    source: string;
+    clusterId?: string;
+    serverlessVersion?: string;
+    envKey: string;
+}
+
+export interface PythonSetupResolvedInfo {
+    pythonVersion: string;
+    /** Omitted (absent) in constraints-only mode. */
+    dbconnectVersion?: string;
+    artifactSource: "network" | "cache";
+}
+
+export interface PythonSetupPhaseEntry {
+    phase: PythonSetupPhaseName;
+    status: PythonSetupPhaseStatus;
+}
+
+export interface PythonSetupPlan {
+    wouldWrite: string;
+    wouldBackup?: string;
+    wouldInstallPython?: string;
+    diff: string;
+}
+
+export interface PythonSetupWarning {
+    code: string;
+    message: string;
+}
+
+export interface PythonSetupError {
+    code: PythonSetupErrorCode;
+    failurePhase: PythonSetupPhaseName;
+    message: string;
+    diskMutated: boolean;
+}
+
+/**
+ * Root of the `--output json` object. `error` is always present as a key —
+ * `null` on success, populated on failure. `phases` and `warnings` are always
+ * arrays (never null). `plan` is present only under `--dry-run`; `venvPath` and
+ * `backupPath` only on a real run.
+ */
+export interface PythonSetupResult {
+    schemaVersion: number;
+    command: string;
+    ok: boolean;
+    mode: PythonSetupMode;
+    dryRun: boolean;
+    target?: PythonSetupTargetInfo;
+    resolved?: PythonSetupResolvedInfo;
+    greenfield: boolean;
+    plan?: PythonSetupPlan;
+    venvPath?: string;
+    backupPath?: string;
+    phases: PythonSetupPhaseEntry[];
+    warnings: PythonSetupWarning[];
+    error: PythonSetupError | null;
+    durationMs: number;
+}
+
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/** Thrown when the CLI stdout is not a parseable setup-local result object. */
+export class PythonSetupParseError extends Error {}
+
+/**
+ * Parse the single JSON object the CLI prints to stdout under `--output json`.
+ * Throws {@link PythonSetupParseError} when stdout is not valid JSON or is not a
+ * result object (missing the required boolean `ok`). Validation is deliberately
+ * minimal — enough to distinguish "a result" from "garbage/partial output" —
+ * because the golden fixtures, not this function, police the full shape.
+ */
+export function parsePythonSetupResult(stdout: string): PythonSetupResult {
+    let obj: unknown;
+    try {
+        obj = JSON.parse(stdout);
+    } catch (e) {
+        throw new PythonSetupParseError(
+            `CLI did not return valid JSON: ${(e as Error).message}`
+        );
+    }
+    if (
+        typeof obj !== "object" ||
+        obj === null ||
+        typeof (obj as {ok?: unknown}).ok !== "boolean"
+    ) {
+        throw new PythonSetupParseError(
+            "CLI JSON is not a setup-local result (missing boolean `ok`)"
+        );
+    }
+    return obj as PythonSetupResult;
+}
+
+/** Whether a parsed result represents a successful run. */
+export function isPythonSetupSuccess(r: PythonSetupResult): boolean {
+    return r.ok === true;
+}

--- a/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
+++ b/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
@@ -1,0 +1,191 @@
+/**
+ * Golden `databricks environments setup-local --output json` results, mirrored
+ * from the CLI's own acceptance suite
+ * (databricks/cli `acceptance/localenv/<case>/output.txt`). These are the single
+ * source of truth for the extension's result parser and consumers.
+ *
+ * They are typed as {@link PythonSetupResult} on purpose: the annotation couples
+ * each fixture to the contract type, so any change to the type (a renamed field,
+ * a tightened union) breaks this file at compile time — turning silent contract
+ * drift into a build error. Parser tests that need raw CLI stdout wrap a fixture
+ * in `JSON.stringify(...)`, which round-trips through `parsePythonSetupResult`.
+ *
+ * Source cases:
+ *  - SUCCESS_DEFAULT          → acceptance/localenv/serverless-json
+ *  - SUCCESS_CONSTRAINTS_ONLY → acceptance/localenv/constraints-only
+ *  - ERROR_NO_TARGET          → acceptance/localenv/json-error
+ *  - ERROR_USAGE              → acceptance/localenv/flag-conflict-json
+ *
+ * SUCCESS_REAL_RUN is synthesized (no committed CLI golden runs a real
+ * provision — every acceptance case uses `--dry-run`). It follows
+ * libs/localenv/result.go: `dryRun: false`, no `plan`, and the `venvPath` /
+ * `backupPath` fields the extension's adopt-interpreter step consumes.
+ */
+
+import {PythonSetupResult} from "../PythonSetupResult";
+
+/** serverless-json: default mode, --dry-run, --output json. */
+export const SUCCESS_DEFAULT: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: true,
+    mode: "default",
+    dryRun: true,
+    target: {
+        source: "serverless",
+        serverlessVersion: "v4",
+        envKey: "serverless/serverless-v4",
+    },
+    resolved: {
+        pythonVersion: "3.12",
+        dbconnectVersion: "17.2.0",
+        artifactSource: "network",
+    },
+    greenfield: true,
+    plan: {
+        wouldWrite: "[TEST_TMP_DIR]/pyproject.toml",
+        wouldInstallPython: "3.12",
+        diff: "--- pyproject.toml\n+++ pyproject.toml\n",
+    },
+    phases: [
+        {phase: "preflight", status: "ok"},
+        {phase: "resolve", status: "ok"},
+        {phase: "fetch", status: "ok"},
+        {phase: "merge", status: "ok"},
+        {phase: "provision", status: "ok"},
+        {phase: "validate", status: "ok"},
+    ],
+    warnings: [],
+    error: null,
+    durationMs: 0,
+};
+
+/** constraints-only: note `resolved` omits `dbconnectVersion`. */
+export const SUCCESS_CONSTRAINTS_ONLY: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: true,
+    mode: "constraints-only",
+    dryRun: true,
+    target: {
+        source: "serverless",
+        serverlessVersion: "v4",
+        envKey: "serverless/serverless-v4",
+    },
+    resolved: {
+        pythonVersion: "3.12",
+        artifactSource: "network",
+    },
+    greenfield: true,
+    plan: {
+        wouldWrite: "[TEST_TMP_DIR]/pyproject.toml",
+        wouldInstallPython: "3.12",
+        diff: "--- pyproject.toml\n+++ pyproject.toml\n",
+    },
+    phases: [
+        {phase: "preflight", status: "ok"},
+        {phase: "resolve", status: "ok"},
+        {phase: "fetch", status: "ok"},
+        {phase: "merge", status: "ok"},
+        {phase: "provision", status: "ok"},
+        {phase: "validate", status: "ok"},
+    ],
+    warnings: [],
+    error: null,
+    durationMs: 0,
+};
+
+/** json-error: E_NO_TARGET at resolve; downstream phases `pending`. */
+export const ERROR_NO_TARGET: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: false,
+    mode: "default",
+    dryRun: false,
+    greenfield: false,
+    phases: [
+        {phase: "preflight", status: "ok"},
+        {phase: "resolve", status: "error"},
+        {phase: "fetch", status: "pending"},
+        {phase: "merge", status: "pending"},
+        {phase: "provision", status: "pending"},
+        {phase: "validate", status: "pending"},
+    ],
+    warnings: [],
+    error: {
+        code: "E_NO_TARGET",
+        failurePhase: "resolve",
+        message:
+            "No compute target is selected. Select a cluster or serverless " +
+            "target, or pass --cluster-id / --cluster-name / " +
+            "--serverless-version / --job-id",
+        diskMutated: false,
+    },
+    durationMs: 0,
+};
+
+/** flag-conflict-json: E_USAGE at preflight. */
+export const ERROR_USAGE: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: false,
+    mode: "default",
+    dryRun: false,
+    greenfield: false,
+    phases: [
+        {phase: "preflight", status: "error"},
+        {phase: "resolve", status: "pending"},
+        {phase: "fetch", status: "pending"},
+        {phase: "merge", status: "pending"},
+        {phase: "provision", status: "pending"},
+        {phase: "validate", status: "pending"},
+    ],
+    warnings: [],
+    error: {
+        code: "E_USAGE",
+        failurePhase: "preflight",
+        message:
+            "invalid compute target flags: flags --cluster-id and " +
+            "--serverless-version are mutually exclusive; specify at most one",
+        diskMutated: false,
+    },
+    durationMs: 0,
+};
+
+/**
+ * Synthesized real (non-dry-run) success: what the extension actually consumes
+ * to adopt the interpreter. No committed CLI golden exercises a real provision.
+ * Shape follows libs/localenv/result.go: `dryRun: false`, no `plan`, `venvPath`
+ * and `backupPath` present.
+ */
+export const SUCCESS_REAL_RUN: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: true,
+    mode: "default",
+    dryRun: false,
+    target: {
+        source: "serverless",
+        serverlessVersion: "v4",
+        envKey: "serverless/serverless-v4",
+    },
+    resolved: {
+        pythonVersion: "3.12",
+        dbconnectVersion: "17.2.0",
+        artifactSource: "network",
+    },
+    greenfield: false,
+    venvPath: "/home/user/project/.venv",
+    backupPath: "/home/user/project/pyproject.toml.bak",
+    phases: [
+        {phase: "preflight", status: "ok"},
+        {phase: "resolve", status: "ok"},
+        {phase: "fetch", status: "ok"},
+        {phase: "merge", status: "ok"},
+        {phase: "provision", status: "ok"},
+        {phase: "validate", status: "ok"},
+    ],
+    warnings: [],
+    error: null,
+    durationMs: 0,
+};


### PR DESCRIPTION
## What

First task of **M4 — Productionize the VS Code extension**.

Adds a typed, verified view of the `databricks environments setup-local --output json` contract — the foundation every later python-setup consumer (CLI client, error mapping, orchestrator) builds on.

- **`python-setup/models/PythonSetupResult.ts`** — TypeScript types mirroring the CLI's `libs/localenv` result structs (schema v1): `PythonSetupResult`, phases as `{phase, status}`, an always-present `error` (`null` on success), the `PythonSetupErrorCode` union, plus `parsePythonSetupResult()` (throws `PythonSetupParseError` on non-result stdout) and `isPythonSetupSuccess()`.
- **`python-setup/models/fixtures/setupLocalResults.ts`** — golden JSON captured **verbatim from the CLI's own acceptance suite** (`acceptance/localenv/{serverless-json,constraints-only,json-error,flag-conflict-json}`), plus one synthesized real-run success (no committed CLI golden runs a non-dry-run provision). Kept as string constants because the extension build (`tsc`, rootDir `src`→`out`) does not copy `.json` assets and `resolveJsonModule` is off, so a `.json` fixture wouldn't resolve at unit-test runtime.

## Why

The extension will shell out to the CLI and parse a single JSON result. It needs a contract view backed by real fixtures so the parser can't silently drift from what the CLI emits — if the contract changes, these fixtures (and their tests) are what fail.

## Naming

Uses the user-facing name **python-setup** throughout.

## Contract corrections

Building against the shipped, unhidden CLI surfaced several mismatches with the original plan; the code follows the **real** contract (`libs/localenv/result.go`):

| Plan assumed | Shipped contract |
|---|---|
| `environments install-local` | **`environments setup-local`** |
| phases `{name, ok}` | **`{phase, status}`**, status ∈ `ok\|error\|pending` |
| no schema/duration fields | **`schemaVersion`** + **`durationMs`** present |
| `--serverless-version v5` | takes bare `5`, **normalized to `vN`** in output |
| `error` omitted on success | **`error: null`** always present |

## Backward compatibility

No user-facing change. All new files under `src/python-setup/`; nothing existing is imported or modified. Feature is not wired anywhere yet.

## Verification

- `yarn test:unit` → **307 passing, 0 failing** (10 new assertions across `parsePythonSetupResult` / `isPythonSetupSuccess`).
- `yarn test:lint` → clean (prettier + eslint).

This pull request and its description were written by Isaac.
