### PR TITLE
[3/?] feat(python-setup): add setup-local CLI client (argv, path, spawn, JSON)

### DIFF
--- a/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
+++ b/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
@@ -1,0 +1,405 @@
+import {expect} from "chai";
+import {EventEmitter} from "node:events";
+import {
+    PythonSetupCancelledError,
+    PythonSetupCliClient,
+    SpawnFn,
+    TerminatePrimitives,
+    terminateProcessTree,
+} from "./PythonSetupCliClient";
+import {
+    SUCCESS_DEFAULT,
+    ERROR_NO_TARGET,
+} from "../models/fixtures/setupLocalResults";
+
+/**
+ * A fake child process that emits scripted stdout/stderr then closes. Lets us
+ * drive the client without spawning a real binary. `stdout`/`stderr` may be a
+ * single string or a list of raw byte chunks, so tests can reproduce a payload
+ * split across "data" events (e.g. a multi-byte char straddling the boundary).
+ */
+function fakeSpawn(script: {
+    stdout?: string | Buffer[];
+    stderr?: string | Buffer[];
+    code?: number;
+    spawnError?: Error;
+    onKill?: () => void;
+    captureArgs?: (
+        cmd: string,
+        args: string[],
+        cwd: string,
+        detached: boolean
+    ) => void;
+}): SpawnFn {
+    const toChunks = (v?: string | Buffer[]): Buffer[] => {
+        if (v === undefined) {
+            return [];
+        }
+        return typeof v === "string" ? [Buffer.from(v)] : v;
+    };
+    return (cmd, args, opts) => {
+        script.captureArgs?.(cmd, args, opts.cwd, opts.detached);
+        const child: any = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = () => script.onKill?.();
+        setImmediate(() => {
+            if (script.spawnError) {
+                child.emit("error", script.spawnError);
+                return;
+            }
+            for (const chunk of toChunks(script.stderr)) {
+                child.stderr.emit("data", chunk);
+            }
+            for (const chunk of toChunks(script.stdout)) {
+                child.stdout.emit("data", chunk);
+            }
+            child.emit("close", script.code ?? 0);
+        });
+        return child;
+    };
+}
+
+const inv = {
+    mode: "default" as const,
+    compute: {kind: "serverless" as const, version: "5"},
+};
+
+describe("PythonSetupCliClient", () => {
+    it("parses the JSON result from stdout on success", async () => {
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({stdout: JSON.stringify(SUCCESS_DEFAULT), code: 0})
+        );
+        const result = await client.run(inv, {cwd: "/proj"});
+        expect(result.ok).to.equal(true);
+        expect(result.command).to.equal("environments setup-local");
+    });
+
+    it("returns the parsed failure result on a non-zero exit with JSON", async () => {
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({stdout: JSON.stringify(ERROR_NO_TARGET), code: 1})
+        );
+        const result = await client.run(inv, {cwd: "/proj"});
+        expect(result.ok).to.equal(false);
+        expect(result.error?.code).to.equal("E_NO_TARGET");
+    });
+
+    it("spawns the resolved path with setup-local argv in the given cwd", async () => {
+        let seenCmd = "";
+        let seenArgs: string[] = [];
+        let seenCwd = "";
+        const client = new PythonSetupCliClient(
+            () => "/custom/databricks",
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                captureArgs: (c, a, cwd) => {
+                    seenCmd = c;
+                    seenArgs = a;
+                    seenCwd = cwd;
+                },
+            })
+        );
+        await client.run(inv, {cwd: "/my/project"});
+        expect(seenCmd).to.equal("/custom/databricks");
+        expect(seenArgs.slice(0, 4)).to.deep.equal([
+            "environments",
+            "setup-local",
+            "--serverless-version",
+            "5",
+        ]);
+        expect(seenArgs.slice(-2)).to.deep.equal(["--output", "json"]);
+        expect(seenCwd).to.equal("/my/project");
+    });
+
+    it("spawns detached on POSIX so the process group can be killed", async () => {
+        let seenDetached: boolean | undefined;
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                captureArgs: (_c, _a, _cwd, detached) => {
+                    seenDetached = detached;
+                },
+            })
+        );
+        await client.run(inv, {cwd: "/proj"});
+        // detached everywhere except Windows (where taskkill /T handles the
+        // tree and detached would spawn an extra console window).
+        expect(seenDetached).to.equal(process.platform !== "win32");
+    });
+
+    it("forwards captured stderr to the onLog callback", async () => {
+        const logs: string[] = [];
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                stderr: "uv: resolving dependencies…\n",
+            })
+        );
+        await client.run(inv, {cwd: "/proj", onLog: (t) => logs.push(t)});
+        expect(logs.join("")).to.contain("resolving dependencies");
+    });
+
+    it("flushes a partial trailing stderr byte to onLog at close", async () => {
+        // stderr ends mid-"…" (U+2026, 3 bytes) and the completing bytes never
+        // arrive: the decoder holds the incomplete sequence back on the data
+        // event, so the tail must be flushed to onLog when the process closes.
+        const full = Buffer.from("done…", "utf8");
+        const truncated = full.subarray(0, full.length - 1); // drop last byte
+        const logs: string[] = [];
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                stderr: [truncated],
+            })
+        );
+        await client.run(inv, {cwd: "/proj", onLog: (t) => logs.push(t)});
+        // "done" arrives on the data event; the held-back partial char is
+        // flushed (as U+FFFD) at close rather than being silently dropped.
+        const joined = logs.join("");
+        expect(joined.startsWith("done")).to.equal(true);
+        expect(joined.length).to.be.greaterThan("done".length);
+    });
+
+    it("rejects with PythonSetupParseError, appending stderr, when stdout is not valid JSON", async () => {
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({stdout: "not json", stderr: "boom", code: 1})
+        );
+        let threw = false;
+        try {
+            await client.run(inv, {cwd: "/proj"});
+        } catch (e) {
+            threw = true;
+            // The parse error stays the surfaced type, with the captured
+            // stderr appended so the failure is actionable.
+            expect((e as Error).message).to.match(/valid JSON/i);
+            expect((e as Error).message).to.contain("boom");
+        }
+        expect(threw).to.equal(true);
+    });
+
+    it("decodes a multi-byte char split across two stdout chunks", async () => {
+        // "…" (U+2026) is 3 bytes in UTF-8; split it down the middle so each
+        // chunk holds a partial code point. Naive per-chunk toString() would
+        // corrupt it to U+FFFD and break JSON.parse.
+        const json = JSON.stringify({...SUCCESS_DEFAULT, note: "a…b"});
+        const bytes = Buffer.from(json, "utf8");
+        const cut = bytes.indexOf(0xe2) + 1; // mid-ellipsis
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({stdout: [bytes.subarray(0, cut), bytes.subarray(cut)]})
+        );
+        const result = await client.run(inv, {cwd: "/proj"});
+        expect(result.ok).to.equal(true);
+        expect((result as any).note).to.equal("a…b");
+    });
+
+    it("rejects when the process fails to spawn", async () => {
+        const client = new PythonSetupCliClient(
+            () => "/missing/databricks",
+            fakeSpawn({spawnError: new Error("ENOENT")})
+        );
+        let threw = false;
+        try {
+            await client.run(inv, {cwd: "/proj"});
+        } catch (e) {
+            threw = true;
+            expect((e as Error).message).to.contain("ENOENT");
+        }
+        expect(threw).to.equal(true);
+    });
+
+    // A process that hangs until terminated, then emits "close" (as a real
+    // SIGTERM'd process would), letting the run promise settle.
+    const hangingSpawn: SpawnFn = () => {
+        const child: any = new EventEmitter();
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        child.kill = () => child.emit("close", null);
+        child.pid = 1234;
+        return child;
+    };
+
+    // A cancellation token whose callback fires on the next tick, tracking
+    // whether its subscription was disposed.
+    function nextTickToken(): {
+        token: {
+            isCancellationRequested: boolean;
+            onCancellationRequested: (cb: () => void) => {dispose(): void};
+        };
+        disposed: () => boolean;
+    } {
+        let disposed = false;
+        return {
+            disposed: () => disposed,
+            token: {
+                isCancellationRequested: false,
+                onCancellationRequested: (cb: () => void) => {
+                    setImmediate(cb);
+                    return {
+                        dispose() {
+                            disposed = true;
+                        },
+                    };
+                },
+            },
+        };
+    }
+
+    it("terminates the child via the injected terminator on cancellation", async () => {
+        let terminatedChild: any;
+        const {token} = nextTickToken();
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            hangingSpawn,
+            (child) => {
+                terminatedChild = child;
+                child.kill();
+            }
+        );
+        await client.run(inv, {cwd: "/proj", token}).catch(() => undefined);
+        expect(terminatedChild?.pid).to.equal(1234);
+    });
+
+    it("rejects with PythonSetupCancelledError when cancelled", async () => {
+        const {token} = nextTickToken();
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            hangingSpawn,
+            (child) => child.kill()
+        );
+        let caught: unknown;
+        await client.run(inv, {cwd: "/proj", token}).catch((e) => (caught = e));
+        expect(caught).to.be.instanceOf(PythonSetupCancelledError);
+    });
+
+    it("does not spawn and rejects when the token is already cancelled at entry", async () => {
+        let spawned = false;
+        const preCancelledToken = {
+            isCancellationRequested: true,
+            onCancellationRequested: () => ({dispose() {}}),
+        };
+        const spySpawn: SpawnFn = (...a) => {
+            spawned = true;
+            return hangingSpawn(...a);
+        };
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            spySpawn
+        );
+        let caught: unknown;
+        await client
+            .run(inv, {cwd: "/proj", token: preCancelledToken})
+            .catch((e) => (caught = e));
+        // The mutating CLI must never start for an already-cancelled request.
+        expect(spawned).to.equal(false);
+        expect(caught).to.be.instanceOf(PythonSetupCancelledError);
+    });
+
+    it("disposes the cancellation subscription on a normal exit", async () => {
+        // A token that never fires cancel, so the run completes normally; we
+        // still expect its listener to be disposed to avoid a leak.
+        let disposed = false;
+        const token = {
+            isCancellationRequested: false,
+            onCancellationRequested: () => ({
+                dispose() {
+                    disposed = true;
+                },
+            }),
+        };
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            fakeSpawn({stdout: JSON.stringify(SUCCESS_DEFAULT)})
+        );
+        const result = await client.run(inv, {cwd: "/proj", token});
+        expect(result.ok).to.equal(true);
+        expect(disposed).to.equal(true);
+    });
+
+    it("does not let a throwing terminator escape cancellation", async () => {
+        const {token} = nextTickToken();
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            hangingSpawn,
+            (child) => {
+                // Emit close so the promise still settles, then throw.
+                child.kill();
+                throw new Error("kill failed");
+            }
+        );
+        // Must reject cleanly (as a cancellation), not blow up synchronously.
+        let caught: unknown;
+        await client.run(inv, {cwd: "/proj", token}).catch((e) => (caught = e));
+        expect(caught).to.be.instanceOf(PythonSetupCancelledError);
+    });
+});
+
+describe("terminateProcessTree", () => {
+    // Records what the terminator did, plus a fake child whose direct kill()
+    // we can observe. `killThrows` simulates the group being gone (ESRCH).
+    function harness(platform: NodeJS.Platform, killThrows = false) {
+        const calls = {
+            groupKill: [] as Array<[number, NodeJS.Signals]>,
+            spawned: [] as Array<[string, string[]]>,
+            directKill: [] as (NodeJS.Signals | undefined)[],
+        };
+        const prims: TerminatePrimitives = {
+            platform,
+            kill: (pid, signal) => {
+                if (killThrows) {
+                    throw new Error("ESRCH");
+                }
+                calls.groupKill.push([pid, signal]);
+            },
+            spawnHelper: (cmd, args) => calls.spawned.push([cmd, args]),
+        };
+        const child: any = new EventEmitter();
+        child.pid = 4321;
+        child.kill = (signal?: NodeJS.Signals) => calls.directKill.push(signal);
+        return {calls, prims, child};
+    }
+
+    it("kills the negated pid (process group) with SIGTERM on POSIX", () => {
+        const {calls, prims, child} = harness("linux");
+        terminateProcessTree(child, prims);
+        expect(calls.groupKill).to.deep.equal([[-4321, "SIGTERM"]]);
+        expect(calls.directKill).to.be.empty;
+    });
+
+    it("falls back to a direct child kill when the group is already gone", () => {
+        const {calls, prims, child} = harness("darwin", /*killThrows*/ true);
+        terminateProcessTree(child, prims);
+        expect(calls.directKill).to.deep.equal(["SIGTERM"]);
+    });
+
+    it("shells taskkill /T /F with the string pid on Windows", () => {
+        const {calls, prims, child} = harness("win32");
+        terminateProcessTree(child, prims);
+        expect(calls.spawned).to.deep.equal([
+            ["taskkill", ["/pid", "4321", "/T", "/F"]],
+        ]);
+        expect(calls.directKill).to.be.empty;
+    });
+
+    it("falls back to a direct kill when the child has no pid", () => {
+        const {calls, prims, child} = harness("linux");
+        child.pid = undefined;
+        terminateProcessTree(child, prims);
+        expect(calls.groupKill).to.be.empty;
+        expect(calls.directKill).to.deep.equal(["SIGTERM"]);
+    });
+
+    it("falls back to a direct kill on Windows when the child has no pid", () => {
+        const {calls, prims, child} = harness("win32");
+        child.pid = undefined;
+        terminateProcessTree(child, prims);
+        expect(calls.spawned).to.be.empty;
+        expect(calls.directKill).to.deep.equal(["SIGTERM"]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.ts
+++ b/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.ts
@@ -1,0 +1,263 @@
+import {
+    spawn as nodeSpawn,
+    ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import {StringDecoder} from "node:string_decoder";
+import {
+    buildSetupLocalArgs,
+    SetupLocalInvocation,
+} from "../utils/setupLocalArgs";
+import {
+    parsePythonSetupResult,
+    PythonSetupResult,
+} from "../models/PythonSetupResult";
+
+/**
+ * Minimal cancellation signal, structurally compatible with `vscode.Cancellation
+ * Token`. Declared locally so this gateway carries no `vscode` import and stays
+ * unit-testable without the extension host.
+ */
+export interface CancellationLike {
+    readonly isCancellationRequested: boolean;
+    onCancellationRequested(listener: () => void): {dispose(): void};
+}
+
+/**
+ * Injectable spawn seam. The real implementation is Node's `child_process.
+ * spawn`; tests pass a fake that emits scripted stdout/stderr.
+ */
+export type SpawnFn = (
+    command: string,
+    args: string[],
+    options: {cwd: string; env: NodeJS.ProcessEnv; detached: boolean}
+) => ChildProcessWithoutNullStreams;
+
+/**
+ * Injectable process-tree terminator. `setup-local` spawns `uv sync` as a
+ * grandchild, and killing only the direct `databricks` child orphans it: on
+ * Windows a plain `SIGTERM` doesn't even reach the CLI, and on POSIX a signal
+ * to the direct child is not propagated to grandchildren. The default kills the
+ * whole tree on both — `taskkill /T /F` on Windows, and (because the child is
+ * spawned {@link https://nodejs.org/api/child_process.html detached}, i.e. its
+ * own process-group leader) a `SIGTERM` to the negated pid on POSIX, which
+ * signals the entire group. Injectable so cancellation is assertable in tests
+ * without spawning real processes.
+ */
+export type TerminateFn = (child: ChildProcessWithoutNullStreams) => void;
+
+/**
+ * OS primitives used by {@link terminateProcessTree}, injectable so the
+ * termination logic can be unit-tested without touching real processes.
+ */
+export interface TerminatePrimitives {
+    platform: NodeJS.Platform;
+    /** Send `signal` to `pid` (a negative pid targets the process group). */
+    kill(pid: number, signal: NodeJS.Signals): void;
+    /** Fire-and-forget helper spawn (e.g. `taskkill`). */
+    spawnHelper(command: string, args: string[]): void;
+}
+
+const realTerminatePrimitives: TerminatePrimitives = {
+    platform: process.platform,
+    kill: (pid, signal) => process.kill(pid, signal),
+    spawnHelper: (command, args) => {
+        // Swallow the async spawn error (e.g. taskkill not on PATH) so it can't
+        // become an uncaught exception in the extension host during cancel.
+        nodeSpawn(command, args).on("error", () => {});
+    },
+};
+
+/**
+ * Kill the whole `setup-local` process tree, injectable primitives and all. On
+ * Windows a plain `SIGTERM` doesn't reach the CLI, so force-kill the tree with
+ * `taskkill /T /F`; on POSIX the child is a process-group leader (spawned
+ * detached), so signalling the negated pid tears down the whole group —
+ * including the `uv` grandchild a direct-child SIGTERM would orphan — with a
+ * fallback to a direct kill if the group is already gone.
+ */
+export function terminateProcessTree(
+    child: ChildProcessWithoutNullStreams,
+    prims: TerminatePrimitives = realTerminatePrimitives
+): void {
+    const pid = child.pid;
+    if (prims.platform === "win32") {
+        if (pid) {
+            prims.spawnHelper("taskkill", ["/pid", String(pid), "/T", "/F"]);
+            return;
+        }
+    } else if (pid) {
+        try {
+            prims.kill(-pid, "SIGTERM");
+            return;
+        } catch {
+            // Group already gone / not a leader — fall through to a direct kill.
+        }
+    }
+    child.kill("SIGTERM");
+}
+
+const defaultTerminate: TerminateFn = (child) => terminateProcessTree(child);
+
+/**
+ * Rejection raised when a {@link PythonSetupCliClient.run} is aborted via its
+ * cancellation token, so callers can distinguish a user cancellation from a
+ * genuine CLI failure (which surfaces as a `PythonSetupParseError` or the
+ * spawn error).
+ */
+export class PythonSetupCancelledError extends Error {
+    constructor() {
+        super("Python setup was cancelled");
+        this.name = "PythonSetupCancelledError";
+    }
+}
+
+export interface RunOptions {
+    /** Working directory the CLI runs in (the project root). */
+    cwd: string;
+    /** Receives raw stderr chunks for the output/"Show Logs" channel. */
+    onLog?: (chunk: string) => void;
+    /** When cancelled, the child process is terminated. */
+    token?: CancellationLike;
+}
+
+/**
+ * Gateway to the `databricks environments setup-local` CLI command.
+ *
+ * Runs the CLI with `--output json`, captures stdout (the single structured
+ * {@link PythonSetupResult}) and stderr (raw logs), and resolves with the parsed
+ * result on both success and failure exits — the caller branches on `result.ok`
+ * / `result.error`, not on the process exit code. A cancelled run rejects with
+ * {@link PythonSetupCancelledError} so callers can tell it apart from a genuine
+ * CLI failure.
+ *
+ * There is deliberately no live phase narration: under `--output json` the CLI
+ * emits only the final JSON object on stdout (per-phase text is text-mode only,
+ * and `uv sync` output is buffered), so callers show an indeterminate progress
+ * indicator and read the per-phase outcomes from `result.phases` afterwards.
+ *
+ * The client itself does no I/O beyond spawning: path resolution and argv are
+ * pure helpers, and the spawn function is injected, so it is fully unit-testable.
+ */
+export class PythonSetupCliClient {
+    constructor(
+        private readonly resolvePath: () => string,
+        private readonly spawnFn: SpawnFn = nodeSpawn as unknown as SpawnFn,
+        private readonly terminateFn: TerminateFn = defaultTerminate
+    ) {}
+
+    run(
+        invocation: SetupLocalInvocation,
+        options: RunOptions
+    ): Promise<PythonSetupResult> {
+        // `setup-local` mutates the project (.venv / pyproject.toml), so if the
+        // request is already cancelled don't even start it — reject before
+        // spawning rather than spawn-then-kill, which would let it run briefly.
+        if (options.token?.isCancellationRequested) {
+            return Promise.reject(new PythonSetupCancelledError());
+        }
+        const args = buildSetupLocalArgs(invocation);
+        return new Promise<PythonSetupResult>((resolve, reject) => {
+            let child: ChildProcessWithoutNullStreams;
+            try {
+                child = this.spawnFn(this.resolvePath(), args, {
+                    cwd: options.cwd,
+                    env: process.env,
+                    // Give the child its own process group on POSIX so cancel
+                    // can kill the whole tree (see defaultTerminate). On Windows
+                    // `detached` opens a new console; we use taskkill there, so
+                    // leave it off.
+                    detached: process.platform !== "win32",
+                });
+            } catch (e) {
+                reject(e as Error);
+                return;
+            }
+
+            // Accumulate raw bytes and decode once at the end: a multi-byte
+            // UTF-8 sequence can straddle two "data" chunks, and decoding each
+            // chunk in isolation would corrupt it (turning a valid JSON payload
+            // into U+FFFD garbage that fails to parse). stderr is streamed to
+            // onLog as it arrives, so it goes through a StringDecoder that holds
+            // back any trailing partial code point until the next chunk.
+            const stdoutChunks: Buffer[] = [];
+            const stderrDecoder = new StringDecoder("utf8");
+            let stderr = "";
+            let settled = false;
+            let cancelled = false;
+
+            const requestCancel = () => {
+                cancelled = true;
+                // Best-effort terminate; the "close"/"error" handler still
+                // fires and settles the promise, so cancellation never leaves
+                // it hanging. Guard against terminate throwing (e.g. the child
+                // is already gone) so it can't escape this callback.
+                try {
+                    this.terminateFn(child);
+                } catch {
+                    // ignore — the process-exit handler will settle the promise
+                }
+            };
+
+            const cancelSub =
+                options.token?.onCancellationRequested(requestCancel);
+
+            const finish = (fn: () => void) => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                cancelSub?.dispose();
+                fn();
+            };
+
+            child.stdout.on("data", (b: Buffer) => stdoutChunks.push(b));
+            child.stderr.on("data", (b: Buffer) => {
+                const text = stderrDecoder.write(b);
+                if (text) {
+                    stderr += text;
+                    options.onLog?.(text);
+                }
+            });
+
+            // A stream-level error (e.g. EPIPE) would otherwise be an unhandled
+            // "error" event, which Node throws as an uncaught exception in the
+            // extension host. Route it through finish() like any other failure.
+            child.stdout.on("error", (err: Error) => finish(() => reject(err)));
+            child.stderr.on("error", (err: Error) => finish(() => reject(err)));
+
+            child.on("error", (err: Error) => finish(() => reject(err)));
+
+            child.on("close", () =>
+                finish(() => {
+                    // Flush any partial trailing byte the decoder held back, and
+                    // forward it to onLog too so the log channel isn't missing
+                    // the final fragment.
+                    const tail = stderrDecoder.end();
+                    if (tail) {
+                        stderr += tail;
+                        options.onLog?.(tail);
+                    }
+                    if (cancelled) {
+                        reject(new PythonSetupCancelledError());
+                        return;
+                    }
+                    const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+                    try {
+                        resolve(parsePythonSetupResult(stdout));
+                    } catch (e) {
+                        // No parseable result on stdout. Append captured stderr
+                        // (uv/CLI diagnostics, or an auth error printed before a
+                        // result object was built) so the failure is actionable,
+                        // while preserving the original error's type.
+                        const err = e as Error;
+                        const detail = stderr.trim();
+                        if (detail) {
+                            err.message = `${err.message}\n${detail}`;
+                        }
+                        reject(err);
+                    }
+                })
+            );
+        });
+    }
+}

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
@@ -97,6 +97,10 @@ export interface PythonSetupResult {
     ok: boolean;
     mode: PythonSetupMode;
     dryRun: boolean;
+    // TODO: rename to `compute` (+ PythonSetupTargetInfo -> PythonSetupComputeInfo)
+    // to match SetupLocalInvocation.compute. This field mirrors the CLI's wire
+    // key `target`, so the rename must land in the CLI's --output json first
+    // (with a schemaVersion bump), then here.
     target?: PythonSetupTargetInfo;
     resolved?: PythonSetupResolvedInfo;
     greenfield: boolean;

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
@@ -1,0 +1,104 @@
+import {expect} from "chai";
+import {
+    buildSetupLocalArgs,
+    resolveCliPath,
+    SetupLocalInvocation,
+} from "./setupLocalArgs";
+
+describe("buildSetupLocalArgs", () => {
+    it("builds a default serverless invocation with JSON output", () => {
+        const inv: SetupLocalInvocation = {
+            mode: "default",
+            profile: "dev",
+            compute: {kind: "serverless", version: "5"},
+        };
+        expect(buildSetupLocalArgs(inv)).to.deep.equal([
+            "environments",
+            "setup-local",
+            "--serverless-version",
+            "5",
+            "--profile",
+            "dev",
+            "--output",
+            "json",
+        ]);
+    });
+
+    it("uses --cluster-id for a cluster target", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "cluster", clusterId: "0710-abc"},
+        });
+        const i = args.indexOf("--cluster-id");
+        expect(i).to.be.greaterThan(-1);
+        expect(args[i + 1]).to.equal("0710-abc");
+        expect(args).to.not.include("--serverless-version");
+    });
+
+    it("adds --constraints-only in constraints-only mode", () => {
+        const args = buildSetupLocalArgs({
+            mode: "constraints-only",
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.include("--constraints-only");
+    });
+
+    it("omits --constraints-only in default mode", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.not.include("--constraints-only");
+    });
+
+    it("omits --profile when none is given", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.not.include("--profile");
+    });
+
+    it("passes the hidden --constraint-source-url when provided", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "serverless", version: "5"},
+            constraintSourceUrl: "http://localhost:8077",
+        });
+        const i = args.indexOf("--constraint-source-url");
+        expect(i).to.be.greaterThan(-1);
+        expect(args[i + 1]).to.equal("http://localhost:8077");
+    });
+
+    it("always ends with --output json", () => {
+        const args = buildSetupLocalArgs({
+            mode: "constraints-only",
+            profile: "p",
+            compute: {kind: "cluster", clusterId: "c"},
+            constraintSourceUrl: "u",
+        });
+        expect(args.slice(-2)).to.deep.equal(["--output", "json"]);
+    });
+});
+
+describe("resolveCliPath", () => {
+    it("prefers a non-empty override", () => {
+        expect(
+            resolveCliPath({override: "/custom/databricks", bundled: "/b"})
+        ).to.equal("/custom/databricks");
+    });
+
+    it("trims whitespace and falls back to bundled for a blank override", () => {
+        expect(resolveCliPath({override: "   ", bundled: "/b"})).to.equal("/b");
+    });
+
+    it("falls back to bundled for an empty override", () => {
+        expect(resolveCliPath({override: "", bundled: "/b"})).to.equal("/b");
+    });
+
+    it("falls back to bundled for an undefined override (unset setting)", () => {
+        expect(resolveCliPath({override: undefined, bundled: "/b"})).to.equal(
+            "/b"
+        );
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
@@ -1,0 +1,68 @@
+import {PythonSetupMode} from "../models/PythonSetupResult";
+
+/**
+ * A resolved `environments setup-local` invocation: the mode, the compute
+ * target (cluster or serverless), and optional profile / dev-only
+ * constraint-source override. This is the pure input to
+ * {@link buildSetupLocalArgs}; the gateway turns the argv into a spawned
+ * process.
+ */
+export interface SetupLocalInvocation {
+    mode: PythonSetupMode;
+    profile?: string;
+    compute:
+        | {kind: "cluster"; clusterId: string}
+        | {kind: "serverless"; version: string};
+    /**
+     * Hidden `--constraint-source-url` override (dev/testing only). The
+     * serverless version is passed verbatim as a bare number, e.g. "5" — the
+     * CLI normalizes it to `vN` in its output.
+     */
+    constraintSourceUrl?: string;
+}
+
+/**
+ * Build the argv for `databricks environments setup-local --output json`.
+ * Deterministic and side-effect-free so it is trivially unit-testable; the
+ * order is fixed (compute → mode → profile → source → output) for stable tests.
+ */
+export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
+    const args = ["environments", "setup-local"];
+
+    if (inv.compute.kind === "cluster") {
+        args.push("--cluster-id", inv.compute.clusterId);
+    } else {
+        args.push("--serverless-version", inv.compute.version);
+    }
+
+    if (inv.mode === "constraints-only") {
+        args.push("--constraints-only");
+    }
+    if (inv.profile) {
+        args.push("--profile", inv.profile);
+    }
+    if (inv.constraintSourceUrl) {
+        args.push("--constraint-source-url", inv.constraintSourceUrl);
+    }
+
+    // Always request the machine-readable result last.
+    args.push("--output", "json");
+    return args;
+}
+
+/**
+ * Resolve which `databricks` binary to run: a non-empty override wins,
+ * otherwise the bundled CLI path. The override exists only while the
+ * `setup-local` command is not yet in the bundled CLI (see the
+ * `databricks.experiments.cliPathOverride` setting); this function stays pure —
+ * the config value is read by the caller and passed in.
+ */
+export function resolveCliPath(args: {
+    override: string | undefined;
+    bundled: string;
+}): string {
+    // The override comes from a VS Code setting, so it may be undefined when
+    // unset — coalesce before trimming so this stays a total function.
+    const override = (args.override ?? "").trim();
+    return override.length > 0 ? override : args.bundled;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/venvInterpreterPath.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/venvInterpreterPath.test.ts
@@ -1,0 +1,22 @@
+import {expect} from "chai";
+import {venvInterpreterPath} from "./venvInterpreterPath";
+
+describe("venvInterpreterPath", () => {
+    it("uses Scripts\\python.exe on win32", () => {
+        expect(venvInterpreterPath("C:\\p\\.venv", "win32")).to.equal(
+            "C:\\p\\.venv\\Scripts\\python.exe"
+        );
+    });
+
+    it("uses bin/python on linux", () => {
+        expect(venvInterpreterPath("/p/.venv", "linux")).to.equal(
+            "/p/.venv/bin/python"
+        );
+    });
+
+    it("uses bin/python on darwin", () => {
+        expect(venvInterpreterPath("/p/.venv", "darwin")).to.equal(
+            "/p/.venv/bin/python"
+        );
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/venvInterpreterPath.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/venvInterpreterPath.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+
+/**
+ * The Python interpreter path inside a `.venv`, OS-aware: `Scripts\python.exe`
+ * on Windows, `bin/python` elsewhere. The CLI reports the venv directory
+ * (`venvPath`); the extension needs the concrete interpreter to hand to the MS
+ * Python extension. `platform` is injectable so the behaviour is deterministic
+ * in tests regardless of host OS.
+ */
+export function venvInterpreterPath(
+    venvDir: string,
+    platform: NodeJS.Platform = process.platform
+): string {
+    if (platform === "win32") {
+        return path.win32.join(venvDir, "Scripts", "python.exe");
+    }
+    return path.posix.join(venvDir, "bin", "python");
+}


### PR DESCRIPTION
> **Stacked on #2038** — review that first. This PR's base is `rugpanov/python-setup-error-messages`, so the diff here is only the CLI-client code.

## What

Third task of **M4 — Productionize the VS Code extension**.

The argv/path helpers and the process gateway for driving `databricks environments setup-local`.

- **`utils/setupLocalArgs.ts`** (pure):
  - `buildSetupLocalArgs(invocation)` assembles the argv — target flag (`--cluster-id` or `--serverless-version`) → `--constraints-only` (constraints-only mode) → `--profile` → the hidden `--constraint-source-url` → `--output json`. Serverless version is passed as a bare number (e.g. `5`), per the shipped contract.
  - `resolveCliPath({override, bundled})` prefers a non-empty custom CLI path over the bundled binary. Pure — the config value is read by the caller (the `databricks.experiments.cliPathOverride` setting lands in a later task).
- **`utils/venvInterpreterPath.ts`** (pure): OS-aware interpreter path — `Scripts\python.exe` on Windows, `bin/python` elsewhere; platform injectable.
- **`gateways/PythonSetupCliClient.ts`**: spawns the CLI (injectable spawn seam), captures **stdout → `parsePythonSetupResult`**, forwards **stderr → an `onLog` channel** (for "Show Logs"), resolves with the parsed result on **both success and failure exits** (the caller branches on `result.ok`/`result.error`, not the exit code), rejects on spawn error or unparseable stdout (with captured stderr appended), and terminates the child on cancellation.

## Design note: no live progress under `--output json`

Reading the CLI source (`cmd/environments/output.go`, `libs/localenv/uv.go`) confirmed that in JSON mode the CLI emits **only the final JSON object** on stdout — the per-phase text loop is skipped, and `uv sync` output is buffered (`process.Background`), not streamed. So there is **no live per-phase progress stream** to narrate. Consumers show an indeterminate spinner and read the per-phase outcomes from `result.phases` after the process exits. (The earlier plan's "narrate `=== Phase N ===` stderr lines" idea came from the old POC and does not hold; no phase-narrator is built.)

## Backward compatibility

No user-facing change. New files under `src/python-setup/{utils,gateways}/`; nothing existing is imported or modified. Not wired anywhere yet.

## Verification

- `yarn test:unit` → **325 passing, 0 failing** (argv, path, venv-path, and gateway spawn/parse/cancel cases, incl. two driven by the real CLI golden fixtures).
- `yarn test:lint` → clean.

This pull request and its description were written by Isaac.
