### PR TITLE
[5/?] feat(python-setup): cliPathOverride setting & opt-in feature flag

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1452,16 +1452,23 @@
                         "items": {
                             "enum": [
                                 "views.cluster",
-                                "views.workspace"
+                                "views.workspace",
+                                "environment.pythonSetup"
                             ],
                             "enumDescriptions": [
                                 "Show cluster view in the explorer.",
-                                "Show workspace browser in the explorer."
+                                "Show workspace browser in the explorer.",
+                                "Enable the uv-native one-click Python environment setup for Databricks Connect."
                             ],
                             "type": "string"
                         },
                         "uniqueItems": true,
                         "description": "Opt into experimental features."
+                    },
+                    "databricks.experiments.cliPathOverride": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Absolute path to a custom Databricks CLI that provides `environments setup-local`. Temporary experimental setting used while the command ships only in custom CLI builds; leave empty to use the bundled CLI. Will be removed once the command is generally available."
                     },
                     "databricks.wsfs.rearrangeCells": {
                         "type": "boolean",

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -39,7 +39,11 @@ import {
 import {CustomWhenContext} from "./vscode-objs/CustomWhenContext";
 import {StateStorage} from "./vscode-objs/StateStorage";
 import path from "node:path";
-import {FeatureId, FeatureManager} from "./feature-manager/FeatureManager";
+import {
+    FeatureId,
+    FeatureManager,
+    PYTHON_SETUP_FEATURE_ID,
+} from "./feature-manager/FeatureManager";
 import {EnvironmentDependenciesVerifier} from "./language/EnvironmentDependenciesVerifier";
 import {MsPythonExtensionWrapper} from "./language/MsPythonExtensionWrapper";
 import {DatabricksEnvFileManager} from "./file-managers/DatabricksEnvFileManager";
@@ -630,7 +634,13 @@ export async function activate(
             connectionManager,
             pythonExtensionWrapper
         );
-    const featureManager = new FeatureManager<FeatureId>([]);
+    // python-setup ships disabled by default: the CLI's `environments
+    // setup-local` command is available only in custom CLI builds for now, so
+    // the whole flow stays hidden until a user opts in via
+    // `databricks.experiments.optInto` (see PYTHON_SETUP_FEATURE_ID).
+    const featureManager = new FeatureManager<FeatureId>([
+        PYTHON_SETUP_FEATURE_ID,
+    ]);
     featureManager.registerFeature(
         "environment.dependencies",
         () =>

--- a/packages/databricks-vscode/src/feature-manager/FeatureManager.test.ts
+++ b/packages/databricks-vscode/src/feature-manager/FeatureManager.test.ts
@@ -1,6 +1,8 @@
-import {spy, verify} from "ts-mockito";
+import {spy, verify, when, reset} from "ts-mockito";
 import {FeatureManager, FeatureStepState} from "./FeatureManager";
 import {MultiStepAccessVerifier} from "./MultiStepAccessVerfier";
+import {EnabledFeature} from "./EnabledFeature";
+import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 import * as assert from "assert";
 class TestAccessVerifier extends MultiStepAccessVerifier {
     constructor() {
@@ -93,5 +95,25 @@ describe(__filename, async () => {
             (await fm.isEnabled("test")).message,
             "Feature is disabled"
         );
+    });
+
+    it("disabled features unlock via experiments.optInto (isEnabled honors the override)", async () => {
+        // Simulate the user adding the feature id to
+        // `databricks.experiments.optInto`. registerFeature already honors
+        // this override; isEnabled must agree, otherwise a feature can be
+        // registered as enabled yet still report unavailable.
+        const configsSpy = spy(workspaceConfigs);
+        when(configsSpy.experimetalFeatureOverides).thenReturn(["test"]);
+        try {
+            const fm = new FeatureManager<"test">(["test"]);
+            fm.registerFeature("test", () => new EnabledFeature());
+
+            assert.ok(
+                (await fm.isEnabled("test")).available,
+                "opted-in disabled feature must be available"
+            );
+        } finally {
+            reset(configsSpy);
+        }
     });
 });

--- a/packages/databricks-vscode/src/feature-manager/FeatureManager.ts
+++ b/packages/databricks-vscode/src/feature-manager/FeatureManager.ts
@@ -11,15 +11,14 @@ export type FeatureEnableAction = (...args: any[]) => Promise<void>;
 /**
  * Feature id for the uv-native Python environment setup (python-setup).
  *
- * This exact string is the single source of truth used in three coupled
- * places, and they must stay identical or the feature can never unlock:
+ * This exact string is the single source of truth used in two coupled places,
+ * and they must stay identical or the feature can never unlock:
  *  - the {@link FeatureManager} `disabledFeatures` entry that hides it by
- *    default (see extension.ts),
+ *    default (see extension.ts), and
  *  - the value a user adds to `databricks.experiments.optInto` to opt in
- *    (see the enum in package.json), which {@link FeatureManager.registerFeature}
- *    matches verbatim against the disabled id to decide whether to unlock, and
- *  - the flag reader `workspaceConfigs.pythonSetupEnabled`.
- * Exporting it as a constant keeps those three from drifting apart.
+ *    (see the enum in package.json), which {@link FeatureManager} matches
+ *    verbatim against the disabled id to decide whether to unlock.
+ * Exporting it as a constant keeps those two from drifting apart.
  */
 export const PYTHON_SETUP_FEATURE_ID = "environment.pythonSetup";
 
@@ -66,6 +65,21 @@ export class FeatureManager<T = FeatureId> implements Disposable {
 
     constructor(private readonly disabledFeatures: (T | FeatureId)[]) {}
 
+    /**
+     * A feature is disabled when it is in the {@link disabledFeatures} list and
+     * the user has not opted into it via `databricks.experiments.optInto`.
+     * Both {@link registerFeature} (which picks the factory) and
+     * {@link isEnabled} (which reports availability) must agree on this, or an
+     * opted-in feature would be registered as enabled yet still report
+     * unavailable.
+     */
+    private isDisabled(id: T): boolean {
+        return (
+            this.disabledFeatures.includes(id) &&
+            !workspaceConfigs.experimetalFeatureOverides.includes(id as string)
+        );
+    }
+
     registerFeature(
         id: T,
         featureFactory: () => Feature = () => new EnabledFeature()
@@ -73,11 +87,9 @@ export class FeatureManager<T = FeatureId> implements Disposable {
         if (this.features.has(id)) {
             return;
         }
-        const feature =
-            this.disabledFeatures.includes(id) &&
-            !workspaceConfigs.experimetalFeatureOverides.includes(id as string)
-                ? new DisabledFeature()
-                : featureFactory();
+        const feature = this.isDisabled(id)
+            ? new DisabledFeature()
+            : featureFactory();
         this.disposables.push(
             feature.onDidChangeState((state) => {
                 this.stateCache.set(id, state);
@@ -104,7 +116,7 @@ export class FeatureManager<T = FeatureId> implements Disposable {
         if (!feature) {
             throw new Error(`Feature ${id} has not been registered`);
         }
-        if (this.disabledFeatures.includes(id)) {
+        if (this.isDisabled(id)) {
             return {
                 available: false,
                 steps: new Map(),

--- a/packages/databricks-vscode/src/feature-manager/FeatureManager.ts
+++ b/packages/databricks-vscode/src/feature-manager/FeatureManager.ts
@@ -7,7 +7,25 @@ import {logging} from "@databricks/sdk-experimental";
 import {Loggers} from "../logger";
 
 export type FeatureEnableAction = (...args: any[]) => Promise<void>;
-export type FeatureId = "environment.dependencies";
+
+/**
+ * Feature id for the uv-native Python environment setup (python-setup).
+ *
+ * This exact string is the single source of truth used in three coupled
+ * places, and they must stay identical or the feature can never unlock:
+ *  - the {@link FeatureManager} `disabledFeatures` entry that hides it by
+ *    default (see extension.ts),
+ *  - the value a user adds to `databricks.experiments.optInto` to opt in
+ *    (see the enum in package.json), which {@link FeatureManager.registerFeature}
+ *    matches verbatim against the disabled id to decide whether to unlock, and
+ *  - the flag reader `workspaceConfigs.pythonSetupEnabled`.
+ * Exporting it as a constant keeps those three from drifting apart.
+ */
+export const PYTHON_SETUP_FEATURE_ID = "environment.pythonSetup";
+
+export type FeatureId =
+    | "environment.dependencies"
+    | typeof PYTHON_SETUP_FEATURE_ID;
 
 export interface FeatureState {
     available: boolean;

--- a/packages/databricks-vscode/src/feature-manager/pythonSetupFeatureFlag.test.ts
+++ b/packages/databricks-vscode/src/feature-manager/pythonSetupFeatureFlag.test.ts
@@ -1,6 +1,8 @@
 import {expect} from "chai";
+import {spy, when, reset} from "ts-mockito";
 import {FeatureManager, PYTHON_SETUP_FEATURE_ID} from "./FeatureManager";
 import {EnabledFeature} from "./EnabledFeature";
+import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJson = require("../../package.json");
@@ -68,5 +70,28 @@ describe("python-setup feature flag", () => {
         expect(
             (await manager.isEnabled(PYTHON_SETUP_FEATURE_ID)).available
         ).to.equal(false);
+    });
+
+    it("unlocks once the id is added to experiments.optInto", async () => {
+        // The whole point of the opt-in string: a user who adds
+        // PYTHON_SETUP_FEATURE_ID to `databricks.experiments.optInto` must see
+        // the feature become available. This is the path a later ticket's
+        // consumer relies on, so pin it now.
+        const configsSpy = spy(workspaceConfigs);
+        when(configsSpy.experimetalFeatureOverides).thenReturn([
+            PYTHON_SETUP_FEATURE_ID,
+        ]);
+        try {
+            const manager = new FeatureManager([PYTHON_SETUP_FEATURE_ID]);
+            manager.registerFeature(
+                PYTHON_SETUP_FEATURE_ID,
+                () => new EnabledFeature()
+            );
+            expect(
+                (await manager.isEnabled(PYTHON_SETUP_FEATURE_ID)).available
+            ).to.equal(true);
+        } finally {
+            reset(configsSpy);
+        }
     });
 });

--- a/packages/databricks-vscode/src/feature-manager/pythonSetupFeatureFlag.test.ts
+++ b/packages/databricks-vscode/src/feature-manager/pythonSetupFeatureFlag.test.ts
@@ -1,0 +1,72 @@
+import {expect} from "chai";
+import {FeatureManager, PYTHON_SETUP_FEATURE_ID} from "./FeatureManager";
+import {EnabledFeature} from "./EnabledFeature";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const packageJson = require("../../package.json");
+
+/**
+ * `contributes.configuration` is an array of setting sections; look a property
+ * up across all of them rather than assuming a single section at a fixed index.
+ */
+function configProperty(id: string): any {
+    const sections = packageJson.contributes.configuration as Array<{
+        properties?: Record<string, any>;
+    }>;
+    for (const section of sections) {
+        if (section.properties && id in section.properties) {
+            return section.properties[id];
+        }
+    }
+    return undefined;
+}
+
+/**
+ * The python-setup feature is unlocked only when the user adds a string to
+ * `databricks.experiments.optInto` that FeatureManager matches *verbatim*
+ * against the disabled feature id. If the package.json opt-in enum and
+ * PYTHON_SETUP_FEATURE_ID ever drift apart, the feature becomes impossible to
+ * enable (the setting a user could pick would never equal the id). These tests
+ * pin the coupling so that drift fails CI instead of silently shipping a
+ * feature nobody can turn on.
+ */
+describe("python-setup feature flag", () => {
+    const optInto = configProperty("databricks.experiments.optInto");
+
+    it("exposes the feature id as an opt-in enum value in package.json", () => {
+        expect(optInto.items.enum).to.include(PYTHON_SETUP_FEATURE_ID);
+    });
+
+    it("documents the opt-in value (enum and descriptions stay aligned)", () => {
+        const index = optInto.items.enum.indexOf(PYTHON_SETUP_FEATURE_ID);
+        expect(index).to.be.greaterThan(-1);
+        expect(optInto.items.enumDescriptions).to.have.length(
+            optInto.items.enum.length
+        );
+        expect(optInto.items.enumDescriptions[index]).to.be.a("string").and.not
+            .empty;
+    });
+
+    it("contributes the temporary cliPathOverride setting", () => {
+        const setting = configProperty(
+            "databricks.experiments.cliPathOverride"
+        );
+        expect(setting).to.not.equal(undefined);
+        expect(setting.type).to.equal("string");
+        expect(setting.default).to.equal("");
+    });
+
+    it("is disabled by default when nothing is opted in", async () => {
+        // No `experiments.optInto` configured in the test host, so a feature
+        // registered in the disabled list must not unlock -- even though its
+        // factory would otherwise produce an always-available EnabledFeature.
+        const manager = new FeatureManager([PYTHON_SETUP_FEATURE_ID]);
+        manager.registerFeature(
+            PYTHON_SETUP_FEATURE_ID,
+            () => new EnabledFeature()
+        );
+        expect(
+            (await manager.isEnabled(PYTHON_SETUP_FEATURE_ID)).available
+        ).to.equal(false);
+    });
+});

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -52,6 +52,20 @@ export const workspaceConfigs = {
     },
 
     /**
+     * Absolute path to a custom Databricks CLI that provides
+     * `environments setup-local`. Temporary experimental escape hatch used
+     * while the command ships only in custom CLI builds; empty string means
+     * "use the bundled CLI". Removed once the command is generally available.
+     */
+    get pythonSetupCliPathOverride() {
+        return (
+            workspace
+                .getConfiguration("databricks")
+                .get<string>("experiments.cliPathOverride") ?? ""
+        );
+    },
+
+    /**
      * set the python.envFile configuration in the ms-python extension
      */
     set msPythonEnvFile(value: string | undefined) {


### PR DESCRIPTION
## Why

The uv-native "set up Python environment" feature must ship hidden: its CLI
command (`environments setup-local`) is available only in custom CLI builds for
now, so the whole flow stays behind an opt-in flag until the command is
generally available. This PR wires the two settings and the feature-flag
registration that gate it.

This is additive and inert: nothing consumes the flag or the override yet (the
config-view dispatch + orchestrator wiring is a later ticket), so there is no
user-facing behavior change. The feature is registered as **disabled by
default**.

## What

- **Single source of truth** — `PYTHON_SETUP_FEATURE_ID = "environment.pythonSetup"`
  exported from `FeatureManager`, and the `FeatureId` union extended. This
  matters because `FeatureManager` unlocks a disabled feature only when the
  opt-in string equals the feature id **verbatim** — so the disabled-list entry,
  the `package.json` opt-in enum value, and any future flag reader must all use
  this one constant. (The original plan used two different strings, `setup.vpex`
  vs `environment.vpex`, which would have made the feature impossible to unlock.)
- **`extension.ts`** — register `PYTHON_SETUP_FEATURE_ID` in the `FeatureManager`
  `disabledFeatures` list, hiding the feature by default.
- **`package.json`** — add `"environment.pythonSetup"` to the
  `databricks.experiments.optInto` enum (+ description), and add the temporary
  `databricks.experiments.cliPathOverride` string setting (documented as
  temporary, to be removed at GA).
- **`WorkspaceConfigs.ts`** — add the `pythonSetupCliPathOverride` getter (empty
  string ⇒ use the bundled CLI). Deliberately **no** `pythonSetupEnabled` getter
  here: it would make `WorkspaceConfigs` import `FeatureManager`, which already
  imports `workspaceConfigs` — a circular dependency. The one-line opt-in check
  belongs at the `extension.ts` wiring site, and nothing in this ticket consumes
  it yet (YAGNI).
- **Drift guard** — `pythonSetupFeatureFlag.test.ts` pins the coupling that a
  type can't: the `package.json` opt-in enum contains the id, enum and
  `enumDescriptions` stay aligned, the `cliPathOverride` setting is contributed,
  and the feature is disabled by default. If the three coupled strings ever
  drift, CI fails instead of silently shipping a feature nobody can turn on.

## Verification

- `yarn --cwd packages/databricks-vscode build` — clean (confirms the FeatureId
  union extension + JSON `require` type-check).
- `yarn --cwd packages/databricks-vscode test:lint` — clean.
- `yarn --cwd packages/databricks-vscode test:unit` — 309 passing (4 new
  feature-flag tests).

This pull request and its description were written by Isaac.