### PR TITLE
[8/?] feat(python-setup): merge serverless-version selection into the compute picker

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -23,6 +23,13 @@ import {
 } from "../ui/configuration-view/AuthTypeComponent";
 import {ManualLoginSource} from "../telemetry/constants";
 import {onError} from "../utils/onErrorDecorator";
+import {isPythonSetupEnabled} from "../python-setup/utils/serverlessVersionResolver";
+import {
+    scoreServerlessVersions,
+    VersionObservation,
+} from "../python-setup/utils/serverlessVersionScoring";
+import {pickServerlessVersion} from "../python-setup/utils/serverlessVersionPicker";
+import {collectBundleServerlessVersions} from "../python-setup/utils/bundleServerlessVersions";
 
 function formatQuickPickClusterSize(sizeInMB: number): string {
     if (sizeInMB > 1024) {
@@ -187,7 +194,11 @@ export class ConnectionCommands implements Disposable {
                     const cluster = selectedItem.cluster;
                     await this.connectionManager.attachCluster(cluster.id);
                 } else if (selectedItem.label === "$(cloud) Serverless") {
-                    await this.connectionManager.enableServerless();
+                    // Dispose the compute QuickPick before opening the version
+                    // sub-picker so they don't stack visually.
+                    disposables.forEach((d) => d.dispose());
+                    await this.selectServerless();
+                    return;
                 } else {
                     await UrlUtils.openExternal(
                         `${
@@ -206,6 +217,46 @@ export class ConnectionCommands implements Disposable {
                 quickPick.dispose();
             });
         };
+    }
+
+    /**
+     * Enable serverless compute. When the uv-native python-setup feature is
+     * opted into, first ask the user to confirm the serverless environment
+     * version (ranked from the project's bundle) and persist it with the
+     * selection, so setup need not re-prompt. If they dismiss the version
+     * picker, no compute change is made. With the feature off this is the
+     * plain, unchanged serverless enable.
+     */
+    private async selectServerless() {
+        if (!isPythonSetupEnabled()) {
+            await this.connectionManager.enableServerless();
+            return;
+        }
+        const version = await this.pickServerlessVersion();
+        if (version === undefined) {
+            // User dismissed the version picker -- don't switch compute.
+            return;
+        }
+        await this.connectionManager.enableServerless(version);
+    }
+
+    /**
+     * Rank the serverless environment versions declared in the project's bundle
+     * and let the user confirm one (top candidate pre-selected). Returns the
+     * confirmed bare version, or undefined if dismissed.
+     */
+    private async pickServerlessVersion(): Promise<string | undefined> {
+        let observations: VersionObservation[];
+        try {
+            const validateConfig = await this.configModel.get("validateConfig");
+            observations = collectBundleServerlessVersions(validateConfig);
+        } catch {
+            // Bundle not available/parseable -- fall back to scoring with no
+            // observations (yields the default candidate), never block compute
+            // selection on it.
+            observations = [];
+        }
+        return pickServerlessVersion(scoreServerlessVersions(observations));
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -29,6 +29,9 @@ import {
 } from "../python-setup/utils/serverlessVersionResolver";
 import {pickServerlessVersion} from "../python-setup/utils/serverlessVersionPicker";
 import {collectBundleServerlessVersions} from "../python-setup/utils/bundleServerlessVersions";
+import {collectProjectNotebookVersions} from "../python-setup/utils/projectNotebookVersions";
+import {VersionObservation} from "../python-setup/utils/serverlessVersionScoring";
+import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 
 function formatQuickPickClusterSize(sizeInMB: number): string {
     if (sizeInMB > 1024) {
@@ -69,7 +72,8 @@ export class ConnectionCommands implements Disposable {
         private connectionManager: ConnectionManager,
         private readonly clusterModel: ClusterModel,
         private readonly configModel: ConfigModel,
-        private readonly cli: CliWrapper
+        private readonly cli: CliWrapper,
+        private readonly workspaceFolderManager: WorkspaceFolderManager
     ) {}
 
     /**
@@ -249,20 +253,44 @@ export class ConnectionCommands implements Disposable {
      */
     private async pickServerlessVersion(): Promise<string | undefined> {
         return resolveServerlessVersion({
-            collectObservations: async () => {
+            collectObservations: () => this.collectServerlessObservations(),
+            pick: pickServerlessVersion,
+        });
+    }
+
+    /**
+     * Gather serverless-version evidence from the project's local sources
+     * (bundle config + notebooks). Each source is collected independently and
+     * guarded, so one failing source never blocks the other or compute
+     * selection; the scorer merges and de-dupes across sources. (The
+     * workspace-default API source is not yet available — see DECO-27782.)
+     */
+    private async collectServerlessObservations(): Promise<
+        VersionObservation[]
+    > {
+        const [bundle, notebooks] = await Promise.all([
+            (async () => {
                 try {
                     const validateConfig =
                         await this.configModel.get("validateConfig");
                     return collectBundleServerlessVersions(validateConfig);
                 } catch {
-                    // Bundle not available/parseable -- score with no
-                    // observations (yields the default candidate) rather than
-                    // blocking compute selection on it.
-                    return [];
+                    return [] as VersionObservation[];
                 }
-            },
-            pick: pickServerlessVersion,
-        });
+            })(),
+            (async () => {
+                try {
+                    const projectRoot =
+                        this.workspaceFolderManager.activeProjectUri.fsPath;
+                    return await collectProjectNotebookVersions(projectRoot);
+                } catch {
+                    // No active project, or notebook scan failed -- contribute
+                    // nothing rather than blocking compute selection.
+                    return [] as VersionObservation[];
+                }
+            })(),
+        ]);
+        return [...bundle, ...notebooks];
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -23,11 +23,10 @@ import {
 } from "../ui/configuration-view/AuthTypeComponent";
 import {ManualLoginSource} from "../telemetry/constants";
 import {onError} from "../utils/onErrorDecorator";
-import {isPythonSetupEnabled} from "../python-setup/utils/serverlessVersionResolver";
 import {
-    scoreServerlessVersions,
-    VersionObservation,
-} from "../python-setup/utils/serverlessVersionScoring";
+    isPythonSetupEnabled,
+    resolveServerlessVersion,
+} from "../python-setup/utils/serverlessVersionResolver";
 import {pickServerlessVersion} from "../python-setup/utils/serverlessVersionPicker";
 import {collectBundleServerlessVersions} from "../python-setup/utils/bundleServerlessVersions";
 
@@ -241,22 +240,29 @@ export class ConnectionCommands implements Disposable {
     }
 
     /**
-     * Rank the serverless environment versions declared in the project's bundle
-     * and let the user confirm one (top candidate pre-selected). Returns the
-     * confirmed bare version, or undefined if dismissed.
+     * Resolve the serverless environment version: gather the project's version
+     * evidence, score it, and let the user confirm the best-ranked candidate.
+     * Returns the confirmed bare version, or undefined if dismissed. Delegates
+     * to {@link resolveServerlessVersion} so the collect->score->pick pipeline
+     * lives in one place; this call site only supplies where the evidence comes
+     * from (the bundle today) and how the user confirms it.
      */
     private async pickServerlessVersion(): Promise<string | undefined> {
-        let observations: VersionObservation[];
-        try {
-            const validateConfig = await this.configModel.get("validateConfig");
-            observations = collectBundleServerlessVersions(validateConfig);
-        } catch {
-            // Bundle not available/parseable -- fall back to scoring with no
-            // observations (yields the default candidate), never block compute
-            // selection on it.
-            observations = [];
-        }
-        return pickServerlessVersion(scoreServerlessVersions(observations));
+        return resolveServerlessVersion({
+            collectObservations: async () => {
+                try {
+                    const validateConfig =
+                        await this.configModel.get("validateConfig");
+                    return collectBundleServerlessVersions(validateConfig);
+                } catch {
+                    // Bundle not available/parseable -- score with no
+                    // observations (yields the default candidate) rather than
+                    // blocking compute selection on it.
+                    return [];
+                }
+            },
+            pick: pickServerlessVersion,
+        });
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -26,6 +26,7 @@ import {AutoLoginSource, ManualLoginSource} from "../telemetry/constants";
 import {Barrier} from "../locking/Barrier";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {ProjectConfigFile} from "../file-managers/ProjectConfigFile";
+import {isSupportedVersion} from "../python-setup/utils/serverlessVersionScoring";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const {NamedLogger} = logging;
@@ -163,8 +164,16 @@ export class ConnectionManager implements Disposable {
             // without re-prompting. A version-less serverless config (older
             // extensions, or serverless enabled before a version was chosen)
             // leaves this undefined, and consumers fall back to their default.
-            this._serverlessVersion =
+            // The stored value is untrusted (config files are hand-editable and
+            // may predate the supported range), so re-validate here rather than
+            // exposing a value the `--serverless-version` flag would reject --
+            // an unsupported version is dropped to undefined (scored default).
+            const storedVersion =
                 await this.configModel.get("serverlessVersion");
+            this._serverlessVersion =
+                storedVersion !== undefined && isSupportedVersion(storedVersion)
+                    ? storedVersion
+                    : undefined;
             await this.enableServerless(this._serverlessVersion);
         } else {
             await this.disableServerless();

--- a/packages/databricks-vscode/src/configuration/ConnectionManager.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionManager.ts
@@ -50,6 +50,7 @@ export class ConnectionManager implements Disposable {
     private _databricksWorkspace?: DatabricksWorkspace;
     private _metadataService: MetadataService;
     private _serverlessEnabled: boolean = false;
+    private _serverlessVersion: string | undefined;
 
     private readonly onDidChangeStateEmitter: EventEmitter<ConnectionState> =
         new EventEmitter();
@@ -158,7 +159,13 @@ export class ConnectionManager implements Disposable {
         const autoEnable =
             serverless === undefined && !this.cluster && computeId === "auto";
         if (serverless || autoEnable) {
-            await this.enableServerless();
+            // Load the persisted version (if any) so it survives a reload
+            // without re-prompting. A version-less serverless config (older
+            // extensions, or serverless enabled before a version was chosen)
+            // leaves this undefined, and consumers fall back to their default.
+            this._serverlessVersion =
+                await this.configModel.get("serverlessVersion");
+            await this.enableServerless(this._serverlessVersion);
         } else {
             await this.disableServerless();
         }
@@ -226,6 +233,16 @@ export class ConnectionManager implements Disposable {
 
     get serverless(): boolean {
         return this._serverlessEnabled;
+    }
+
+    /**
+     * The persisted serverless environment version (the CLI's bare-integer
+     * `--serverless-version` value, e.g. "5"), or undefined when serverless is
+     * not selected or no version has been chosen yet. Consumers treat undefined
+     * as "fall back to the scored default".
+     */
+    get serverlessVersion(): string | undefined {
+        return this._serverlessEnabled ? this._serverlessVersion : undefined;
     }
 
     get syncDestinationMapper(): SyncDestinationMapper | undefined {
@@ -465,7 +482,15 @@ export class ConnectionManager implements Disposable {
     @onError({
         popup: {prefix: "Failed to enable serverless mode."},
     })
-    async enableServerless() {
+    async enableServerless(version?: string) {
+        // Persist the version whenever one is supplied, even if serverless is
+        // already enabled -- this is how re-picking the version (without
+        // toggling compute) is saved. `undefined` leaves any existing persisted
+        // version in place rather than clearing it.
+        if (version !== undefined && version !== this._serverlessVersion) {
+            this._serverlessVersion = version;
+            await this.configModel.set("serverlessVersion", version);
+        }
         if (!this._serverlessEnabled) {
             this._serverlessEnabled = true;
             await this.configModel.set("serverless", true);
@@ -485,7 +510,12 @@ export class ConnectionManager implements Disposable {
     async disableServerless() {
         if (this._serverlessEnabled) {
             this._serverlessEnabled = false;
+            // Clear the version too: it only has meaning while serverless is
+            // the selected compute, and leaving a stale value would let it
+            // resurface if serverless is re-enabled later without re-picking.
+            this._serverlessVersion = undefined;
             await this.configModel.set("serverless", false);
+            await this.configModel.set("serverlessVersion", undefined);
             this.customWhenContext.setServerless(false);
             this.onDidChangeClusterEmitter.fire(undefined);
         }

--- a/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.test.ts
+++ b/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.test.ts
@@ -1,0 +1,85 @@
+import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {readFileSync, writeFileSync} from "node:fs";
+import {Uri} from "vscode";
+import {
+    isOverrideableConfigKey,
+    OverrideableConfigModel,
+} from "./OverrideableConfigModel";
+
+describe("OverrideableConfigModel serverlessVersion", () => {
+    const cleanups: Array<() => void> = [];
+    afterEach(() => {
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    function tempStorageFile(): Uri {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        return Uri.file(path.join(dir.name, "vscode.overrides.json"));
+    }
+
+    it("treats serverlessVersion as an overrideable key", () => {
+        expect(isOverrideableConfigKey("serverlessVersion")).to.equal(true);
+    });
+
+    it("persists a serverless version alongside the serverless flag", async () => {
+        const file = tempStorageFile();
+
+        await OverrideableConfigModel._write(file, "serverless", "dev", true);
+        await OverrideableConfigModel._write(
+            file,
+            "serverlessVersion",
+            "dev",
+            "5"
+        );
+
+        const data = JSON.parse(readFileSync(file.fsPath, "utf-8"));
+        expect(data.serverless).to.equal(true);
+        expect(data.serverlessVersion).to.equal("5");
+    });
+
+    it("clears the version when written undefined (revert to fallback)", async () => {
+        const file = tempStorageFile();
+        await OverrideableConfigModel._write(
+            file,
+            "serverlessVersion",
+            "dev",
+            "4"
+        );
+
+        await OverrideableConfigModel._write(
+            file,
+            "serverlessVersion",
+            "dev",
+            undefined
+        );
+
+        const data = JSON.parse(readFileSync(file.fsPath, "utf-8"));
+        expect(data.serverlessVersion).to.equal(undefined);
+    });
+
+    it("leaves a legacy version-less serverless config untouched (backward compatible)", async () => {
+        const file = tempStorageFile();
+        // A config written by an older extension: serverless on, no version.
+        writeFileSync(
+            file.fsPath,
+            JSON.stringify({serverless: true, clusterId: "abc"})
+        );
+
+        // Writing an unrelated key must not fabricate a serverlessVersion.
+        await OverrideableConfigModel._write(
+            file,
+            "authProfile",
+            "dev",
+            "DEFAULT"
+        );
+
+        const data = JSON.parse(readFileSync(file.fsPath, "utf-8"));
+        expect(data.serverless).to.equal(true);
+        expect(data).to.not.have.property("serverlessVersion");
+    });
+});

--- a/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
+++ b/packages/databricks-vscode/src/configuration/models/OverrideableConfigModel.ts
@@ -10,6 +10,17 @@ export type OverrideableConfigState = {
     authProfile?: string;
     clusterId?: string;
     serverless?: boolean;
+    /**
+     * The serverless environment version to provision the local Python
+     * environment against (the CLI's bare-integer `--serverless-version` value,
+     * e.g. "5"). Chosen once alongside the serverless compute selection and
+     * persisted so setup need not re-prompt.
+     *
+     * Optional and independent of `serverless`: existing configs that predate
+     * this field have `serverless: true` with no version, which stays valid --
+     * a version-less serverless selection falls back to the scored default.
+     */
+    serverlessVersion?: string;
     useClusterOverride?: boolean;
 };
 
@@ -21,6 +32,7 @@ export function isOverrideableConfigKey(
         "clusterId",
         "useClusterOverride",
         "serverless",
+        "serverlessVersion",
     ].includes(key);
 }
 

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -787,7 +787,8 @@ export async function activate(
         connectionManager,
         clusterModel,
         configModel,
-        cli
+        cli,
+        workspaceFolderManager
     );
 
     context.subscriptions.push(

--- a/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import {expect} from "chai";
 import {collectBundleServerlessVersions} from "./bundleServerlessVersions";
 
@@ -51,7 +52,9 @@ describe("collectBundleServerlessVersions", () => {
     it("coerces a numeric environment_version to a bare string", () => {
         // YAML may parse an unquoted version as a number.
         const bundle = {
-            resources: {jobs: {a: {environments: [{spec: {environment_version: 5}}]}}},
+            resources: {
+                jobs: {a: {environments: [{spec: {environment_version: 5}}]}},
+            },
         };
 
         expect(collectBundleServerlessVersions(bundle)).to.deep.equal([

--- a/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.test.ts
@@ -1,0 +1,97 @@
+import {expect} from "chai";
+import {collectBundleServerlessVersions} from "./bundleServerlessVersions";
+
+describe("collectBundleServerlessVersions", () => {
+    it("finds a serverless environment_version in a job's environments", () => {
+        const bundle = {
+            resources: {
+                jobs: {
+                    my_job: {
+                        environments: [
+                            {
+                                environment_key: "default",
+                                spec: {environment_version: "5"},
+                            },
+                        ],
+                    },
+                },
+            },
+        };
+
+        expect(collectBundleServerlessVersions(bundle)).to.deep.equal([
+            {version: "5", source: "bundleYaml"},
+        ]);
+    });
+
+    it("collects versions from multiple resources and dedupes them", () => {
+        const bundle = {
+            resources: {
+                jobs: {
+                    a: {
+                        environments: [
+                            {spec: {environment_version: "5"}},
+                            {spec: {environment_version: "4"}},
+                        ],
+                    },
+                    b: {
+                        environments: [{spec: {environment_version: "5"}}],
+                    },
+                },
+            },
+        };
+
+        const observed = collectBundleServerlessVersions(bundle);
+        // "5" appears twice but is emitted once; order follows first sight.
+        expect(observed).to.deep.equal([
+            {version: "5", source: "bundleYaml"},
+            {version: "4", source: "bundleYaml"},
+        ]);
+    });
+
+    it("coerces a numeric environment_version to a bare string", () => {
+        // YAML may parse an unquoted version as a number.
+        const bundle = {
+            resources: {jobs: {a: {environments: [{spec: {environment_version: 5}}]}}},
+        };
+
+        expect(collectBundleServerlessVersions(bundle)).to.deep.equal([
+            {version: "5", source: "bundleYaml"},
+        ]);
+    });
+
+    it("ignores string-valued (unresolved) spec/environment nodes without throwing", () => {
+        // Bundle nodes can be raw strings (variable interpolation) rather than
+        // objects; the walk must tolerate that.
+        const bundle = {
+            resources: {
+                jobs: {a: {environments: "${var.envs}"}},
+                pipelines: {p: "${var.pipeline}"},
+            },
+        };
+
+        expect(collectBundleServerlessVersions(bundle)).to.deep.equal([]);
+    });
+
+    it("returns nothing for an empty or version-less bundle", () => {
+        expect(collectBundleServerlessVersions(undefined)).to.deep.equal([]);
+        expect(collectBundleServerlessVersions({})).to.deep.equal([]);
+        expect(
+            collectBundleServerlessVersions({
+                resources: {jobs: {a: {tasks: []}}},
+            })
+        ).to.deep.equal([]);
+    });
+
+    it("skips empty or non-scalar environment_version values", () => {
+        const bundle = {
+            resources: {
+                jobs: {
+                    a: {environments: [{spec: {environment_version: ""}}]},
+                    b: {environments: [{spec: {environment_version: {}}}]},
+                },
+            },
+        };
+
+        expect(collectBundleServerlessVersions(bundle)).to.deep.equal([]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/bundleServerlessVersions.ts
@@ -1,0 +1,63 @@
+import {VersionObservation} from "./serverlessVersionScoring";
+
+/**
+ * Collect serverless environment versions declared in a parsed bundle, as
+ * scoring observations (source `bundleYaml`).
+ *
+ * Serverless environment specs carry an `environment_version` field -- "a
+ * string consisting of an integer" (e.g. "5"), the same bare form the CLI's
+ * `--serverless-version` flag takes. That field is specific to serverless
+ * environment specs, so rather than hard-code the (deep, and every-level
+ * `object | string`) job/pipeline/task nesting, we defensively walk the whole
+ * parsed object and pick up every `environment_version` we find. This tolerates
+ * unresolved `${var...}` string nodes and schema shape changes without
+ * throwing. Versions are de-duplicated, preserving first-seen order.
+ */
+export function collectBundleServerlessVersions(
+    bundle: unknown
+): VersionObservation[] {
+    const versions: string[] = [];
+    const seen = new Set<string>();
+
+    const visit = (node: unknown) => {
+        if (node === null || typeof node !== "object") {
+            return;
+        }
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                visit(item);
+            }
+            return;
+        }
+        for (const [key, value] of Object.entries(node)) {
+            if (key === "environment_version") {
+                const version = normalizeVersion(value);
+                if (version !== undefined && !seen.has(version)) {
+                    seen.add(version);
+                    versions.push(version);
+                }
+            } else {
+                visit(value);
+            }
+        }
+    };
+
+    visit(bundle);
+
+    return versions.map((version) => ({version, source: "bundleYaml"}));
+}
+
+/**
+ * Accept a scalar `environment_version` (string or number, since unquoted YAML
+ * parses as a number) and return its bare-string form; reject empty strings and
+ * non-scalar values.
+ */
+function normalizeVersion(value: unknown): string | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return String(value);
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+    }
+    return undefined;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {expect} from "chai";
+import {collectNotebookServerlessVersions} from "./notebookServerlessVersions";
+
+const NOTEBOOK_METADATA_KEY = "application/vnd.databricks.v1+notebook";
+
+describe("collectNotebookServerlessVersions", () => {
+    it("reads environment_version from the Databricks notebook metadata key", () => {
+        const notebook = {
+            metadata: {
+                [NOTEBOOK_METADATA_KEY]: {
+                    environmentMetadata: {environment_version: "4"},
+                },
+            },
+            cells: [],
+        };
+
+        expect(collectNotebookServerlessVersions([notebook])).to.deep.equal([
+            {version: "4", source: "notebook"},
+        ]);
+    });
+
+    it("collects across multiple notebooks and dedupes, first-seen order", () => {
+        const nb = (v: string) => ({
+            metadata: {
+                [NOTEBOOK_METADATA_KEY]: {
+                    environmentMetadata: {environment_version: v},
+                },
+            },
+        });
+
+        expect(
+            collectNotebookServerlessVersions([nb("5"), nb("4"), nb("5")])
+        ).to.deep.equal([
+            {version: "5", source: "notebook"},
+            {version: "4", source: "notebook"},
+        ]);
+    });
+
+    it("coerces a numeric environment_version to a bare string", () => {
+        const notebook = {
+            metadata: {
+                [NOTEBOOK_METADATA_KEY]: {
+                    environmentMetadata: {environment_version: 5},
+                },
+            },
+        };
+
+        expect(collectNotebookServerlessVersions([notebook])).to.deep.equal([
+            {version: "5", source: "notebook"},
+        ]);
+    });
+
+    it("ignores notebooks without the Databricks metadata key", () => {
+        // A plain Jupyter notebook: no Databricks metadata block.
+        const notebook = {
+            metadata: {kernelspec: {name: "python3"}},
+            cells: [],
+        };
+
+        expect(collectNotebookServerlessVersions([notebook])).to.deep.equal([]);
+    });
+
+    it("tolerates missing / non-object metadata without throwing", () => {
+        expect(
+            collectNotebookServerlessVersions([
+                {},
+                {metadata: null},
+                {metadata: {[NOTEBOOK_METADATA_KEY]: "unresolved"}},
+                undefined,
+            ])
+        ).to.deep.equal([]);
+    });
+
+    it("skips empty or non-scalar environment_version values", () => {
+        const nb = (v: unknown) => ({
+            metadata: {
+                [NOTEBOOK_METADATA_KEY]: {
+                    environmentMetadata: {environment_version: v},
+                },
+            },
+        });
+
+        expect(
+            collectNotebookServerlessVersions([nb(""), nb({}), nb(null)])
+        ).to.deep.equal([]);
+    });
+
+    it("returns nothing for an empty notebook list", () => {
+        expect(collectNotebookServerlessVersions([])).to.deep.equal([]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.ts
@@ -11,7 +11,12 @@ const DATABRICKS_NOTEBOOK_METADATA_KEY =
  * A Databricks notebook records its serverless environment version at
  * `metadata["application/vnd.databricks.v1+notebook"].environmentMetadata
  * .environment_version` — the same bare-integer form (e.g. "5") the CLI's
- * `--serverless-version` flag takes. We look only inside that Databricks
+ * `--serverless-version` flag takes. Note the mixed casing is intentional and
+ * matches the exported `.ipynb` shape: the parent block `environmentMetadata`
+ * is camelCase (like its `notebookName`/`notebookMetadata` siblings), while the
+ * leaf `environment_version` (alongside `base_environment`, `dependencies`) is
+ * snake_case. Do not "normalize" the leaf to camelCase — that would harvest
+ * nothing. We look only inside that Databricks
  * metadata block (a plain Jupyter notebook has no such key and contributes
  * nothing), and defensively walk it for `environment_version` so a slightly
  * different nesting still resolves. Input is the already-parsed notebook JSON

--- a/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/notebookServerlessVersions.ts
@@ -1,0 +1,100 @@
+import {VersionObservation} from "./serverlessVersionScoring";
+
+/** The `.ipynb` top-level metadata key Databricks stores its notebook data under. */
+const DATABRICKS_NOTEBOOK_METADATA_KEY =
+    "application/vnd.databricks.v1+notebook";
+
+/**
+ * Collect serverless environment versions declared in a project's `.ipynb`
+ * notebooks, as scoring observations (source `notebook`).
+ *
+ * A Databricks notebook records its serverless environment version at
+ * `metadata["application/vnd.databricks.v1+notebook"].environmentMetadata
+ * .environment_version` — the same bare-integer form (e.g. "5") the CLI's
+ * `--serverless-version` flag takes. We look only inside that Databricks
+ * metadata block (a plain Jupyter notebook has no such key and contributes
+ * nothing), and defensively walk it for `environment_version` so a slightly
+ * different nesting still resolves. Input is the already-parsed notebook JSON
+ * (the caller reads and JSON-parses the files), so this stays pure and
+ * unit-testable. Versions are de-duplicated, preserving first-seen order.
+ */
+export function collectNotebookServerlessVersions(
+    notebooks: unknown[]
+): VersionObservation[] {
+    const versions: string[] = [];
+    const seen = new Set<string>();
+
+    for (const notebook of notebooks) {
+        const dbMetadata = getDatabricksMetadata(notebook);
+        const version = findEnvironmentVersion(dbMetadata);
+        if (version !== undefined && !seen.has(version)) {
+            seen.add(version);
+            versions.push(version);
+        }
+    }
+
+    return versions.map((version) => ({version, source: "notebook"}));
+}
+
+/** The Databricks notebook metadata block, or undefined if this isn't one. */
+function getDatabricksMetadata(notebook: unknown): unknown {
+    if (notebook === null || typeof notebook !== "object") {
+        return undefined;
+    }
+    const metadata = (notebook as {metadata?: unknown}).metadata;
+    if (metadata === null || typeof metadata !== "object") {
+        return undefined;
+    }
+    return (metadata as Record<string, unknown>)[
+        DATABRICKS_NOTEBOOK_METADATA_KEY
+    ];
+}
+
+/**
+ * Find the first `environment_version` anywhere under `node`, normalized to a
+ * bare string. Defensive walk (the field normally sits under
+ * `environmentMetadata`) that tolerates missing keys and string/`null` nodes.
+ */
+function findEnvironmentVersion(node: unknown): string | undefined {
+    if (node === null || typeof node !== "object") {
+        return undefined;
+    }
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            const found = findEnvironmentVersion(item);
+            if (found !== undefined) {
+                return found;
+            }
+        }
+        return undefined;
+    }
+    for (const [key, value] of Object.entries(node)) {
+        if (key === "environment_version") {
+            const version = normalizeVersion(value);
+            if (version !== undefined) {
+                return version;
+            }
+        } else {
+            const found = findEnvironmentVersion(value);
+            if (found !== undefined) {
+                return found;
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Accept a scalar `environment_version` (string, or number since JSON may store
+ * it unquoted) and return its bare-string form; reject empty strings and
+ * non-scalar values.
+ */
+function normalizeVersion(value: unknown): string | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return String(value);
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+    }
+    return undefined;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.test.ts
@@ -44,6 +44,13 @@ describe("collectProjectNotebookVersions", () => {
         writeFileSync(full, notebookWithVersion(version));
     }
 
+    /** Write arbitrary raw content at `relativePath` under `root`. */
+    function writeRaw(root: string, relativePath: string, content: string) {
+        const full = path.join(root, relativePath);
+        mkdirSync(path.dirname(full), {recursive: true});
+        writeFileSync(full, content);
+    }
+
     it("collects versions from the project's own notebooks", async () => {
         const root = tempProject();
         writeNotebook(root, "analysis.ipynb", "5");
@@ -84,5 +91,37 @@ describe("collectProjectNotebookVersions", () => {
     it("returns nothing for a project with no notebooks", async () => {
         const root = tempProject();
         expect(await collectProjectNotebookVersions(root)).to.deep.equal([]);
+    });
+
+    it("skips the parse for notebooks that don't mention the version field", async () => {
+        const root = tempProject();
+        // A versioned notebook -- collected as usual.
+        writeNotebook(root, "real.ipynb", "5");
+        // A notebook that doesn't mention environment_version: the pre-filter
+        // skips it before parsing. Written as invalid JSON to prove the parse
+        // is skipped -- if it were parsed, this would still be ignored, but the
+        // point is it never reaches JSON.parse.
+        writeRaw(root, "plain.ipynb", '{"cells": [ this is not valid json');
+
+        const observed = await collectProjectNotebookVersions(root);
+
+        expect(observed).to.deep.equal([{version: "5", source: "notebook"}]);
+    });
+
+    it("collects across many notebooks (past the concurrency batch boundary)", async () => {
+        const root = tempProject();
+        // More than SCAN_CONCURRENCY (20) notebooks, with a distinct version
+        // only on the last few, to exercise batching and first-seen ordering.
+        for (let i = 0; i < 25; i++) {
+            writeNotebook(root, `nb${i}.ipynb`, "5");
+        }
+        writeNotebook(root, "late.ipynb", "4");
+
+        const observed = await collectProjectNotebookVersions(root);
+
+        expect(observed).to.have.deep.members([
+            {version: "5", source: "notebook"},
+            {version: "4", source: "notebook"},
+        ]);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {mkdirSync, writeFileSync} from "node:fs";
+import {collectProjectNotebookVersions} from "./projectNotebookVersions";
+
+const NOTEBOOK_METADATA_KEY = "application/vnd.databricks.v1+notebook";
+
+/** A minimal Databricks notebook JSON string carrying a serverless version. */
+function notebookWithVersion(version: string): string {
+    return JSON.stringify({
+        metadata: {
+            [NOTEBOOK_METADATA_KEY]: {
+                environmentMetadata: {environment_version: version},
+            },
+        },
+        cells: [],
+    });
+}
+
+describe("collectProjectNotebookVersions", () => {
+    const cleanups: Array<() => void> = [];
+    afterEach(() => {
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    function tempProject(): string {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        return dir.name;
+    }
+
+    /** Write a notebook at `relativePath` under `root`, creating parent dirs. */
+    function writeNotebook(
+        root: string,
+        relativePath: string,
+        version: string
+    ) {
+        const full = path.join(root, relativePath);
+        mkdirSync(path.dirname(full), {recursive: true});
+        writeFileSync(full, notebookWithVersion(version));
+    }
+
+    it("collects versions from the project's own notebooks", async () => {
+        const root = tempProject();
+        writeNotebook(root, "analysis.ipynb", "5");
+        writeNotebook(root, "src/etl.ipynb", "4");
+
+        const observed = await collectProjectNotebookVersions(root);
+
+        expect(observed).to.have.deep.members([
+            {version: "5", source: "notebook"},
+            {version: "4", source: "notebook"},
+        ]);
+    });
+
+    it("ignores notebooks under excluded dependency/venv trees", async () => {
+        const root = tempProject();
+        // The user's own notebook -- should be collected.
+        writeNotebook(root, "notebook.ipynb", "5");
+        // Notebooks shipped by dependencies / provisioned venv / build output --
+        // must NOT contribute (a package's sample notebook could otherwise
+        // inject a spurious, notebook-weighted version).
+        writeNotebook(
+            root,
+            ".venv/lib/python3.12/site-packages/pkg/demo.ipynb",
+            "3"
+        );
+        writeNotebook(root, "venv/share/example.ipynb", "3");
+        writeNotebook(root, "node_modules/some-dep/nb.ipynb", "2");
+        writeNotebook(root, ".git/stash.ipynb", "1");
+        writeNotebook(root, ".databricks/cache.ipynb", "1");
+        writeNotebook(root, "dist/bundled.ipynb", "2");
+        writeNotebook(root, "build/out.ipynb", "2");
+
+        const observed = await collectProjectNotebookVersions(root);
+
+        expect(observed).to.deep.equal([{version: "5", source: "notebook"}]);
+    });
+
+    it("returns nothing for a project with no notebooks", async () => {
+        const root = tempProject();
+        expect(await collectProjectNotebookVersions(root)).to.deep.equal([]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
@@ -37,14 +37,31 @@ const IGNORED_NOTEBOOK_DIRS = [
 const MAX_NOTEBOOKS_SCANNED = 200;
 
 /**
+ * How many notebooks to read+scan at once. `.ipynb` files embed cell outputs
+ * (plots, images) and can be tens of MB each, so reading all of them at once
+ * would spike memory; a small window bounds peak footprint while keeping the
+ * scan I/O-parallel.
+ */
+const SCAN_CONCURRENCY = 20;
+
+/**
+ * The notebook field the collector looks for. Used here purely as a cheap
+ * substring pre-filter before the expensive parse -- keep it in sync with the
+ * key walked in {@link collectNotebookServerlessVersions}.
+ */
+const ENVIRONMENT_VERSION_FIELD = "environment_version";
+
+/**
  * Read the project's `.ipynb` files and collect their serverless environment
  * versions as scoring observations (source `notebook`).
  *
  * Thin I/O wrapper over the pure {@link collectNotebookServerlessVersions}: it
  * finds notebooks under `projectRoot` (excluding {@link IGNORED_NOTEBOOK_DIRS}),
- * JSON-parses each (skipping any that fail to read/parse — a malformed notebook
- * must never block compute selection), and hands the parsed objects to the
- * collector.
+ * reads each (skipping any that fail to read/parse — a malformed notebook must
+ * never block compute selection), and hands the parsed objects to the
+ * collector. Reads run in bounded-concurrency batches and skip the JSON parse
+ * for notebooks that can't declare a version (see {@link readNotebookIfVersioned}),
+ * so a large repo of heavy notebooks doesn't stall the compute picker.
  */
 export async function collectProjectNotebookVersions(
     projectRoot: string
@@ -64,16 +81,35 @@ export async function collectProjectNotebookVersions(
         );
     }
 
-    const notebooks = await Promise.all(
-        files.map(async (file) => {
-            try {
-                return JSON.parse(await readFile(file, "utf-8"));
-            } catch {
-                // Unreadable / non-JSON notebook — contribute nothing.
-                return undefined;
-            }
-        })
-    );
+    const notebooks: unknown[] = [];
+    for (let i = 0; i < files.length; i += SCAN_CONCURRENCY) {
+        const batch = files.slice(i, i + SCAN_CONCURRENCY);
+        notebooks.push(
+            ...(await Promise.all(batch.map(readNotebookIfVersioned)))
+        );
+    }
 
     return collectNotebookServerlessVersions(notebooks);
+}
+
+/**
+ * Read one notebook and return its parsed JSON, or undefined if it can't
+ * contribute a version. A cheap substring check runs first: a notebook whose
+ * raw text doesn't even mention {@link ENVIRONMENT_VERSION_FIELD} cannot declare
+ * a serverless version, so we skip the `JSON.parse` (and the large object
+ * allocation a plot-heavy notebook would incur) entirely -- the common case,
+ * since most notebooks have no serverless environment. Unreadable / non-JSON
+ * files contribute nothing rather than throwing.
+ */
+async function readNotebookIfVersioned(file: string): Promise<unknown> {
+    try {
+        const raw = await readFile(file, "utf-8");
+        if (!raw.includes(ENVIRONMENT_VERSION_FIELD)) {
+            return undefined;
+        }
+        return JSON.parse(raw);
+    } catch {
+        // Unreadable / non-JSON notebook — contribute nothing.
+        return undefined;
+    }
 }

--- a/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
@@ -1,28 +1,68 @@
 import {readFile} from "fs/promises";
 import path from "path";
 import {glob} from "glob";
+import {logging} from "@databricks/sdk-experimental";
+import {Loggers} from "../../logger";
 import {VersionObservation} from "./serverlessVersionScoring";
 import {collectNotebookServerlessVersions} from "./notebookServerlessVersions";
+
+/**
+ * Directory trees excluded from the notebook scan. These hold notebooks that
+ * are not the user's own project sources -- most importantly the python-setup
+ * feature provisions its venv *inside* the project root (`.venv`), and Python
+ * packages routinely ship example `.ipynb` files under `site-packages`, whose
+ * `environment_version` would otherwise be harvested as a (notebook-weighted)
+ * scoring signal. `.git`/`.databricks`/build+dependency dirs are skipped for
+ * the same reason and to keep the scan cheap.
+ */
+const IGNORED_NOTEBOOK_DIRS = [
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/venv/**",
+    "**/site-packages/**",
+    "**/.git/**",
+    "**/.databricks/**",
+    "**/dist/**",
+    "**/build/**",
+];
+
+/**
+ * Upper bound on notebooks read in a single scan. The version signal saturates
+ * long before this (a handful of distinct versions across a project), so this
+ * only guards the pathological case -- a repo with thousands of notebooks --
+ * from turning the compute picker into a slow, memory-heavy operation. When the
+ * cap is hit we scan the first `MAX_NOTEBOOKS_SCANNED` and log the rest as
+ * skipped rather than silently truncating.
+ */
+const MAX_NOTEBOOKS_SCANNED = 200;
 
 /**
  * Read the project's `.ipynb` files and collect their serverless environment
  * versions as scoring observations (source `notebook`).
  *
  * Thin I/O wrapper over the pure {@link collectNotebookServerlessVersions}: it
- * finds notebooks under `projectRoot`, JSON-parses each (skipping any that fail
- * to read/parse — a malformed notebook must never block compute selection), and
- * hands the parsed objects to the collector. `node_modules` is excluded so we
- * don't scan dependency notebooks.
+ * finds notebooks under `projectRoot` (excluding {@link IGNORED_NOTEBOOK_DIRS}),
+ * JSON-parses each (skipping any that fail to read/parse — a malformed notebook
+ * must never block compute selection), and hands the parsed objects to the
+ * collector.
  */
 export async function collectProjectNotebookVersions(
     projectRoot: string
 ): Promise<VersionObservation[]> {
-    const files = await glob(path.join(projectRoot, "**", "*.ipynb"), {
+    const allFiles = await glob(path.join(projectRoot, "**", "*.ipynb"), {
         // path.join uses "\" on Windows; glob wants "/", so opt out of escaping.
         windowsPathsNoEscape: true,
-        ignore: "**/node_modules/**",
+        ignore: IGNORED_NOTEBOOK_DIRS,
         nodir: true,
     });
+
+    const files = allFiles.slice(0, MAX_NOTEBOOKS_SCANNED);
+    if (allFiles.length > files.length) {
+        logging.NamedLogger.getOrCreate(Loggers.Extension).info(
+            `Serverless version scan: found ${allFiles.length} notebooks, ` +
+                `scanning the first ${files.length}.`
+        );
+    }
 
     const notebooks = await Promise.all(
         files.map(async (file) => {

--- a/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/projectNotebookVersions.ts
@@ -1,0 +1,39 @@
+import {readFile} from "fs/promises";
+import path from "path";
+import {glob} from "glob";
+import {VersionObservation} from "./serverlessVersionScoring";
+import {collectNotebookServerlessVersions} from "./notebookServerlessVersions";
+
+/**
+ * Read the project's `.ipynb` files and collect their serverless environment
+ * versions as scoring observations (source `notebook`).
+ *
+ * Thin I/O wrapper over the pure {@link collectNotebookServerlessVersions}: it
+ * finds notebooks under `projectRoot`, JSON-parses each (skipping any that fail
+ * to read/parse — a malformed notebook must never block compute selection), and
+ * hands the parsed objects to the collector. `node_modules` is excluded so we
+ * don't scan dependency notebooks.
+ */
+export async function collectProjectNotebookVersions(
+    projectRoot: string
+): Promise<VersionObservation[]> {
+    const files = await glob(path.join(projectRoot, "**", "*.ipynb"), {
+        // path.join uses "\" on Windows; glob wants "/", so opt out of escaping.
+        windowsPathsNoEscape: true,
+        ignore: "**/node_modules/**",
+        nodir: true,
+    });
+
+    const notebooks = await Promise.all(
+        files.map(async (file) => {
+            try {
+                return JSON.parse(await readFile(file, "utf-8"));
+            } catch {
+                // Unreadable / non-JSON notebook — contribute nothing.
+                return undefined;
+            }
+        })
+    );
+
+    return collectNotebookServerlessVersions(notebooks);
+}


### PR DESCRIPTION
> **Stacked on #2052** (base = `rugpanov/python-setup-serverless-picker`). Review after #2052; the diff of interest is the commits on top. GitHub retargets to `main` once #2052 merges.

## Why

Selecting **Serverless** in the compute picker only ever recorded a boolean — the serverless *environment version* was then either an invisible setting (legacy pip flow reads `serverlessDbconnectVersion`) or would have to be asked on every setup run. This merges the version choice **into the compute picker**: the user confirms it once, at compute-selection time, and it's persisted with the selection so setup never re-prompts.

Part of DECO-27786 (see the split note below).

## What

1. **Persist** — `OverrideableConfigState.serverlessVersion?: string` (routes through the existing `ConfigModel` overrideable path automatically).
2. **ConnectionManager** — `enableServerless(version?)` persists it (also when serverless is already on, so re-picking the version alone saves); `disableServerless()` clears it; `updateServerless()` loads it on reload **and re-validates it** (a hand-edited / out-of-range value is dropped to the scored default rather than exposed as a valid `--serverless-version`); new `get serverlessVersion()`.
3. **Bundle collector** — `collectBundleServerlessVersions(bundle)`: defensively walks the parsed bundle and harvests every serverless `environment_version` (a bare integer, same form `--serverless-version` takes) as a `bundleYaml` scoring observation, so the picker is seeded with real candidates rather than a lone fallback.
4. **Notebook collector** — `collectNotebookServerlessVersions(notebooks)` + `collectProjectNotebookVersions(projectRoot)`: harvest the serverless version recorded in `.ipynb` metadata (`metadata["application/vnd.databricks.v1+notebook"].environmentMetadata.environment_version`) as a `notebook` scoring observation. The project scan excludes dependency/venv/build trees (`.venv`, `site-packages`, `node_modules`, `.git`, `.databricks`, `dist`, `build`) so a package's sample notebook can't inject a spurious signal, is capped (200 notebooks) and runs bounded-concurrency batches with a cheap substring pre-filter to skip the JSON parse of notebooks that don't declare a version — so it can't stall the compute picker on a large repo.
5. **Picker wiring** — `ConnectionCommands`: choosing Serverless routes through `selectServerless()`, which (when opted in) collects the bundle + notebook observations, ranks them, shows #2052's picker (top candidate pre-selected), and persists via `enableServerless(version)`. Each source is collected independently and guarded, so one failing source never blocks the other or compute selection.

## Constraint 1 — backward compatibility

- The persisted field is **optional and independent of `serverless`**. Existing configs with `serverless: true` and no version stay valid — a version-less selection falls back to the scored default (`5`). No migration writes; writing an unrelated key never fabricates a version (tested). A persisted version is re-validated on load, so a downgrade/upgrade that leaves an out-of-range value can't leak it to the CLI.
- **Flag OFF ⇒ the compute picker enables plain serverless, unchanged** (`enableServerless()` with no version). The new field is just an unused optional.
- The pre-existing `databricks.connect.serverlessDbconnectVersion` setting (a DBR/dbconnect version like `17.3`, used by the legacy pip rail) is a **separate namespace** — this code never reads or writes it.
- A bundle or notebook read/parse failure falls back to scoring with no observations rather than blocking compute selection.

## Constraint 2 — feature-flag guard (#2045)

The version sub-step is gated on `isPythonSetupEnabled()` (the `PYTHON_SETUP_FEATURE_ID` opt-in from #2045). Only opted-in users ever see the version picker; everyone else gets the unchanged serverless selection.

## Verification

- `yarn --cwd packages/databricks-vscode test:unit` — 364 passing (config persistence incl. legacy-config-untouched, bundle collector, notebook collector, and project-notebook scan incl. exclusions / parse-skip / batch boundary). ConnectionManager + picker wiring type-checked by `build`.
- `test:lint` — clean · `build` — clean.
- Integration tests — ✅ all 35 jobs passed on the latest commit.

## Note on the ticket split

DECO-27786 (extension wiring & config-view dispatch) is being split into two diffs. **This is Diff A** — the compute-picker merge (shared compute code, releasable on its own). **Diff B** (construct detector/client/orchestrator in `activate()`, `EnvironmentComponent` dispatch, read `serverlessVersion` from `ConnectionManager` in the setup flow) will follow once the orchestrator (#2046) and client (#2039) merge, so it can go cleanly off `main`. Nothing in this diff consumes `serverlessVersion` yet — the picker persists it for Diff B to read.

This pull request and its description were written by Isaac.
