### PR TITLE
test(e2e): harden run_files cancel against toast-action race and unbounded poll

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/run_files.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_files.e2e.ts
@@ -49,30 +49,76 @@ describe("Run files", async function () {
     it("should cancel a run during deployment", async () => {
         const workbench = await driver.getWorkbench();
         await executeCommandWhenAvailable("Databricks: Upload and Run File");
-        await browser.waitUntil(async () => {
-            const notifications = await workbench.getNotifications();
-            console.log("Notifications:", notifications.length);
-            for (const notification of notifications) {
-                const message = await notification.getMessage();
-                console.log("Message:", message);
-                if (message.includes("Uploading bundle assets")) {
-                    await notification.takeAction("Cancel");
-                    return true;
+
+        // Catching the in-flight "Uploading bundle assets" toast and clicking
+        // its Cancel action is a tight race on the slow Windows shard: the
+        // toast is transient and its action button can lag the toast body by a
+        // few frames. A throw from takeAction() inside a waitUntil condition
+        // rejects the whole wait — wdio does NOT retry a condition that throws
+        // — which is exactly the "element wasn't found" failure observed in CI.
+        // Guard both the message read and the click so a not-yet-rendered
+        // button just retries on the next poll, and only resolve once the click
+        // actually lands. Fail closed with a clear message if the cancellable
+        // toast never appears.
+        let cancelled = false;
+        await browser.waitUntil(
+            async () => {
+                const notifications = await workbench.getNotifications();
+                console.log("Notifications:", notifications.length);
+                for (const notification of notifications) {
+                    let message: string;
+                    try {
+                        message = await notification.getMessage();
+                    } catch {
+                        // Notification vanished between listing and read — skip.
+                        continue;
+                    }
+                    console.log("Message:", message);
+                    if (message.includes("Uploading bundle assets")) {
+                        try {
+                            await notification.takeAction("Cancel");
+                            cancelled = true;
+                            return true;
+                        } catch {
+                            // The Cancel button hasn't rendered yet; retry.
+                            return false;
+                        }
+                    }
                 }
+                return false;
+            },
+            {
+                timeout: 60_000,
+                interval: 500,
+                timeoutMsg:
+                    "The cancellable 'Uploading bundle assets' notification never appeared",
             }
-            return false;
-        });
+        );
+        assert(
+            cancelled,
+            "Failed to click Cancel on the deployment notification"
+        );
+
+        // Previously an unbounded `while (true)` poll: if "Cancelled" never
+        // showed (cancel didn't register, or the deploy already finished) it
+        // spun until the per-test mocha timeout surfaced as a bare
+        // `Error: Timeout` with no context. Bound the wait so a genuine miss
+        // fails fast with a diagnostic reason instead.
         const debugOutput = await workbench
             .getBottomBar()
             .openDebugConsoleView();
-        while (true) {
-            const text = await (await debugOutput.elem).getHTML();
-            if (text && text.includes("Cancelled")) {
-                break;
-            } else {
-                await sleep(2000);
+        await browser.waitUntil(
+            async () => {
+                const text = await (await debugOutput.elem).getHTML();
+                return Boolean(text && text.includes("Cancelled"));
+            },
+            {
+                timeout: 120_000,
+                interval: 2_000,
+                timeoutMsg:
+                    "Deployment run did not report 'Cancelled' in the debug console",
             }
-        }
+        );
     });
 
     it("should run a python file on a cluster", async () => {


### PR DESCRIPTION
## Why

`Run files :: should cancel a run during deployment` is the **top e2e flake** in recent `vscode-isolated-pr` runs — 3 hits in ~24h, all on the Windows shard — with two distinct failure signatures that both trace to unguarded spots in the test:

- **`Can't call elementClick ... title='Cancel' ... element wasn't found`** — `takeAction("Cancel")` runs *inside* a `browser.waitUntil` condition. wdio rejects a condition that **throws** rather than retrying it, so a Cancel button that hasn't rendered yet kills the test instead of being retried on the next poll.
- **bare `Error: Timeout`** — the follow-up `while (true)` poll for `"Cancelled"` in the debug console has **no timeout**, so a missed cancel spins until mocha's per-test timeout with zero diagnostic context.

## What

- Wrap the notification message read and `takeAction("Cancel")` in `try/catch` inside the `waitUntil` condition, so a not-yet-rendered button (or a toast that vanished between listing and click) simply retries on the next 500ms poll. A `cancelled` flag is asserted afterward, with an explicit `timeoutMsg`, so a genuinely absent toast fails **closed** with a clear reason (60s budget).
- Replace the unbounded `while (true)` `"Cancelled"` poll with a bounded `browser.waitUntil` (120s, 2s interval) that fails with a diagnostic `timeoutMsg` instead of a context-free mocha timeout.

No production code changes. The test still requires a **real** Cancel click and a **real** `"Cancelled"` debug-console line, so a broken cancel path cannot pass silently.

## Verification

- `prettier --check`: clean
- `eslint`: clean
- `tsc --noEmit` (e2e tsconfig): no errors
- Isolated `vscode-isolated-pr` runs dispatched against this branch.

This pull request and its description were written by Isaac.