### PR TITLE
[6/?] feat(python-setup): setup orchestrator (first CLI-client caller)

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -1,0 +1,447 @@
+import {expect} from "chai";
+import {
+    PythonSetupEnvironmentSetup,
+    PythonSetupSetupDeps,
+} from "./PythonSetupEnvironmentSetup";
+import {
+    CancellationLike,
+    PythonSetupCancelledError,
+    RunOptions,
+} from "../gateways/PythonSetupCliClient";
+import {PythonSetupResult} from "../models/PythonSetupResult";
+import {
+    SUCCESS_REAL_RUN,
+    ERROR_NO_TARGET,
+} from "../models/fixtures/setupLocalResults";
+import {SetupLocalInvocation} from "../utils/setupLocalArgs";
+
+/**
+ * A never-cancelled {@link CancellationLike} that can be flipped via `cancel()`,
+ * firing its listeners — the shape the real `window.withProgress` token has.
+ */
+function makeToken(): CancellationLike & {cancel(): void} {
+    const listeners: Array<() => void> = [];
+    let cancelled = false;
+    return {
+        get isCancellationRequested() {
+            return cancelled;
+        },
+        onCancellationRequested(listener: () => void) {
+            listeners.push(listener);
+            return {dispose() {}};
+        },
+        cancel() {
+            cancelled = true;
+            listeners.forEach((l) => l());
+        },
+    };
+}
+
+/**
+ * A recording fake of the one method the orchestrator calls on the CLI client.
+ * `run` is scripted to resolve with a fixture (or reject, for cancellation),
+ * and it captures the invocation *and* the {@link RunOptions} it was handed so
+ * tests can assert the argv the orchestrator built and that `cwd` / `onLog` /
+ * `token` are threaded through.
+ */
+function makeCli(
+    outcome: {resolve: PythonSetupResult} | {reject: Error} = {
+        resolve: SUCCESS_REAL_RUN,
+    }
+) {
+    const calls: SetupLocalInvocation[] = [];
+    const options: RunOptions[] = [];
+    return {
+        calls,
+        options,
+        run: async (invocation: SetupLocalInvocation, opts: RunOptions) => {
+            calls.push(invocation);
+            options.push(opts);
+            if ("reject" in outcome) {
+                throw outcome.reject;
+            }
+            return outcome.resolve;
+        },
+    };
+}
+
+function makeDeps(
+    overrides: Partial<PythonSetupSetupDeps> = {}
+): PythonSetupSetupDeps {
+    return {
+        cli: makeCli(),
+        projectRoot: () => "/proj",
+        // Default seams model a connected serverless session that opted in.
+        isVisible: async () => true,
+        resolveCompute: async () => ({kind: "serverless", version: "5"}),
+        adoptInterpreter: async () => {},
+        saveState: () => {},
+        showError: async () => {},
+        showSuccess: async () => {},
+        // Mirror the production wrapper: hand the task a log sink and a
+        // (never-cancelled) progress token.
+        withProgress: async (_title, task) => task(() => {}, makeToken()),
+        ...overrides,
+    };
+}
+
+describe("PythonSetupEnvironmentSetup.setup", () => {
+    it("runs the CLI and marks ready on a successful real run", async () => {
+        const cli = makeCli({resolve: SUCCESS_REAL_RUN});
+        const adopted: string[] = [];
+        const saved: Array<{envKey: string; pythonVersion: string}> = [];
+        const succeeded: PythonSetupResult[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                adoptInterpreter: async (p) => {
+                    adopted.push(p);
+                },
+                saveState: (s) => {
+                    saved.push(s);
+                },
+                showSuccess: async (r) => {
+                    succeeded.push(r);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(true);
+        expect(cli.calls).to.have.length(1);
+        // Serverless version "5" flows into the invocation the client runs.
+        expect(cli.calls[0].compute).to.deep.equal({
+            kind: "serverless",
+            version: "5",
+        });
+        // cwd (the project root) and an onLog sink are threaded into the run.
+        expect(cli.options[0].cwd).to.equal("/proj");
+        expect(cli.options[0].onLog).to.be.a("function");
+        expect(adopted).to.deep.equal([SUCCESS_REAL_RUN.venvPath]);
+        expect(saved).to.deep.equal([
+            {
+                envKey: SUCCESS_REAL_RUN.target!.envKey,
+                pythonVersion: SUCCESS_REAL_RUN.resolved!.pythonVersion,
+            },
+        ]);
+        // The success is announced, with the parsed result.
+        expect(succeeded).to.deep.equal([SUCCESS_REAL_RUN]);
+    });
+
+    it("does nothing when there is no open project", async () => {
+        const cli = makeCli();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({cli, projectRoot: () => undefined})
+        );
+
+        await setup.setup();
+
+        expect(cli.calls).to.have.length(0);
+        expect(setup.ready).to.equal(false);
+    });
+
+    it("does not run the CLI when the gate is closed", async () => {
+        const cli = makeCli();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({cli, isVisible: async () => false})
+        );
+
+        await setup.setup();
+
+        expect(cli.calls).to.have.length(0);
+        expect(setup.ready).to.equal(false);
+    });
+
+    it("does not run when no compute could be resolved", async () => {
+        const cli = makeCli();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({cli, resolveCompute: async () => undefined})
+        );
+
+        await setup.setup();
+
+        expect(cli.calls).to.have.length(0);
+        expect(setup.ready).to.equal(false);
+    });
+
+    it("surfaces a mapped error message on CLI failure and stays not-ready", async () => {
+        const shownErrors: string[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: ERROR_NO_TARGET}),
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(false);
+        expect(shownErrors).to.have.length(1);
+        // The mapped, user-facing copy for E_NO_TARGET (not the raw CLI text).
+        expect(shownErrors[0]).to.contain(
+            "Select a cluster or serverless compute"
+        );
+    });
+
+    it("surfaces the raw error message when the CLI run rejects", async () => {
+        const shownErrors: string[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                // A spawn/parse rejection (not a cancellation): no result to map.
+                cli: makeCli({reject: new Error("spawn databricks ENOENT")}),
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(false);
+        expect(shownErrors).to.deep.equal(["spawn databricks ENOENT"]);
+    });
+
+    it("treats a success without a venv path as a failure", async () => {
+        const shownErrors: string[] = [];
+        const adopted: string[] = [];
+        const saved: PythonSetupResult[] = [];
+        const succeeded: PythonSetupResult[] = [];
+        // An ok:true result that carries no venvPath (e.g. a dry-run shape or
+        // CLI/schema drift): there is no interpreter to adopt.
+        const withoutVenv: PythonSetupResult = {
+            ...SUCCESS_REAL_RUN,
+            venvPath: undefined,
+        };
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: withoutVenv}),
+                adoptInterpreter: async (p) => {
+                    adopted.push(p);
+                },
+                saveState: () => {
+                    saved.push(withoutVenv);
+                },
+                showSuccess: async (r) => {
+                    succeeded.push(r);
+                },
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(false);
+        expect(adopted).to.have.length(0);
+        // Neither the drift baseline nor the success announcement fire.
+        expect(saved).to.have.length(0);
+        expect(succeeded).to.have.length(0);
+        // The generic fallback copy (the result's `error` is null on an ok run).
+        expect(shownErrors).to.deep.equal(["Python environment setup failed."]);
+    });
+
+    it("treats a success missing target/resolved as a failure", async () => {
+        const shownErrors: string[] = [];
+        const adopted: string[] = [];
+        const saved: unknown[] = [];
+        // ok:true with a venvPath but no target/resolved: we could adopt an
+        // interpreter, but drift detection would have no baseline to persist —
+        // so this is treated as a failure rather than a hollow "ready".
+        const withoutBaseline: PythonSetupResult = {
+            ...SUCCESS_REAL_RUN,
+            target: undefined,
+            resolved: undefined,
+        };
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: withoutBaseline}),
+                adoptInterpreter: async (p) => {
+                    adopted.push(p);
+                },
+                saveState: (s) => {
+                    saved.push(s);
+                },
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(false);
+        // No interpreter is adopted and no baseline is persisted.
+        expect(adopted).to.have.length(0);
+        expect(saved).to.have.length(0);
+        expect(shownErrors).to.have.length(1);
+    });
+
+    it("stays not-ready and shows no error when the run is cancelled", async () => {
+        const shownErrors: string[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({reject: new PythonSetupCancelledError()}),
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(setup.ready).to.equal(false);
+        // Cancellation is a user action, not a failure — no error toast.
+        expect(shownErrors).to.have.length(0);
+    });
+
+    it("threads the progress cancellation token through to cli.run", async () => {
+        const shownErrors: string[] = [];
+        const token = makeToken();
+        // A client that honours the token the way the real one does: reject with
+        // PythonSetupCancelledError once cancellation has been requested.
+        const cli = {
+            calls: [] as SetupLocalInvocation[],
+            options: [] as RunOptions[],
+            run: async (invocation: SetupLocalInvocation, opts: RunOptions) => {
+                cli.calls.push(invocation);
+                cli.options.push(opts);
+                if (opts.token?.isCancellationRequested) {
+                    throw new PythonSetupCancelledError();
+                }
+                return SUCCESS_REAL_RUN;
+            },
+        };
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+                // Model a user who clicked "Cancel" on the progress notification
+                // before the CLI got going.
+                withProgress: async (_title, task) => {
+                    token.cancel();
+                    return task(() => {}, token);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        // The same token the progress indicator owns reached the client...
+        expect(cli.options[0].token).to.equal(token);
+        // ...and a token-driven cancellation is silent, exactly like a rejection.
+        expect(setup.ready).to.equal(false);
+        expect(shownErrors).to.have.length(0);
+    });
+
+    it("fires onDidChangeState when it becomes ready", async () => {
+        let fired = 0;
+        const setup = new PythonSetupEnvironmentSetup(makeDeps());
+        setup.onDidChangeState(() => {
+            fired += 1;
+        });
+
+        await setup.setup();
+
+        expect(fired).to.equal(1);
+    });
+
+    it("coalesces overlapping setup() calls onto a single CLI run", async () => {
+        let release: (r: PythonSetupResult) => void = () => {};
+        const gate = new Promise<PythonSetupResult>((res) => {
+            release = res;
+        });
+        const cli = {
+            calls: [] as SetupLocalInvocation[],
+            run: (invocation: SetupLocalInvocation) => {
+                cli.calls.push(invocation);
+                return gate;
+            },
+        };
+        const setup = new PythonSetupEnvironmentSetup(makeDeps({cli}));
+
+        // Two overlapping invocations while the first run is still in-flight.
+        const first = setup.setup();
+        const second = setup.setup();
+        release(SUCCESS_REAL_RUN);
+        await Promise.all([first, second]);
+
+        // Only one project-mutating CLI process was started.
+        expect(cli.calls).to.have.length(1);
+
+        // Once the in-flight run settles, a later call starts a fresh run.
+        await setup.setup();
+        expect(cli.calls).to.have.length(2);
+    });
+
+    it("clears the in-flight guard even when a run rejects", async () => {
+        const cli = makeCli({resolve: SUCCESS_REAL_RUN});
+        // isVisible runs outside runSetup()'s try/catch, so a throw here rejects
+        // runSetup — the path that must still clear `inFlight` (via the finally)
+        // so a later call is not deadlocked.
+        let failNext = true;
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                isVisible: async () => {
+                    if (failNext) {
+                        failNext = false;
+                        throw new Error("gate blew up");
+                    }
+                    return true;
+                },
+            })
+        );
+
+        let rejected = false;
+        try {
+            await setup.setup();
+        } catch {
+            rejected = true;
+        }
+        expect(rejected).to.equal(true);
+        expect(cli.calls).to.have.length(0);
+
+        // The guard was cleared despite the rejection: a fresh run proceeds.
+        await setup.setup();
+        expect(cli.calls).to.have.length(1);
+        expect(setup.ready).to.equal(true);
+    });
+
+    it("surfaces an error and stays not-ready when interpreter adoption fails", async () => {
+        const shownErrors: string[] = [];
+        const saved: unknown[] = [];
+        const succeeded: PythonSetupResult[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: SUCCESS_REAL_RUN}),
+                adoptInterpreter: async () => {
+                    throw new Error("could not select interpreter");
+                },
+                saveState: (s) => {
+                    saved.push(s);
+                },
+                showSuccess: async (r) => {
+                    succeeded.push(r);
+                },
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        // A provisioned-but-unadopted env is a failure: show the error, and do
+        // not persist state, flip ready, or announce success.
+        expect(setup.ready).to.equal(false);
+        expect(shownErrors).to.deep.equal(["could not select interpreter"]);
+        expect(saved).to.have.length(0);
+        expect(succeeded).to.have.length(0);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -1,0 +1,212 @@
+import {Disposable, Event, EventEmitter} from "vscode";
+import {
+    CancellationLike,
+    PythonSetupCancelledError,
+    RunOptions,
+} from "../gateways/PythonSetupCliClient";
+import {
+    isPythonSetupSuccess,
+    PythonSetupResult,
+} from "../models/PythonSetupResult";
+import {getPythonSetupErrorMessage} from "../utils/errorMessages";
+import {SetupLocalInvocation} from "../utils/setupLocalArgs";
+
+/**
+ * The one method the orchestrator needs from {@link PythonSetupCliClient}, typed
+ * structurally so the flow is unit-testable without a spawn/`vscode` dependency.
+ */
+export interface CliRunner {
+    run(
+        invocation: SetupLocalInvocation,
+        options: RunOptions
+    ): Promise<PythonSetupResult>;
+}
+
+export type SetupCompute = SetupLocalInvocation["compute"];
+
+/** Persisted after a successful setup, for later drift detection. */
+export interface PythonSetupPersistedState {
+    envKey: string;
+    pythonVersion: string;
+}
+
+type ReadyLocalEnvironmentResult = PythonSetupResult &
+    Required<Pick<PythonSetupResult, "venvPath" | "target" | "resolved">>;
+
+function isLocalEnvironmentReady(
+    r: PythonSetupResult
+): r is ReadyLocalEnvironmentResult {
+    return (
+        isPythonSetupSuccess(r) &&
+        r.venvPath !== undefined &&
+        r.target !== undefined &&
+        r.resolved !== undefined
+    );
+}
+
+/**
+ * Runs under a progress indicator, forwarding `log` to the client's `onLog` and
+ * `token` to its `RunOptions.token` so a user "Cancel" tears down the CLI. The
+ * production wrapper is `window.withProgress` + an output channel.
+ */
+export type ProgressTask<T> = (
+    log: (chunk: string) => void,
+    token: CancellationLike
+) => Promise<T>;
+
+/**
+ * Injected collaborators for {@link PythonSetupEnvironmentSetup}: seams so the
+ * flow is tested without a VS Code host, and so the not-yet-built pieces
+ * (visibility gate, serverless-version selection) can be stubbed until their
+ * own tickets wire the real implementations in.
+ */
+export interface PythonSetupSetupDeps {
+    cli: CliRunner;
+
+    /** Absolute path of the open project the CLI runs against, if any. */
+    projectRoot: () => string | undefined;
+
+    /**
+     * Whether the uv-native setup should run for the current project.
+     *
+     * TODO(#2044): replace the wiring-site stub with
+     * `shouldShowPythonSetup({flagOn: workspaceConfigs.pythonSetupEnabled,
+     * detection: await detector.detect(projectRoot)})`. Until then the extension
+     * passes a stub that returns `false`, so the feature is inert end-to-end.
+     */
+    isVisible: () => Promise<boolean>;
+
+    /**
+     * The compute target to provision for, or `undefined` to abort silently
+     * (nothing selected / the user dismissed the picker).
+     *
+     * TODO(#2052 / #2053): for a serverless session this must resolve the version
+     * via the serverless-version picker (`scoreServerlessVersions` +
+     * `pickServerlessVersion`). Until that ticket lands the extension passes a
+     * stub that returns `undefined`, so a serverless setup is a no-op; the
+     * cluster case can already return `{kind: "cluster", clusterId}`.
+     */
+    resolveCompute: () => Promise<SetupCompute | undefined>;
+
+    /** Point the MS Python extension at the provisioned venv interpreter. */
+    adoptInterpreter: (venvPath: string) => Promise<void>;
+
+    saveState: (state: PythonSetupPersistedState) => void;
+
+    /** Shows the mapped, user-facing copy — not raw CLI text. */
+    showError: (message: string) => Promise<void>;
+
+    showSuccess: (result: PythonSetupResult) => Promise<void>;
+
+    withProgress: <T>(title: string, task: ProgressTask<T>) => Promise<T>;
+}
+
+/**
+ * Orchestrates the uv-native "set up Python environment" flow: decide whether
+ * to run, resolve the compute target, invoke the CLI under a progress
+ * indicator, then adopt the provisioned interpreter and persist state on
+ * success — or surface a mapped error on failure.
+ */
+export class PythonSetupEnvironmentSetup implements Disposable {
+    private _ready = false;
+    /** True once a setup has completed successfully this session. */
+    get ready(): boolean {
+        return this._ready;
+    }
+
+    private readonly stateEmitter = new EventEmitter<void>();
+    /** Fires when {@link ready} flips to true. */
+    readonly onDidChangeState: Event<void> = this.stateEmitter.event;
+
+    /**
+     * The in-flight run, if any. `setup-local` mutates the project, so
+     * overlapping runs against the same cwd would race each other's writes;
+     * {@link setup} coalesces onto this instead of spawning a second process.
+     */
+    private inFlight: Promise<void> | undefined;
+
+    constructor(private readonly deps: PythonSetupSetupDeps) {}
+
+    setup(): Promise<void> {
+        // Re-entrancy guard: coalesce concurrent callers onto the running run
+        // rather than spawning a second project-mutating CLI process.
+        if (this.inFlight) {
+            return this.inFlight;
+        }
+        const run = this.runSetup().finally(() => {
+            this.inFlight = undefined;
+        });
+        this.inFlight = run;
+        return run;
+    }
+
+    private async runSetup(): Promise<void> {
+        const {cli, projectRoot, isVisible, resolveCompute, withProgress} =
+            this.deps;
+
+        const cwd = projectRoot();
+        if (cwd === undefined) {
+            return;
+        }
+        // Gate first: never touch the project or prompt when the feature is not
+        // meant to be offered here.
+        if (!(await isVisible())) {
+            return;
+        }
+
+        const compute = await resolveCompute();
+        if (compute === undefined) {
+            return;
+        }
+
+        const invocation: SetupLocalInvocation = {
+            mode: "default",
+            compute,
+        };
+
+        let result: PythonSetupResult;
+        try {
+            result = await withProgress(
+                "Setting up Python environment",
+                (log, token) => cli.run(invocation, {cwd, onLog: log, token})
+            );
+        } catch (e) {
+            // A cancelled run is a user action, not a failure: stay quiet.
+            if (e instanceof PythonSetupCancelledError) {
+                return;
+            }
+            // Spawn/parse errors reject with a real Error carrying CLI stderr;
+            // there is no result to map, so surface the message directly.
+            await this.deps.showError((e as Error).message);
+            return;
+        }
+
+        if (!isLocalEnvironmentReady(result)) {
+            await this.deps.showError(getPythonSetupErrorMessage(result));
+            return;
+        }
+
+        // Adoption is the point of the flow: without it the venv exists on disk
+        // but is unusable from the editor, so a failure here is a setup failure —
+        // surface it and stay not-ready rather than rejecting with no message.
+        try {
+            await this.deps.adoptInterpreter(result.venvPath);
+        } catch (e) {
+            await this.deps.showError((e as Error).message);
+            return;
+        }
+
+        this.deps.saveState({
+            envKey: result.target.envKey,
+            pythonVersion: result.resolved.pythonVersion,
+        });
+
+        this._ready = true;
+        this.stateEmitter.fire();
+        await this.deps.showSuccess(result);
+    }
+
+    dispose(): void {
+        this.stateEmitter.dispose();
+    }
+}


### PR DESCRIPTION
> **Stacked on #2039** (base = `rugpanov/python-setup-cli-client`). Review after #2039; the diff of interest is the single `controllers/` commit on top. Once #2039 merges, GitHub retargets this to `main` automatically.

## Why

#2039 adds `PythonSetupCliClient` with no call site — as raised in review, the API is hard to judge without seeing it used. This PR adds the orchestrator that actually drives the client end-to-end, so the client's usage ships alongside it.

## What

`PythonSetupEnvironmentSetup` (`python-setup/controllers/`) — the first real caller of `PythonSetupCliClient`:

1. gate → resolve compute → `cli.run(invocation, {cwd, onLog})` under a progress indicator,
2. on success: adopt the provisioned venv interpreter + persist `{envKey, pythonVersion}` for drift detection,
3. on failure: surface the mapped `getPythonSetupErrorMessage` copy,
4. `PythonSetupCancelledError` → treated as a silent user action (no error toast).

It consumes the **real** client surface (`run(invocation{compute}, {cwd, onLog})`, `isPythonSetupSuccess`, `getPythonSetupErrorMessage`), and depends on the client **structurally** (`CliRunner`) so the flow is unit-testable without spawn/`vscode`.

### The two not-yet-built pieces are injected seams, not hard deps

Per the agreed approach, the gate and serverless-version selection are stubbed behind injected functions with explicit TODOs, so this PR stacks only on the CLI-client change and doesn't pull in unbuilt tickets:

- `isVisible()` — **TODO(DECO-27781 / #2044):** `shouldShowPythonSetup(...)`. The wiring stub returns `false`, so the feature is **inert end-to-end** for now.
- `resolveCompute()` — **TODO(DECO-27782):** serverless-version picker (`scoreServerlessVersions` + `pickServerlessVersion`). The wiring stub returns `undefined`, so a serverless setup is a no-op until that ticket; the cluster case can already resolve.

The real gate and picker drop in through these seams in their own tickets (and the extension.ts wiring lands in DECO-27786). Nothing is wired into the extension in this PR.

## Verification

- `yarn --cwd packages/databricks-vscode test:unit` — 344 passing (6 new orchestrator cases: success→ready+adopt+saveState, gate-closed→no run, no-compute→no run, CLI failure→mapped error, cancel→silent, `onDidChangeState` fires).
- `test:lint` — clean · `build` — clean.

This pull request and its description were written by Isaac.