### PR TITLE
[4/?] feat(python-setup): package-manager gating & live detection

### DIFF
--- a/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
+++ b/packages/databricks-vscode/src/language/PackageManagerTelemetry.ts
@@ -1,5 +1,3 @@
-import fs from "node:fs";
-import path from "node:path";
 import {NamedLogger} from "@databricks/sdk-experimental/dist/logging";
 import {Loggers} from "../logger";
 import {Telemetry} from "../telemetry";
@@ -7,15 +5,8 @@ import {ComputeType, SetupTrigger} from "../telemetry/constants";
 import "../telemetry/packageManagerExtensions";
 import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
 import {ResolvedEnvironment} from "./MsPythonExtensionApi";
-import {
-    detectPackageManagers,
-    interpreterUnderCondaPrefix,
-    InterpreterSource,
-    PackageManagerSignals,
-    pyprojectHasPackagingTable,
-    pyprojectHasToolSection,
-    pyvenvCfgMarksUv,
-} from "./packageManagerDetection";
+import {detectPackageManagers} from "./packageManagerDetection";
+import {collectPackageManagerSignals} from "./packageManagerSignals";
 
 export type {SetupTrigger};
 
@@ -78,7 +69,11 @@ export class PackageManagerTelemetry {
             this.emitted.add(dedupeKey);
 
             const env = await this.resolveEnvironment();
-            const signals = this.collectSignals(projectRoot, env);
+            const signals = collectPackageManagerSignals(
+                projectRoot,
+                env,
+                (message, e) => this.logger.debug(message, e)
+            );
             const detection = detectPackageManagers(signals);
 
             this.telemetry.recordPackageManagerDetection(detection, {
@@ -112,169 +107,5 @@ export class PackageManagerTelemetry {
             return undefined;
         }
         return `${version.major}.${version.minor}`;
-    }
-
-    /**
-     * Classify the *active interpreter's* provenance from the resolved
-     * environment alone. This is deliberately independent of project files: a
-     * project carrying `uv.lock` but running a conda/venv/system interpreter
-     * must report that interpreter's real source, so the setup-flow gap ("uv
-     * project, interpreter not uv-managed yet") stays visible. `uv.lock` is
-     * still captured as a strong *project* signal via `hasUvLock`.
-     */
-    private getInterpreterSource(
-        env: ResolvedEnvironment | undefined
-    ): InterpreterSource {
-        if (env?.environment === undefined) {
-            // No managed environment: a global/system interpreter.
-            return env ? "system" : "unknown";
-        }
-
-        const tools = env.tools ?? [];
-        if (env.environment.type === "Conda" || tools.includes("Conda")) {
-            return "conda";
-        }
-        // Poetry envs are venvs, but must be attributed to poetry rather than
-        // collapsed into the generic venv (which the detector reads as pip).
-        if (tools.includes("Poetry")) {
-            return "poetry";
-        }
-        if (
-            tools.includes("Venv") ||
-            tools.includes("VirtualEnv") ||
-            tools.includes("Pipenv") ||
-            env.environment.type === "VirtualEnvironment"
-        ) {
-            // The MS Python extension reports uv-created venvs as plain virtual
-            // environments. Distinguish a genuinely uv-provisioned interpreter
-            // by the `uv = <version>` line uv writes into pyvenv.cfg -- this is
-            // interpreter provenance, not the mere presence of uv.lock.
-            return this.isUvCreatedVenv(env) ? "uv" : "venv";
-        }
-        return "unknown";
-    }
-
-    /**
-     * True if the active venv's pyvenv.cfg marks it as uv-created. Thin fs
-     * wrapper around the pure {@link pyvenvCfgMarksUv}.
-     */
-    private isUvCreatedVenv(env: ResolvedEnvironment): boolean {
-        try {
-            const sysPrefix = env.executable.sysPrefix;
-            if (!sysPrefix) {
-                return false;
-            }
-            const cfg = path.join(sysPrefix, "pyvenv.cfg");
-            if (!fs.existsSync(cfg)) {
-                return false;
-            }
-            return pyvenvCfgMarksUv(fs.readFileSync(cfg, "utf-8"));
-        } catch (e) {
-            this.logger.debug("Failed to read pyvenv.cfg", e);
-            return false;
-        }
-    }
-
-    /**
-     * Gather raw signals from disk and the environment. Each probe is guarded
-     * so a single failure degrades that signal to absent rather than aborting.
-     */
-    private collectSignals(
-        projectRoot: string,
-        env: ResolvedEnvironment | undefined
-    ): PackageManagerSignals {
-        const exists = (file: string) => this.fileExists(projectRoot, file);
-        const interpreterSource = this.getInterpreterSource(env);
-        const pyproject = this.readPyproject(projectRoot);
-
-        const hasPyprojectToolUv = pyprojectHasToolSection(pyproject, "uv");
-        const hasPyprojectToolPoetry = pyprojectHasToolSection(
-            pyproject,
-            "poetry"
-        );
-        // Only attribute pip when the pyproject actually declares packaging
-        // (`[project]`/`[build-system]`); a file with only tool config such as
-        // `[tool.ruff]` is not a pip signal.
-        const hasPyprojectPipOnly =
-            pyprojectHasPackagingTable(pyproject) &&
-            !hasPyprojectToolUv &&
-            !hasPyprojectToolPoetry;
-
-        return {
-            hasUvLock: exists("uv.lock"),
-            hasPyprojectToolUv,
-            // uvOnPath is intentionally left unset: it is a weak signal that
-            // never attributes a project to uv, and probing it would mean
-            // executing a PATH-resolved `uv` binary purely for telemetry.
-            hasPoetryLock: exists("poetry.lock"),
-            hasPyprojectToolPoetry,
-            poetryOnPath: undefined,
-            hasRequirementsTxt: this.hasRequirementsTxt(projectRoot),
-            hasConstraintsTxt: exists("constraints.txt"),
-            hasPyprojectPipOnly,
-            hasCondaEnvFile:
-                exists("environment.yml") || exists("environment.yaml"),
-            hasCondaPrefix: this.hasActiveCondaInterpreter(env),
-            interpreterSource,
-        };
-    }
-
-    /**
-     * Whether the *active interpreter* lives under `CONDA_PREFIX`.
-     *
-     * We deliberately do NOT fire on the bare presence of `CONDA_PREFIX` /
-     * `CONDA_DEFAULT_ENV`: those are session-global in the extension host (set
-     * for every project when VS Code is launched from an activated conda
-     * shell), so using them directly would over-count conda for uv/poetry/pip
-     * projects. Requiring the active interpreter to reside under the prefix
-     * keeps this a project-scoped signal.
-     */
-    private hasActiveCondaInterpreter(
-        env: ResolvedEnvironment | undefined
-    ): boolean {
-        return interpreterUnderCondaPrefix(
-            env?.executable.sysPrefix,
-            process.env["CONDA_PREFIX"]
-        );
-    }
-
-    private fileExists(projectRoot: string, file: string): boolean {
-        try {
-            return fs.existsSync(path.join(projectRoot, file));
-        } catch (e) {
-            this.logger.debug(`Failed to stat ${file}`, e);
-            return false;
-        }
-    }
-
-    /**
-     * True if any pip-style requirements file exists in the project root:
-     * `requirements.txt` or a separator-suffixed variant such as
-     * `requirements-dev.txt` / `requirements_test.txt` / `requirements.ci.txt`.
-     * Deliberately does not match `requirementsfoo.txt` (no separator), which
-     * isn't a conventional requirements file.
-     */
-    private hasRequirementsTxt(projectRoot: string): boolean {
-        try {
-            return fs
-                .readdirSync(projectRoot)
-                .some((name) => /^requirements([-_.].+)?\.txt$/.test(name));
-        } catch (e) {
-            this.logger.debug("Failed to list project root", e);
-            return false;
-        }
-    }
-
-    private readPyproject(projectRoot: string): string | undefined {
-        try {
-            const file = path.join(projectRoot, "pyproject.toml");
-            if (!fs.existsSync(file)) {
-                return undefined;
-            }
-            return fs.readFileSync(file, "utf-8");
-        } catch (e) {
-            this.logger.debug("Failed to read pyproject.toml", e);
-            return undefined;
-        }
     }
 }

--- a/packages/databricks-vscode/src/language/packageManagerSignals.ts
+++ b/packages/databricks-vscode/src/language/packageManagerSignals.ts
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+import {ResolvedEnvironment} from "./MsPythonExtensionApi";
+import {
+    interpreterUnderCondaPrefix,
+    InterpreterSource,
+    PackageManagerSignals,
+    pyprojectHasPackagingTable,
+    pyprojectHasToolSection,
+    pyvenvCfgMarksUv,
+} from "./packageManagerDetection";
+
+/**
+ * Optional sink for best-effort probe failures. A collector callsite that has a
+ * logger (the telemetry emitter, the extension host) passes one so failed
+ * probes are visible in debug logs; callers that don't (unit tests) omit it.
+ * Every failure here is non-fatal — the signal simply degrades to absent.
+ */
+export type SignalDebugLog = (message: string, error: unknown) => void;
+
+const noopLog: SignalDebugLog = () => {};
+
+/**
+ * Gather raw package-manager signals from disk and the resolved interpreter.
+ *
+ * Single-sourced collection layer: both {@link PackageManagerTelemetry} (for
+ * the detection telemetry event) and the live python-setup gate detector call
+ * this, so the two never drift. Pure w.r.t. its inputs apart from the disk
+ * reads it performs; every probe is individually guarded so one failure
+ * degrades that signal to absent/`false` rather than aborting the whole
+ * collection or throwing into the caller's flow.
+ */
+export function collectPackageManagerSignals(
+    projectRoot: string,
+    env: ResolvedEnvironment | undefined,
+    log: SignalDebugLog = noopLog
+): PackageManagerSignals {
+    const exists = (file: string) => fileExists(projectRoot, file, log);
+    const interpreterSource = getInterpreterSource(env, log);
+    const pyproject = readPyproject(projectRoot, log);
+
+    const hasPyprojectToolUv = pyprojectHasToolSection(pyproject, "uv");
+    const hasPyprojectToolPoetry = pyprojectHasToolSection(pyproject, "poetry");
+    // Only attribute pip when the pyproject actually declares packaging
+    // (`[project]`/`[build-system]`); a file with only tool config such as
+    // `[tool.ruff]` is not a pip signal.
+    const hasPyprojectPipOnly =
+        pyprojectHasPackagingTable(pyproject) &&
+        !hasPyprojectToolUv &&
+        !hasPyprojectToolPoetry;
+
+    return {
+        hasUvLock: exists("uv.lock"),
+        hasPyprojectToolUv,
+        // uvOnPath is intentionally left unset: it is a weak signal that never
+        // attributes a project to uv, and probing it would mean executing a
+        // PATH-resolved `uv` binary purely for this classification.
+        hasPoetryLock: exists("poetry.lock"),
+        hasPyprojectToolPoetry,
+        poetryOnPath: undefined,
+        hasRequirementsTxt: hasRequirementsTxt(projectRoot, log),
+        hasConstraintsTxt: exists("constraints.txt"),
+        hasPyprojectPipOnly,
+        hasCondaEnvFile:
+            exists("environment.yml") || exists("environment.yaml"),
+        hasCondaPrefix: hasActiveCondaInterpreter(env),
+        interpreterSource,
+    };
+}
+
+/**
+ * Classify the *active interpreter's* provenance from the resolved environment
+ * alone. This is deliberately independent of project files: a project carrying
+ * `uv.lock` but running a conda/venv/system interpreter must report that
+ * interpreter's real source, so the setup-flow gap ("uv project, interpreter
+ * not uv-managed yet") stays visible. `uv.lock` is still captured as a strong
+ * *project* signal via `hasUvLock`.
+ */
+function getInterpreterSource(
+    env: ResolvedEnvironment | undefined,
+    log: SignalDebugLog
+): InterpreterSource {
+    if (env?.environment === undefined) {
+        // No managed environment: a global/system interpreter.
+        return env ? "system" : "unknown";
+    }
+
+    const tools = env.tools ?? [];
+    if (env.environment.type === "Conda" || tools.includes("Conda")) {
+        return "conda";
+    }
+    // Poetry envs are venvs, but must be attributed to poetry rather than
+    // collapsed into the generic venv (which the detector reads as pip).
+    if (tools.includes("Poetry")) {
+        return "poetry";
+    }
+    if (
+        tools.includes("Venv") ||
+        tools.includes("VirtualEnv") ||
+        tools.includes("Pipenv") ||
+        env.environment.type === "VirtualEnvironment"
+    ) {
+        // The MS Python extension reports uv-created venvs as plain virtual
+        // environments. Distinguish a genuinely uv-provisioned interpreter by
+        // the `uv = <version>` line uv writes into pyvenv.cfg -- this is
+        // interpreter provenance, not the mere presence of uv.lock.
+        return isUvCreatedVenv(env, log) ? "uv" : "venv";
+    }
+    return "unknown";
+}
+
+/**
+ * True if the active venv's pyvenv.cfg marks it as uv-created. Thin fs wrapper
+ * around the pure {@link pyvenvCfgMarksUv}.
+ */
+function isUvCreatedVenv(
+    env: ResolvedEnvironment,
+    log: SignalDebugLog
+): boolean {
+    try {
+        const sysPrefix = env.executable.sysPrefix;
+        if (!sysPrefix) {
+            return false;
+        }
+        const cfg = path.join(sysPrefix, "pyvenv.cfg");
+        if (!fs.existsSync(cfg)) {
+            return false;
+        }
+        return pyvenvCfgMarksUv(fs.readFileSync(cfg, "utf-8"));
+    } catch (e) {
+        log("Failed to read pyvenv.cfg", e);
+        return false;
+    }
+}
+
+/**
+ * Whether the *active interpreter* lives under `CONDA_PREFIX`.
+ *
+ * We deliberately do NOT fire on the bare presence of `CONDA_PREFIX` /
+ * `CONDA_DEFAULT_ENV`: those are session-global in the extension host (set for
+ * every project when VS Code is launched from an activated conda shell), so
+ * using them directly would over-count conda for uv/poetry/pip projects.
+ * Requiring the active interpreter to reside under the prefix keeps this a
+ * project-scoped signal.
+ */
+function hasActiveCondaInterpreter(
+    env: ResolvedEnvironment | undefined
+): boolean {
+    return interpreterUnderCondaPrefix(
+        env?.executable.sysPrefix,
+        process.env["CONDA_PREFIX"]
+    );
+}
+
+function fileExists(
+    projectRoot: string,
+    file: string,
+    log: SignalDebugLog
+): boolean {
+    try {
+        return fs.existsSync(path.join(projectRoot, file));
+    } catch (e) {
+        log(`Failed to stat ${file}`, e);
+        return false;
+    }
+}
+
+/**
+ * True if any pip-style requirements file exists in the project root:
+ * `requirements.txt` or a separator-suffixed variant such as
+ * `requirements-dev.txt` / `requirements_test.txt` / `requirements.ci.txt`.
+ * Deliberately does not match `requirementsfoo.txt` (no separator), which isn't
+ * a conventional requirements file.
+ */
+function hasRequirementsTxt(projectRoot: string, log: SignalDebugLog): boolean {
+    try {
+        return fs
+            .readdirSync(projectRoot)
+            .some((name) => /^requirements([-_.].+)?\.txt$/.test(name));
+    } catch (e) {
+        log("Failed to list project root", e);
+        return false;
+    }
+}
+
+function readPyproject(
+    projectRoot: string,
+    log: SignalDebugLog
+): string | undefined {
+    try {
+        const file = path.join(projectRoot, "pyproject.toml");
+        if (!fs.existsSync(file)) {
+            return undefined;
+        }
+        return fs.readFileSync(file, "utf-8");
+    } catch (e) {
+        log("Failed to read pyproject.toml", e);
+        return undefined;
+    }
+}

--- a/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.test.ts
@@ -1,0 +1,61 @@
+import {expect} from "chai";
+import {PythonSetupManagerDetector} from "./PythonSetupManagerDetector";
+
+// A fake collector lets us drive the detector's classification wiring without
+// touching disk or the MS Python extension.
+describe("PythonSetupManagerDetector", () => {
+    it("returns uv primary for uv-lock signals", async () => {
+        const detector = new PythonSetupManagerDetector(async () => ({
+            hasUvLock: true,
+        }));
+
+        const result = await detector.detect("/proj");
+
+        expect(result.primary).to.equal("uv");
+        expect(result.managers).to.deep.equal(["uv"]);
+    });
+
+    it("returns unknown with no managers for a greenfield project", async () => {
+        const detector = new PythonSetupManagerDetector(async () => ({}));
+
+        const result = await detector.detect("/proj");
+
+        expect(result.primary).to.equal("unknown");
+        expect(result.managers).to.deep.equal([]);
+    });
+
+    it("reports every co-existing manager (uv + pip)", async () => {
+        const detector = new PythonSetupManagerDetector(async () => ({
+            hasUvLock: true,
+            hasRequirementsTxt: true,
+        }));
+
+        const result = await detector.detect("/proj");
+
+        expect(result.primary).to.equal("uv");
+        expect(result.managers).to.deep.equal(["uv", "pip"]);
+    });
+
+    it("degrades to unknown when signal collection throws", async () => {
+        const detector = new PythonSetupManagerDetector(async () => {
+            throw new Error("disk error");
+        });
+
+        const result = await detector.detect("/proj");
+
+        expect(result.primary).to.equal("unknown");
+        expect(result.managers).to.deep.equal([]);
+    });
+
+    it("passes the project root through to the collector", async () => {
+        const seen: string[] = [];
+        const detector = new PythonSetupManagerDetector(async (root) => {
+            seen.push(root);
+            return {};
+        });
+
+        await detector.detect("/some/where");
+
+        expect(seen).to.deep.equal(["/some/where"]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.ts
@@ -1,0 +1,40 @@
+import {
+    detectPackageManagers,
+    PackageManagerDetection,
+    PackageManagerSignals,
+} from "../../language/packageManagerDetection";
+
+/**
+ * Gathers the package-manager signals for a project root. Injected so the
+ * detector's classification wiring is unit-testable without disk access or the
+ * MS Python extension; the extension wires a real collector that resolves the
+ * active interpreter and calls `collectPackageManagerSignals`.
+ */
+export type SignalCollector = (
+    projectRoot: string
+) => Promise<PackageManagerSignals>;
+
+/**
+ * Live package-manager detection for the python-setup visibility gate.
+ *
+ * Thin async shell over the pure {@link detectPackageManagers}: it collects the
+ * project's signals via the injected {@link SignalCollector}, classifies them,
+ * and returns only the fields the gate needs. Detection is best-effort and must
+ * never disrupt the setup/config-view flow, so any collection failure degrades
+ * to `unknown`/`[]` (which the gate reads as "greenfield" — safe to offer).
+ */
+export class PythonSetupManagerDetector {
+    constructor(private readonly collect: SignalCollector) {}
+
+    async detect(
+        projectRoot: string
+    ): Promise<Pick<PackageManagerDetection, "primary" | "managers">> {
+        try {
+            const signals = await this.collect(projectRoot);
+            const {primary, managers} = detectPackageManagers(signals);
+            return {primary, managers};
+        } catch {
+            return {primary: "unknown", managers: []};
+        }
+    }
+}

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
@@ -1,0 +1,85 @@
+import {expect} from "chai";
+import {
+    PackageManager,
+    PrimaryManager,
+} from "../../language/packageManagerDetection";
+import {shouldShowPythonSetup} from "./pythonSetupGate";
+
+const det = (primary: PrimaryManager, managers: PackageManager[]) => ({
+    primary,
+    managers,
+});
+
+describe("shouldShowPythonSetup", () => {
+    it("shows for a clean uv project when the flag is on", () => {
+        expect(
+            shouldShowPythonSetup({flagOn: true, detection: det("uv", ["uv"])})
+        ).to.equal(true);
+    });
+
+    it("shows for an unknown/greenfield project when the flag is on", () => {
+        expect(
+            shouldShowPythonSetup({flagOn: true, detection: det("unknown", [])})
+        ).to.equal(true);
+    });
+
+    it("hides when the flag is off, even for a clean uv project", () => {
+        expect(
+            shouldShowPythonSetup({flagOn: false, detection: det("uv", ["uv"])})
+        ).to.equal(false);
+    });
+
+    it("hides for a pip project", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("pip", ["pip"]),
+            })
+        ).to.equal(false);
+    });
+
+    it("hides for a uv project that also has pip (competing manager)", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("uv", ["uv", "pip"]),
+            })
+        ).to.equal(false);
+    });
+
+    it("hides for a uv project running a conda interpreter", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("uv", ["uv", "conda"]),
+            })
+        ).to.equal(false);
+    });
+
+    it("hides for a uv project that also uses poetry", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("uv", ["uv", "poetry"]),
+            })
+        ).to.equal(false);
+    });
+
+    it("hides for a poetry project", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("poetry", ["poetry"]),
+            })
+        ).to.equal(false);
+    });
+
+    it("hides for a conda project", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("conda", ["conda"]),
+            })
+        ).to.equal(false);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
@@ -1,0 +1,41 @@
+import {
+    PackageManager,
+    PackageManagerDetection,
+} from "../../language/packageManagerDetection";
+
+/**
+ * Managers whose presence means the project is already committed to a
+ * non-uv workflow. If any of these fired, we must not offer uv-native setup —
+ * it would fight the tool the project already uses (pip/poetry/conda). The
+ * legacy pip checklist covers those projects instead; the two entry points are
+ * mutually exclusive and never shown together.
+ */
+const COMPETING_MANAGERS: PackageManager[] = ["pip", "poetry", "conda"];
+
+/**
+ * Whether to surface the uv-native python-setup entry for the current project.
+ *
+ * Pure predicate over the feature flag and the live detection result. Shows
+ * only when all hold:
+ *  - the feature flag is on (the whole feature is opt-in while the CLI command
+ *    ships only in custom builds), AND
+ *  - the primary manager is `uv` or `unknown` (a clean uv project, or a
+ *    greenfield project with no manager yet — the two cases uv-native setup
+ *    fits), AND
+ *  - no competing manager (pip/poetry/conda) fired at all. Even a uv-primary
+ *    project is excluded if it also shows pip/conda/poetry signals, so setup
+ *    never fights an environment the project already depends on.
+ */
+export function shouldShowPythonSetup(args: {
+    flagOn: boolean;
+    detection: Pick<PackageManagerDetection, "primary" | "managers">;
+}): boolean {
+    if (!args.flagOn) {
+        return false;
+    }
+    const {primary, managers} = args.detection;
+    if (primary !== "uv" && primary !== "unknown") {
+        return false;
+    }
+    return !managers.some((m) => COMPETING_MANAGERS.includes(m));
+}


