### PR TITLE
[10/?] feat(python-setup): setup-state storage key for drift detection

### DIFF
--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.test.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.test.ts
@@ -1,0 +1,88 @@
+import {expect} from "chai";
+import {ExtensionContext, Memento} from "vscode";
+import {PythonSetupState, StateStorage} from "./StateStorage";
+
+/** Minimal in-memory Memento so StateStorage can be exercised off-host. */
+function fakeMemento(): Memento {
+    const store = new Map<string, unknown>();
+    return {
+        keys: () => [...store.keys()],
+        get: <T>(key: string, defaultValue?: T) =>
+            (store.has(key) ? store.get(key) : defaultValue) as T,
+        update: async (key: string, value: unknown) => {
+            if (value === undefined) {
+                store.delete(key);
+            } else {
+                store.set(key, value);
+            }
+        },
+    } as Memento;
+}
+
+function makeStorage(): StateStorage {
+    const context = {
+        workspaceState: fakeMemento(),
+        globalState: fakeMemento(),
+    } as unknown as ExtensionContext;
+    return new StateStorage(context);
+}
+
+describe("StateStorage python-setup setup state", () => {
+    it("round-trips the persisted setup state", async () => {
+        const storage = makeStorage();
+        const state: PythonSetupState = {
+            envKey: "serverless/serverless-v5",
+            pythonVersion: "3.12",
+            timestamp: "2026-07-27T10:00:00.000Z",
+        };
+
+        await storage.set("databricks.pythonSetup.setupState", state);
+
+        expect(storage.get("databricks.pythonSetup.setupState")).to.deep.equal(
+            state
+        );
+    });
+
+    it("returns undefined before anything is persisted", () => {
+        expect(makeStorage().get("databricks.pythonSetup.setupState")).to.equal(
+            undefined
+        );
+    });
+
+    it("clears the state when set to undefined", async () => {
+        const storage = makeStorage();
+        await storage.set("databricks.pythonSetup.setupState", {
+            envKey: "cluster/0101",
+            pythonVersion: "3.11",
+            timestamp: "2026-07-27T10:00:00.000Z",
+        });
+
+        await storage.set("databricks.pythonSetup.setupState", undefined);
+
+        expect(storage.get("databricks.pythonSetup.setupState")).to.equal(
+            undefined
+        );
+    });
+
+    it("is stored in workspace state (per-project), not global", async () => {
+        const workspaceState = fakeMemento();
+        const globalState = fakeMemento();
+        const storage = new StateStorage({
+            workspaceState,
+            globalState,
+        } as unknown as ExtensionContext);
+
+        await storage.set("databricks.pythonSetup.setupState", {
+            envKey: "serverless/serverless-v5",
+            pythonVersion: "3.12",
+            timestamp: "2026-07-27T10:00:00.000Z",
+        });
+
+        expect(
+            workspaceState.get("databricks.pythonSetup.setupState")
+        ).to.not.equal(undefined);
+        expect(globalState.get("databricks.pythonSetup.setupState")).to.equal(
+            undefined
+        );
+    });
+});

--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
@@ -5,6 +5,23 @@ import {Mutex} from "../locking";
 import lodash from "lodash";
 import {StoredFavoriteRef} from "../ui/unity-catalog/types";
 
+/**
+ * Persisted after a successful uv-native Python environment setup, so a later
+ * change of compute target can be detected as drift (the provisioned env no
+ * longer matches the selected target) and surfaced to the user.
+ *
+ * - `envKey`: the CLI's resolved environment key for the target that was set up
+ *   (e.g. `serverless/serverless-v5`), from the setup-local result.
+ * - `pythonVersion`: the interpreter minor version that was provisioned (e.g.
+ *   `3.12`).
+ * - `timestamp`: ISO-8601 time of the successful setup.
+ */
+export interface PythonSetupState {
+    envKey: string;
+    pythonVersion: string;
+    timestamp: string;
+}
+
 /* eslint-disable @typescript-eslint/naming-convention */
 type KeyInfo<V> = {
     location: "global" | "workspace";
@@ -75,6 +92,12 @@ const StorageConfigurations = {
     "databricks.lastInstalledExtensionVersion": withType<string>()({
         location: "global",
         defaultValue: "0.0.0",
+    }),
+
+    // Per-project: the environment provisioned by the last successful
+    // python-setup run, used to detect drift when the compute target changes.
+    "databricks.pythonSetup.setupState": withType<PythonSetupState>()({
+        location: "workspace",
     }),
 };
 


### PR DESCRIPTION
## Why

After a successful uv-native Python environment setup, the extension needs to remember what environment was provisioned, so a later change of compute target can be detected as **drift** (the local env no longer matches the selected target) and surfaced to the user. This lands the persistence key.

Scoped deliberately to the storage layer: it builds off `main` with no dependency on the (still-open) wiring stack. The **write site** — the orchestrator's `saveState` — is wired separately when the extension-wiring PR (#2054) lands; it currently holds a `TODO(DECO-27784)` no-op that this key will back.

## What

- **`PythonSetupState`** type — `{envKey, pythonVersion, timestamp}`:
  - `envKey`: the CLI's resolved environment key for the target (e.g. `serverless/serverless-v5`).
  - `pythonVersion`: the provisioned interpreter minor version (e.g. `3.12`).
  - `timestamp`: ISO-8601 time of the successful setup.
- **`"databricks.pythonSetup.setupState"`** `StorageConfigurations` entry, **workspace-scoped** (drift is per-project). Flows through the existing typed `get`/`set` surface — no new accessor code.
- **First `StateStorage` unit test** (in-memory `Memento` fake): round-trip, undefined-before-write, clear-on-undefined, and workspace-not-global placement.

## Verification

- `yarn --cwd packages/databricks-vscode build / test:lint / test:unit` — 329 passing (4 new). Build confirms the typed key resolves through `get`/`set`.

This pull request and its description were written by Isaac.