### PR TITLE
[7/?] feat(python-setup): serverless version resolution & picker

### DIFF
--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
@@ -1,0 +1,45 @@
+import {expect} from "chai";
+import {buildVersionPickItems} from "./serverlessVersionPicker";
+
+describe("buildVersionPickItems", () => {
+    it("pre-picks the top candidate and shows its provenance", () => {
+        const items = buildVersionPickItems([
+            {version: "4", score: 150, sources: ["bundleYaml", "notebook"]},
+            {version: "5", score: 20, sources: ["workspaceDefault"]},
+        ]);
+
+        expect(items[0].version).to.equal("4");
+        expect(items[0].picked).to.equal(true);
+        // Multi-source provenance is summarised in the description.
+        expect(items[0].description).to.match(/bundle|notebook|2 source/i);
+        expect(items[1].version).to.equal("5");
+        expect(items[1].picked).to.equal(false);
+    });
+
+    it("labels each item with the bare version and only stars the picked one", () => {
+        const items = buildVersionPickItems([
+            {version: "5", score: 100, sources: ["bundleYaml"]},
+            {version: "4", score: 50, sources: ["notebook"]},
+        ]);
+
+        // The picked item is visually marked; others are the plain version.
+        expect(items[0].label).to.contain("5");
+        expect(items[0].label).to.not.equal(items[0].version);
+        expect(items[1].label).to.equal("4");
+    });
+
+    it("handles a fallback-only list", () => {
+        const items = buildVersionPickItems([
+            {version: "5", score: 1, sources: ["fallback"]},
+        ]);
+
+        expect(items).to.have.length(1);
+        expect(items[0].version).to.equal("5");
+        expect(items[0].picked).to.equal(true);
+        expect(items[0].description).to.match(/fallback|default/i);
+    });
+
+    it("returns no items for an empty ranking", () => {
+        expect(buildVersionPickItems([])).to.deep.equal([]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
@@ -2,13 +2,16 @@ import {expect} from "chai";
 import {buildVersionPickItems} from "./serverlessVersionPicker";
 
 describe("buildVersionPickItems", () => {
-    it("pre-picks the top candidate and shows its provenance", () => {
+    it("marks the top candidate as the recommendation and shows its provenance", () => {
         const items = buildVersionPickItems([
             {version: "4", score: 150, sources: ["bundleYaml", "notebook"]},
             {version: "5", score: 20, sources: ["workspaceDefault"]},
         ]);
 
         expect(items[0].version).to.equal("4");
+        // `picked` is set on the top row (cosmetic in single-select, but kept
+        // for completeness); the star label + first-position ordering are the
+        // actual recommendation cues.
         expect(items[0].picked).to.equal(true);
         // Multi-source provenance is summarised in the description.
         expect(items[0].description).to.match(/bundle|notebook|2 source/i);

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
@@ -31,11 +31,15 @@ function describeSources(sources: VersionSource[]): string {
 }
 
 /**
- * Build the QuickPick rows for a ranked version list (pure, so the labelling
- * and pre-selection are unit-testable without a VS Code host). The first, i.e.
- * highest-scoring, candidate is pre-picked and visually starred; every row
- * carries its bare `version` for the caller to forward to the CLI, and a
- * `description` summarising where the version came from.
+ * Build the QuickPick rows for a ranked version list (pure, so the labelling is
+ * unit-testable without a VS Code host). The first, i.e. highest-scoring,
+ * candidate is marked as the recommendation: it is listed first and visually
+ * starred. (`picked` is also set for completeness, but note `showQuickPick`
+ * only honours it in multi-select mode -- see {@link pickServerlessVersion} --
+ * so in this single-select picker the star and ordering are what actually
+ * signal the recommendation.) Every row carries its bare `version` for the
+ * caller to forward to the CLI, and a `description` summarising where the
+ * version came from.
  */
 export function buildVersionPickItems(
     ranked: ScoredVersion[]
@@ -53,9 +57,10 @@ export function buildVersionPickItems(
 
 /**
  * Show an always-visible, ranked serverless-version QuickPick with the top
- * candidate pre-selected, and return the confirmed bare version (or undefined
- * if the user dismissed it). Selection is never silent -- the user must
- * confirm, matching the "no silent auto-selection" requirement.
+ * candidate presented as the recommendation (starred, listed first, and named
+ * in the placeholder), and return the confirmed bare version (or undefined if
+ * the user dismissed it). Selection is never silent -- the user must actively
+ * confirm a row, matching the "no silent auto-selection" requirement.
  */
 export async function pickServerlessVersion(
     ranked: ScoredVersion[]

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
@@ -1,0 +1,72 @@
+import {window} from "vscode";
+import {ScoredVersion, VersionSource} from "./serverlessVersionScoring";
+
+/** A pick item derived from a scored version; `version` is the bare value. */
+export interface VersionPickItem {
+    label: string;
+    description: string;
+    version: string;
+    picked: boolean;
+}
+
+/** Human-readable provenance labels (the enum keys are internal jargon). */
+const SOURCE_LABELS: Record<VersionSource, string> = {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    bundleYaml: "bundle config",
+    notebook: "notebook metadata",
+    workspaceDefault: "workspace default",
+    fallback: "default",
+    /* eslint-enable @typescript-eslint/naming-convention */
+};
+
+function describeSources(sources: VersionSource[]): string {
+    const labels = sources.map((s) => SOURCE_LABELS[s]);
+    if (labels.length === 0) {
+        return "";
+    }
+    if (labels.length === 1) {
+        return `from ${labels[0]}`;
+    }
+    return `from ${labels.length} sources: ${labels.join(", ")}`;
+}
+
+/**
+ * Build the QuickPick rows for a ranked version list (pure, so the labelling
+ * and pre-selection are unit-testable without a VS Code host). The first, i.e.
+ * highest-scoring, candidate is pre-picked and visually starred; every row
+ * carries its bare `version` for the caller to forward to the CLI, and a
+ * `description` summarising where the version came from.
+ */
+export function buildVersionPickItems(
+    ranked: ScoredVersion[]
+): VersionPickItem[] {
+    return ranked.map((r, i) => {
+        const picked = i === 0;
+        return {
+            label: picked ? `$(star-full) ${r.version}` : r.version,
+            description: describeSources(r.sources),
+            version: r.version,
+            picked,
+        };
+    });
+}
+
+/**
+ * Show an always-visible, ranked serverless-version QuickPick with the top
+ * candidate pre-selected, and return the confirmed bare version (or undefined
+ * if the user dismissed it). Selection is never silent -- the user must
+ * confirm, matching the "no silent auto-selection" requirement.
+ */
+export async function pickServerlessVersion(
+    ranked: ScoredVersion[]
+): Promise<string | undefined> {
+    const items = buildVersionPickItems(ranked);
+    if (items.length === 0) {
+        return undefined;
+    }
+    const selected = await window.showQuickPick(items, {
+        title: "Select serverless environment version",
+        placeHolder: `Recommended: ${items[0].version}`,
+    });
+    return selected?.version;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -13,24 +13,38 @@ function makeDeps(
 } {
     let collectCalls = 0;
     const pickedRankings: ScoredVersion[][] = [];
-    const deps: ServerlessVersionResolverDeps = {
+    const base: ServerlessVersionResolverDeps = {
         isEnabled: () => true,
-        collectObservations: async () => {
-            collectCalls += 1;
-            return [] as VersionObservation[];
-        },
+        collectObservations: async () => [] as VersionObservation[],
         pick: async (ranked) => {
             pickedRankings.push(ranked);
             return ranked[0]?.version;
         },
         ...overrides,
     };
-    return Object.assign(deps, {
-        get collectCalls() {
-            return collectCalls;
+    // Wrap the (possibly overridden) collector so the call count reflects real
+    // invocations regardless of which collector a test supplies.
+    const collect = base.collectObservations;
+    const deps: ServerlessVersionResolverDeps = {
+        ...base,
+        collectObservations: async () => {
+            collectCalls += 1;
+            return collect();
         },
-        pickedRankings,
+    };
+    const probe = deps as ServerlessVersionResolverDeps & {
+        collectCalls: number;
+        pickedRankings: ScoredVersion[][];
+    };
+    probe.pickedRankings = pickedRankings;
+    // Define a *live* accessor: `Object.assign` would invoke the getter once and
+    // copy its current value (0), freezing `collectCalls` at 0 and making the
+    // "collection is skipped when disabled" assertion a tautology.
+    Object.defineProperty(probe, "collectCalls", {
+        get: () => collectCalls,
+        enumerable: true,
     });
+    return probe;
 }
 
 describe("resolveServerlessVersion", () => {
@@ -65,6 +79,10 @@ describe("resolveServerlessVersion", () => {
 
         // bundleYaml (100) outranks notebook (50), so "4" is recommended.
         expect(version).to.equal("4");
+        // The live counter proves collection actually ran (and that the
+        // disabled-path assertion below is observing a real value, not a frozen
+        // 0): the enabled path must collect exactly once.
+        expect(deps.collectCalls).to.equal(1);
     });
 
     it("offers the fallback candidate even when nothing was observed", async () => {

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -53,18 +53,19 @@ describe("resolveServerlessVersion", () => {
         const deps = makeDeps({
             collectObservations: async () => [
                 {version: "4", source: "bundleYaml"},
-                {version: "6", source: "notebook"},
+                {version: "3", source: "notebook"},
             ],
             pick: async (ranked) => ranked[0].version,
         });
 
         const version = await resolveServerlessVersion(deps);
 
+        // Both versions are in range, so this genuinely exercises weighting:
         // bundleYaml (100) outranks notebook (50), so "4" is recommended.
         expect(version).to.equal("4");
-        // The live counter proves collection actually ran (and that the
-        // disabled-path assertion below is observing a real value, not a frozen
-        // 0): the enabled path must collect exactly once.
+        // The live counter proves collection ran exactly once -- the collector
+        // runs during resolve (after makeDeps wires this accessor), so a plain
+        // snapshot copy would read a stale 0.
         expect(deps.collectCalls).to.equal(1);
     });
 

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -14,7 +14,6 @@ function makeDeps(
     let collectCalls = 0;
     const pickedRankings: ScoredVersion[][] = [];
     const base: ServerlessVersionResolverDeps = {
-        isEnabled: () => true,
         collectObservations: async () => [] as VersionObservation[],
         pick: async (ranked) => {
             pickedRankings.push(ranked);
@@ -37,9 +36,8 @@ function makeDeps(
         pickedRankings: ScoredVersion[][];
     };
     probe.pickedRankings = pickedRankings;
-    // Define a *live* accessor: `Object.assign` would invoke the getter once and
-    // copy its current value (0), freezing `collectCalls` at 0 and making the
-    // "collection is skipped when disabled" assertion a tautology.
+    // Define a *live* accessor so `collectCalls` reflects real invocations at
+    // assert time (a plain copy would freeze it at 0).
     Object.defineProperty(probe, "collectCalls", {
         get: () => collectCalls,
         enumerable: true,
@@ -48,24 +46,9 @@ function makeDeps(
 }
 
 describe("resolveServerlessVersion", () => {
-    it("returns undefined and does nothing when the feature is disabled", async () => {
-        let picked = false;
-        const deps = makeDeps({
-            isEnabled: () => false,
-            pick: async () => {
-                picked = true;
-                return "5";
-            },
-        });
-
-        const version = await resolveServerlessVersion(deps);
-
-        expect(version).to.equal(undefined);
-        // The gate short-circuits before any collection or UI.
-        expect(deps.collectCalls).to.equal(0);
-        expect(picked).to.equal(false);
-    });
-
+    // The feature-flag gate is the caller's responsibility (see
+    // ConnectionCommands.selectServerless); this function is only invoked when
+    // the flow is active, so it always collects, scores, and offers a pick.
     it("scores collected observations and returns the confirmed version", async () => {
         const deps = makeDeps({
             collectObservations: async () => [

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -1,0 +1,94 @@
+import {expect} from "chai";
+import {
+    resolveServerlessVersion,
+    ServerlessVersionResolverDeps,
+} from "./serverlessVersionResolver";
+import {ScoredVersion, VersionObservation} from "./serverlessVersionScoring";
+
+function makeDeps(
+    overrides: Partial<ServerlessVersionResolverDeps> = {}
+): ServerlessVersionResolverDeps & {
+    collectCalls: number;
+    pickedRankings: ScoredVersion[][];
+} {
+    let collectCalls = 0;
+    const pickedRankings: ScoredVersion[][] = [];
+    const deps: ServerlessVersionResolverDeps = {
+        isEnabled: () => true,
+        collectObservations: async () => {
+            collectCalls += 1;
+            return [] as VersionObservation[];
+        },
+        pick: async (ranked) => {
+            pickedRankings.push(ranked);
+            return ranked[0]?.version;
+        },
+        ...overrides,
+    };
+    return Object.assign(deps, {
+        get collectCalls() {
+            return collectCalls;
+        },
+        pickedRankings,
+    });
+}
+
+describe("resolveServerlessVersion", () => {
+    it("returns undefined and does nothing when the feature is disabled", async () => {
+        let picked = false;
+        const deps = makeDeps({
+            isEnabled: () => false,
+            pick: async () => {
+                picked = true;
+                return "5";
+            },
+        });
+
+        const version = await resolveServerlessVersion(deps);
+
+        expect(version).to.equal(undefined);
+        // The gate short-circuits before any collection or UI.
+        expect(deps.collectCalls).to.equal(0);
+        expect(picked).to.equal(false);
+    });
+
+    it("scores collected observations and returns the confirmed version", async () => {
+        const deps = makeDeps({
+            collectObservations: async () => [
+                {version: "4", source: "bundleYaml"},
+                {version: "6", source: "notebook"},
+            ],
+            pick: async (ranked) => ranked[0].version,
+        });
+
+        const version = await resolveServerlessVersion(deps);
+
+        // bundleYaml (100) outranks notebook (50), so "4" is recommended.
+        expect(version).to.equal("4");
+    });
+
+    it("offers the fallback candidate even when nothing was observed", async () => {
+        const deps = makeDeps({
+            collectObservations: async () => [],
+        });
+
+        const version = await resolveServerlessVersion(deps);
+
+        // The ranking handed to the picker always contains the fallback "5".
+        expect(deps.pickedRankings[0].map((r) => r.version)).to.include("5");
+        expect(version).to.equal("5");
+    });
+
+    it("returns undefined when the user dismisses the picker", async () => {
+        const deps = makeDeps({
+            collectObservations: async () => [
+                {version: "5", source: "workspaceDefault"},
+            ],
+            pick: async () => undefined,
+        });
+
+        const version = await resolveServerlessVersion(deps);
+
+        expect(version).to.equal(undefined);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
@@ -1,0 +1,64 @@
+import {workspaceConfigs} from "../../vscode-objs/WorkspaceConfigs";
+import {PYTHON_SETUP_FEATURE_ID} from "../../feature-manager/FeatureManager";
+import {
+    scoreServerlessVersions,
+    VersionObservation,
+} from "./serverlessVersionScoring";
+
+/**
+ * Whether the user has opted into the uv-native Python environment setup.
+ *
+ * The feature ships disabled by default (its CLI command is only in custom CLI
+ * builds); it unlocks when {@link PYTHON_SETUP_FEATURE_ID} is present in
+ * `databricks.experiments.optInto`. This is the same string the FeatureManager
+ * matches to unlock the feature, so the flag can never disagree with it. Kept
+ * in `python-setup/` rather than on `workspaceConfigs` to avoid a circular
+ * import (WorkspaceConfigs <-> FeatureManager).
+ */
+export function isPythonSetupEnabled(): boolean {
+    return workspaceConfigs.experimetalFeatureOverides.includes(
+        PYTHON_SETUP_FEATURE_ID
+    );
+}
+
+/**
+ * Injected collaborators for {@link resolveServerlessVersion}. The feature
+ * gate, the (I/O-bound) observation collection, and the QuickPick are all seams
+ * so the resolution flow is unit-testable without a VS Code host, and the
+ * pieces wired at the extension site can be swapped in later.
+ */
+export interface ServerlessVersionResolverDeps {
+    /** Feature-flag gate; defaults to {@link isPythonSetupEnabled} in prod. */
+    isEnabled: () => boolean;
+    /** Gather raw version observations (bundle YAML, notebooks, workspace default). */
+    collectObservations: () => Promise<VersionObservation[]>;
+    /** Present the ranked candidates and return the confirmed bare version. */
+    pick: (
+        ranked: ReturnType<typeof scoreServerlessVersions>
+    ) => Promise<string | undefined>;
+}
+
+/**
+ * Resolve the serverless environment version to provision: gate on the feature
+ * flag, collect observations, score them, and let the user confirm a candidate.
+ * Returns the confirmed bare version (e.g. "5", the `--serverless-version`
+ * value) or `undefined` when the feature is disabled or the user dismisses the
+ * picker.
+ *
+ * The flag gate is checked first, before any collection or UI, so with the
+ * feature off the resolver is completely inert -- no disk reads, no picker.
+ * This is deliberately independent of the legacy
+ * `databricks.connect.serverlessDbconnectVersion` setting (a DBR/dbconnect
+ * version like "17.3"): that is a different namespace consumed by the legacy
+ * pip flow and must not leak into `--serverless-version`.
+ */
+export async function resolveServerlessVersion(
+    deps: ServerlessVersionResolverDeps
+): Promise<string | undefined> {
+    if (!deps.isEnabled()) {
+        return undefined;
+    }
+    const observations = await deps.collectObservations();
+    const ranked = scoreServerlessVersions(observations);
+    return deps.pick(ranked);
+}

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
@@ -22,14 +22,18 @@ export function isPythonSetupEnabled(): boolean {
 }
 
 /**
- * Injected collaborators for {@link resolveServerlessVersion}. The feature
- * gate, the (I/O-bound) observation collection, and the QuickPick are all seams
- * so the resolution flow is unit-testable without a VS Code host, and the
- * pieces wired at the extension site can be swapped in later.
+ * Injected collaborators for {@link resolveServerlessVersion}. The (I/O-bound)
+ * observation collection and the QuickPick are seams so the resolution flow is
+ * unit-testable without a VS Code host, and the pieces wired at the extension
+ * site can be swapped in later.
+ *
+ * The feature-flag gate is deliberately NOT here: callers own it, because
+ * "feature off" and "user dismissed the picker" need different handling at the
+ * call site (e.g. the compute picker still enables plain serverless when the
+ * flag is off, but makes no change on dismissal) -- both of which this function
+ * would otherwise collapse into a single `undefined`.
  */
 export interface ServerlessVersionResolverDeps {
-    /** Feature-flag gate; defaults to {@link isPythonSetupEnabled} in prod. */
-    isEnabled: () => boolean;
     /** Gather raw version observations (bundle YAML, notebooks, workspace default). */
     collectObservations: () => Promise<VersionObservation[]>;
     /** Present the ranked candidates and return the confirmed bare version. */
@@ -39,25 +43,21 @@ export interface ServerlessVersionResolverDeps {
 }
 
 /**
- * Resolve the serverless environment version to provision: gate on the feature
- * flag, collect observations, score them, and let the user confirm a candidate.
+ * Resolve the serverless environment version to provision: collect the evidence
+ * for what version this project should use (bundle YAML, notebooks, workspace
+ * default), score it, and let the user confirm the best-ranked candidate.
  * Returns the confirmed bare version (e.g. "5", the `--serverless-version`
- * value) or `undefined` when the feature is disabled or the user dismisses the
- * picker.
+ * value) or `undefined` when the user dismisses the picker.
  *
- * The flag gate is checked first, before any collection or UI, so with the
- * feature off the resolver is completely inert -- no disk reads, no picker.
- * This is deliberately independent of the legacy
- * `databricks.connect.serverlessDbconnectVersion` setting (a DBR/dbconnect
- * version like "17.3"): that is a different namespace consumed by the legacy
- * pip flow and must not leak into `--serverless-version`.
+ * Callers gate this on the feature flag ({@link isPythonSetupEnabled}); it is
+ * only invoked when the flow is active. It is deliberately independent of the
+ * legacy `databricks.connect.serverlessDbconnectVersion` setting (a
+ * DBR/dbconnect version like "17.3"): that is a different namespace consumed by
+ * the legacy pip flow and must not leak into `--serverless-version`.
  */
 export async function resolveServerlessVersion(
     deps: ServerlessVersionResolverDeps
 ): Promise<string | undefined> {
-    if (!deps.isEnabled()) {
-        return undefined;
-    }
     const observations = await deps.collectObservations();
     const ranked = scoreServerlessVersions(observations);
     return deps.pick(ranked);

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -86,13 +86,18 @@ describe("scoreServerlessVersions", () => {
         expect(fives[0].sources).to.deep.equal(["fallback"]);
     });
 
-    it("drops non-numeric and out-of-range versions", () => {
+    it("drops non-numeric, out-of-range and non-canonical versions", () => {
         const ranked = scoreServerlessVersions([
             {version: "abc", source: "bundleYaml"},
             {version: "", source: "notebook"},
             {version: "0", source: "bundleYaml"},
             {version: "6", source: "bundleYaml"},
             {version: "4.2", source: "notebook"},
+            // Non-canonical bare integers: parse into range but are not the
+            // exact string the CLI expects, so they must be dropped too.
+            {version: "05", source: "bundleYaml"},
+            {version: "+5", source: "notebook"},
+            {version: " 5", source: "workspaceDefault"},
         ]);
         // Everything invalid is filtered; only the fallback survives.
         expect(ranked).to.have.length(1);

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -27,12 +27,12 @@ describe("scoreServerlessVersions", () => {
         // Use a non-fallback version so the fallback merge does not add a
         // second source and muddy the dedup assertion.
         const ranked = scoreServerlessVersions([
-            {version: "6", source: "notebook"},
-            {version: "6", source: "notebook"},
+            {version: "4", source: "notebook"},
+            {version: "4", source: "notebook"},
         ]);
-        const v6 = ranked.find((r) => r.version === "6")!;
-        expect(v6.sources).to.deep.equal(["notebook"]);
-        expect(v6.score).to.equal(WEIGHTS.notebook);
+        const v4 = ranked.find((r) => r.version === "4")!;
+        expect(v4.sources).to.deep.equal(["notebook"]);
+        expect(v4.score).to.equal(WEIGHTS.notebook);
     });
 
     it("breaks ties by higher numeric version", () => {
@@ -64,12 +64,47 @@ describe("scoreServerlessVersions", () => {
     it("surfaces disagreeing versions all in the ranked list", () => {
         const ranked = scoreServerlessVersions([
             {version: "4", source: "bundleYaml"},
-            {version: "6", source: "notebook"},
+            {version: "3", source: "notebook"},
         ]);
         expect(ranked.map((r) => r.version)).to.include.members([
             "4",
-            "6",
+            "3",
             "5",
         ]);
+    });
+
+    it("drops the `vN` display form so only the bare integer is scored", () => {
+        // The CLI echoes "v5" but accepts "5"; a "v5" observation must not
+        // create a second row alongside the bare fallback "5".
+        const ranked = scoreServerlessVersions([
+            {version: "v5", source: "bundleYaml"},
+        ]);
+        const fives = ranked.filter((r) => r.version === "5");
+        expect(ranked.map((r) => r.version)).to.not.include("v5");
+        expect(fives).to.have.length(1);
+        // "v5" was dropped, so "5" is corroborated only by the fallback.
+        expect(fives[0].sources).to.deep.equal(["fallback"]);
+    });
+
+    it("drops non-numeric and out-of-range versions", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "abc", source: "bundleYaml"},
+            {version: "", source: "notebook"},
+            {version: "0", source: "bundleYaml"},
+            {version: "6", source: "bundleYaml"},
+            {version: "4.2", source: "notebook"},
+        ]);
+        // Everything invalid is filtered; only the fallback survives.
+        expect(ranked).to.have.length(1);
+        expect(ranked[0].version).to.equal("5");
+        expect(ranked[0].sources).to.deep.equal(["fallback"]);
+    });
+
+    it("keeps every version at the supported boundaries (1 and 5)", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "1", source: "bundleYaml"},
+            {version: "5", source: "notebook"},
+        ]);
+        expect(ranked.map((r) => r.version)).to.include.members(["1", "5"]);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -1,0 +1,80 @@
+import {expect} from "chai";
+import {
+    scoreServerlessVersions,
+    WEIGHTS,
+} from "./serverlessVersionScoring";
+
+describe("scoreServerlessVersions", () => {
+    it("ranks the version with the most weight first", () => {
+        // bundleYaml outweighs workspaceDefault, so v4 wins despite v5 being
+        // numerically higher.
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "bundleYaml"},
+            {version: "5", source: "workspaceDefault"},
+        ]);
+        expect(ranked[0].version).to.equal("4");
+    });
+
+    it("adds weight when multiple sources agree on a version", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "bundleYaml"},
+            {version: "4", source: "notebook"},
+            {version: "5", source: "bundleYaml"},
+        ]);
+        expect(ranked[0].version).to.equal("4");
+        expect(ranked[0].score).to.equal(
+            WEIGHTS.bundleYaml + WEIGHTS.notebook
+        );
+        expect(ranked[0].sources).to.have.members(["bundleYaml", "notebook"]);
+    });
+
+    it("does not double-count a repeated (version, source) pair", () => {
+        // Use a non-fallback version so the fallback merge does not add a
+        // second source and muddy the dedup assertion.
+        const ranked = scoreServerlessVersions([
+            {version: "6", source: "notebook"},
+            {version: "6", source: "notebook"},
+        ]);
+        const v6 = ranked.find((r) => r.version === "6")!;
+        expect(v6.sources).to.deep.equal(["notebook"]);
+        expect(v6.score).to.equal(WEIGHTS.notebook);
+    });
+
+    it("breaks ties by higher numeric version", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "notebook"},
+            {version: "5", source: "notebook"},
+        ]);
+        expect(ranked[0].version).to.equal("5");
+    });
+
+    it("always includes the fallback candidate, even with no observations", () => {
+        const ranked = scoreServerlessVersions([]);
+        expect(ranked).to.have.length(1);
+        expect(ranked[0].version).to.equal("5");
+        expect(ranked[0].sources).to.deep.equal(["fallback"]);
+    });
+
+    it("merges the fallback into a matching observed version instead of duplicating it", () => {
+        // An observation for the fallback version itself must not produce two
+        // "5" rows -- it is one candidate corroborated by two sources.
+        const ranked = scoreServerlessVersions([
+            {version: "5", source: "bundleYaml"},
+        ]);
+        const fives = ranked.filter((r) => r.version === "5");
+        expect(fives).to.have.length(1);
+        expect(fives[0].sources).to.have.members(["bundleYaml", "fallback"]);
+    });
+
+    it("surfaces disagreeing versions all in the ranked list", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "bundleYaml"},
+            {version: "6", source: "notebook"},
+        ]);
+        expect(ranked.map((r) => r.version)).to.include.members([
+            "4",
+            "6",
+            "5",
+        ]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -1,8 +1,5 @@
 import {expect} from "chai";
-import {
-    scoreServerlessVersions,
-    WEIGHTS,
-} from "./serverlessVersionScoring";
+import {scoreServerlessVersions, WEIGHTS} from "./serverlessVersionScoring";
 
 describe("scoreServerlessVersions", () => {
     it("ranks the version with the most weight first", () => {
@@ -22,9 +19,7 @@ describe("scoreServerlessVersions", () => {
             {version: "5", source: "bundleYaml"},
         ]);
         expect(ranked[0].version).to.equal("4");
-        expect(ranked[0].score).to.equal(
-            WEIGHTS.bundleYaml + WEIGHTS.notebook
-        );
+        expect(ranked[0].score).to.equal(WEIGHTS.bundleYaml + WEIGHTS.notebook);
         expect(ranked[0].sources).to.have.members(["bundleYaml", "notebook"]);
     });
 

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
@@ -8,7 +8,10 @@
  * Versions are the CLI's bare-integer form (e.g. "4", "5") -- the value
  * `--serverless-version` accepts -- NOT the `vN` display form the CLI echoes in
  * its result output. The picker forwards the chosen value straight into the
- * setup-local invocation, so it must stay bare.
+ * setup-local invocation, so it must stay bare. Observations that are not a
+ * bare integer in the supported range (see {@link isSupportedVersion}) are
+ * dropped before scoring, so neither the `vN` form nor an unrealistic version
+ * can ever reach the picker or the CLI.
  */
 
 /** Where a candidate serverless version was observed. */
@@ -53,9 +56,27 @@ export const WEIGHTS: Record<VersionSource, number> = {
  */
 export const FALLBACK_VERSION = "5";
 
+/** Lowest / highest serverless environment version the CLI accepts, inclusive. */
+export const MIN_SUPPORTED_VERSION = 1;
+export const MAX_SUPPORTED_VERSION = 5;
+
+/**
+ * A version is valid only if it is a bare integer (no `vN` prefix, no decimals,
+ * no surrounding whitespace) within the supported range. This is the trust
+ * boundary: observations gathered from bundle YAML, notebook metadata, etc. are
+ * untrusted strings, and anything that is not a value the `--serverless-version`
+ * flag would accept must never reach the picker or the CLI.
+ */
+export function isSupportedVersion(version: string): boolean {
+    if (!/^\d+$/.test(version)) {
+        return false;
+    }
+    const n = parseInt(version, 10);
+    return n >= MIN_SUPPORTED_VERSION && n <= MAX_SUPPORTED_VERSION;
+}
+
 function versionNumber(v: string): number {
-    const n = parseInt(v.replace(/^v/i, ""), 10);
-    return Number.isFinite(n) ? n : 0;
+    return parseInt(v, 10);
 }
 
 /**
@@ -67,8 +88,11 @@ function versionNumber(v: string): number {
 export function scoreServerlessVersions(
     observations: VersionObservation[]
 ): ScoredVersion[] {
+    // Drop anything that is not a supported bare integer before it can be
+    // scored -- a `vN`-form or unrealistic version must never be forwarded to
+    // the CLI. The fallback is known-valid and always kept.
     const all: VersionObservation[] = [
-        ...observations,
+        ...observations.filter((o) => isSupportedVersion(o.version)),
         {version: FALLBACK_VERSION, source: "fallback"},
     ];
 

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
@@ -61,18 +61,27 @@ export const MIN_SUPPORTED_VERSION = 1;
 export const MAX_SUPPORTED_VERSION = 5;
 
 /**
- * A version is valid only if it is a bare integer (no `vN` prefix, no decimals,
- * no surrounding whitespace) within the supported range. This is the trust
- * boundary: observations gathered from bundle YAML, notebook metadata, etc. are
- * untrusted strings, and anything that is not a value the `--serverless-version`
- * flag would accept must never reach the picker or the CLI.
+ * A version is valid only if it is a bare integer in canonical form (no `vN`
+ * prefix, no `+` sign, no decimals, no leading zeros, no surrounding
+ * whitespace) within the supported range. This is the trust boundary:
+ * observations gathered from bundle YAML, notebook metadata, etc. are untrusted
+ * strings, and anything that is not a value the `--serverless-version` flag
+ * would accept must never reach the picker or the CLI.
+ *
+ * The `String(n) === version` check rejects non-canonical spellings like "05"
+ * that would otherwise parse into the range but not match the bare string the
+ * CLI expects (and would fail to merge with the canonical "5" candidate).
  */
 export function isSupportedVersion(version: string): boolean {
     if (!/^\d+$/.test(version)) {
         return false;
     }
     const n = parseInt(version, 10);
-    return n >= MIN_SUPPORTED_VERSION && n <= MAX_SUPPORTED_VERSION;
+    return (
+        String(n) === version &&
+        n >= MIN_SUPPORTED_VERSION &&
+        n <= MAX_SUPPORTED_VERSION
+    );
 }
 
 function versionNumber(v: string): number {

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure, weighted scoring of candidate serverless environment versions gathered
+ * from several provenance sources. Kept side-effect free so the ranking is
+ * deterministic and unit-testable; the collection of raw observations (reading
+ * bundle YAML, notebook metadata, the workspace default) happens in the caller
+ * and is passed in.
+ *
+ * Versions are the CLI's bare-integer form (e.g. "4", "5") -- the value
+ * `--serverless-version` accepts -- NOT the `vN` display form the CLI echoes in
+ * its result output. The picker forwards the chosen value straight into the
+ * setup-local invocation, so it must stay bare.
+ */
+
+/** Where a candidate serverless version was observed. */
+export type VersionSource =
+    | "bundleYaml"
+    | "notebook"
+    | "workspaceDefault"
+    | "fallback";
+
+/** A candidate version with its accumulated score and the sources that back it. */
+export interface ScoredVersion {
+    /** Bare-integer version, e.g. "5". */
+    version: string;
+    score: number;
+    sources: VersionSource[];
+}
+
+/** A single raw observation of a version from one source. */
+export interface VersionObservation {
+    version: string;
+    source: VersionSource;
+}
+
+/**
+ * Per-source weights, high → low: an explicit project declaration (bundle YAML)
+ * is the strongest signal, a notebook's recorded environment next, the
+ * workspace default weaker, and the built-in fallback weakest so it only ever
+ * wins when nothing else was observed.
+ */
+export const WEIGHTS: Record<VersionSource, number> = {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    bundleYaml: 100,
+    notebook: 50,
+    workspaceDefault: 20,
+    fallback: 1,
+    /* eslint-enable @typescript-eslint/naming-convention */
+};
+
+/**
+ * The version offered when no other source suggests one. Bare integer to match
+ * the `--serverless-version` flag.
+ */
+export const FALLBACK_VERSION = "5";
+
+function versionNumber(v: string): number {
+    const n = parseInt(v.replace(/^v/i, ""), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Rank candidate versions by total weight (desc), breaking ties by higher
+ * numeric version. The {@link FALLBACK_VERSION} is always included as a
+ * candidate; if it coincides with an observed version the two are merged into a
+ * single, better-corroborated row rather than duplicated.
+ */
+export function scoreServerlessVersions(
+    observations: VersionObservation[]
+): ScoredVersion[] {
+    const all: VersionObservation[] = [
+        ...observations,
+        {version: FALLBACK_VERSION, source: "fallback"},
+    ];
+
+    const byVersion = new Map<string, ScoredVersion>();
+    for (const {version, source} of all) {
+        const entry = byVersion.get(version) ?? {
+            version,
+            score: 0,
+            sources: [],
+        };
+        // Guard against a repeated (version, source) pair inflating the score
+        // or listing a source twice -- each source corroborates a version at
+        // most once.
+        if (!entry.sources.includes(source)) {
+            entry.score += WEIGHTS[source];
+            entry.sources.push(source);
+        }
+        byVersion.set(version, entry);
+    }
+
+    return [...byVersion.values()].sort(
+        (a, b) =>
+            b.score - a.score ||
+            versionNumber(b.version) - versionNumber(a.version)
+    );
+}


### PR DESCRIPTION
## Why

When a Databricks Connect setup targets serverless, the extension must decide which serverless environment version to provision. The signal comes from several places of differing trust (a bundle YAML declaration, a notebook's recorded environment, the workspace default), so we score candidates by weighted provenance and let the user confirm — rather than guessing or silently auto-selecting. This is the piece the setup orchestrator's compute-resolution seam calls for a serverless target.

Additive: nothing is wired into the extension yet (that's the config-view/orchestrator wiring ticket, DECO-27786), so there is no user-facing change.

## What

Three pure/near-pure units under `python-setup/utils/`:

1. **`serverlessVersionScoring.ts`** — `scoreServerlessVersions(observations)`: deterministic ranking by total per-source weight (`bundleYaml` 100 > `notebook` 50 > `workspaceDefault` 20 > `fallback` 1), ties broken by higher numeric version. A built-in fallback candidate is always present and *merges* into a matching observed version (no duplicate row); repeated `(version, source)` pairs aren't double-counted.
2. **`serverlessVersionPicker.ts`** — `buildVersionPickItems` (pure: pre-picks + stars the top candidate, human-readable provenance in the description) + `pickServerlessVersion` (thin `window.showQuickPick` wrapper). The user must confirm — the recommendation is pre-selected, never auto-applied.
3. **`serverlessVersionResolver.ts`** — `resolveServerlessVersion(deps)`: the flag-guarded entry point that ties collect → score → confirm together, plus `isPythonSetupEnabled()`.

### Constraint 1 — backward compatibility

The new serverless-environment version is a **bare integer** (`4`, `5` — the value the CLI's `--serverless-version` flag accepts, verified against the CLI's own acceptance goldens and `--help`). This is a **distinct namespace** from the existing `databricks.connect.serverlessDbconnectVersion` setting (a DBR/dbconnect version like `17.3`, consumed by the legacy pip flow). The resolver never reads or writes that setting, so existing users are completely unaffected. (Note: the JIRA's `--serverless-version <vN>` phrasing is the CLI's *display* form; the *input* flag is bare — the picker emits bare integers accordingly.)

### Constraint 2 — feature-flag guard (#2045)

`resolveServerlessVersion` checks the `PYTHON_SETUP_FEATURE_ID` opt-in **first**, before any observation collection or UI. With the feature off it returns `undefined` and is fully inert — no disk reads, no picker. `isPythonSetupEnabled()` reads `experiments.optInto.includes(PYTHON_SETUP_FEATURE_ID)` — the exact string FeatureManager matches to unlock the feature (from #2045), so the flag can't disagree with it. (It lives in `python-setup/` rather than on `workspaceConfigs` to avoid the `WorkspaceConfigs`↔`FeatureManager` circular import.)

## Verification

- `yarn --cwd packages/databricks-vscode test:unit` — 340 passing (15 new: 7 scoring, 4 picker builder, 4 resolver incl. disabled→inert).
- `test:lint` — clean · `build` — clean.

This pull request and its description were written by Isaac.