### PR TITLE
test(e2e): harden bundle_variables revert against watcher refresh race

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/bundle_variables.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/bundle_variables.e2e.ts
@@ -250,14 +250,30 @@ describe("Bundle Variables", async function () {
 
         await browser.waitUntil(
             async () => {
-                await assertVariableValue(section, "varWithDefault", {
-                    value: "dev",
-                    defaultValue: "default",
-                });
-                return true;
+                try {
+                    await assertVariableValue(section, "varWithDefault", {
+                        value: "dev",
+                        defaultValue: "default",
+                    });
+                    return true;
+                } catch {
+                    // The tree reverts off the extension's FileSystemWatcher,
+                    // which can lag the reset on a slow/busy shard. Re-trigger
+                    // the "Reset bundle variables to default values" action
+                    // (re-fetched, since the element can go stale across tree
+                    // refreshes), then let the next poll re-check. Resetting
+                    // when already-default is a harmless no-op.
+                    const resetAction = await section.getAction(
+                        "Reset bundle variables to default values"
+                    );
+                    if (resetAction) {
+                        await (await resetAction.elem).click();
+                    }
+                    return false;
+                }
             },
             {
-                timeout: 10_000,
+                timeout: 30_000,
                 interval: 2_000,
                 timeoutMsg: "Variable value not updated",
             }


### PR DESCRIPTION
## Why
`bundle_variables :: should revert overrides` flakes on the Windows shard — the **same FileSystemWatcher refresh race** that #2033 fixed for the sibling `should override default variable`. The test clicks **"Reset bundle variables to default values"** and expects the tree to revert `varWithDefault` to `"dev"`, but within the **10 s** window it still reads the stale `"new value"` because the watcher hadn't refreshed the tree yet.

Seen post-merge on `main` (all of #2032/#2033/#2034 already landed): [run 30004574431](https://github.com/databricks-eng/eng-dev-ecosystem/actions/runs/30004574431) — 31/32 green, the only failure being this test (`+ 'new value' - 'dev'`). #2033 hardened only the override test; this applies the identical pattern to its revert sibling.

## What
- Widen the assertion `waitUntil` **10 s → 30 s**.
- On each still-stale poll, **re-click the (re-fetched) "Reset bundle variables to default values" action** to re-trigger the watcher. Re-fetching guards against a stale element across tree refreshes; resetting when already-default is a harmless no-op.
- The `assertVariableValue` ground-truth assertion is unchanged.

Test-only change; no product code touched.

## Verification
`tsc --noEmit` exit 0; eslint + prettier clean. e2e can't run locally — the `bundle_variables` shard (Linux + Windows) is exercised across repeated isolated CI runs.

This pull request and its description were written by Isaac.