### PR DESCRIPTION
## Why

The upcoming uv-native "set up Python environment" feature must be offered only
when it fits the project, and never alongside the legacy pip checklist. This PR
adds the two decision pieces — a live package-manager classification of the
active project, and the pure gate predicate the config view will consult — plus
the refactor that lets the detector and the existing detection telemetry share
one signal-collection layer instead of drifting.

This is additive: nothing here is wired into the extension yet (that lands with
the orchestrator + config-view dispatch), so there is no user-facing behavior
change. The whole feature stays behind a flag; this PR only supplies the
building blocks.

## What

- **Extract the shared collector** — move the private disk+interpreter signal
  collection out of `PackageManagerTelemetry` into
  `language/packageManagerSignals.ts` (`collectPackageManagerSignals`), with an
  injectable debug-log sink so callers without a logger (tests) can omit it.
  `PackageManagerTelemetry` now calls it; behavior is unchanged and its existing
  tests pass untouched.
- **Live detector** — `python-setup/utils/PythonSetupManagerDetector.ts`: a thin
  async shell over the pure `detectPackageManagers`, driven by an injected
  signal collector, returning `{primary, managers}`. Any collection failure
  degrades to `{unknown, []}` so detection never disrupts the flow.
- **Gate predicate** — `python-setup/utils/pythonSetupGate.ts`
  (`shouldShowPythonSetup`): show only when the flag is on, the primary manager
  is `uv` or `unknown`, and no competing manager (pip/poetry/conda) fired. This
  is the single point that keeps uv-native setup and the legacy pip checklist
  mutually exclusive.

## Verification

- `yarn --cwd packages/databricks-vscode test:unit` — 319 passing (14 new:
  5 detector, 9 gate; the unchanged `PackageManagerTelemetry` suite included).
- `yarn --cwd packages/databricks-vscode test:lint` — clean.
- `yarn --cwd packages/databricks-vscode build` — clean.

This pull request and its description were written by Isaac.