### PR TITLE
feat(python-setup): rename result `target` field to `compute` (ext side)

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -121,7 +121,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         expect(adopted).to.deep.equal([SUCCESS_REAL_RUN.venvPath]);
         expect(saved).to.deep.equal([
             {
-                envKey: SUCCESS_REAL_RUN.target!.envKey,
+                envKey: SUCCESS_REAL_RUN.compute!.envKey,
                 pythonVersion: SUCCESS_REAL_RUN.resolved!.pythonVersion,
             },
         ]);
@@ -248,12 +248,12 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         const shownErrors: string[] = [];
         const adopted: string[] = [];
         const saved: unknown[] = [];
-        // ok:true with a venvPath but no target/resolved: we could adopt an
+        // ok:true with a venvPath but no compute/resolved: we could adopt an
         // interpreter, but drift detection would have no baseline to persist —
         // so this is treated as a failure rather than a hollow "ready".
         const withoutBaseline: PythonSetupResult = {
             ...SUCCESS_REAL_RUN,
-            target: undefined,
+            compute: undefined,
             resolved: undefined,
         };
         const setup = new PythonSetupEnvironmentSetup(

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -31,7 +31,7 @@ export interface PythonSetupPersistedState {
 }
 
 type ReadyLocalEnvironmentResult = PythonSetupResult &
-    Required<Pick<PythonSetupResult, "venvPath" | "target" | "resolved">>;
+    Required<Pick<PythonSetupResult, "venvPath" | "compute" | "resolved">>;
 
 function isLocalEnvironmentReady(
     r: PythonSetupResult
@@ -39,7 +39,7 @@ function isLocalEnvironmentReady(
     return (
         isPythonSetupSuccess(r) &&
         r.venvPath !== undefined &&
-        r.target !== undefined &&
+        r.compute !== undefined &&
         r.resolved !== undefined
     );
 }
@@ -197,7 +197,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         }
 
         this.deps.saveState({
-            envKey: result.target.envKey,
+            envKey: result.compute.envKey,
             pythonVersion: result.resolved.pythonVersion,
         });
 

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
@@ -24,8 +24,8 @@ describe("parsePythonSetupResult", () => {
         expect(r.schemaVersion).to.equal(1);
         expect(r.mode).to.equal("default");
         expect(r.dryRun).to.equal(true);
-        expect(r.target?.serverlessVersion).to.equal("v4");
-        expect(r.target?.envKey).to.equal("serverless/serverless-v4");
+        expect(r.compute?.serverlessVersion).to.equal("v4");
+        expect(r.compute?.envKey).to.equal("serverless/serverless-v4");
         expect(r.resolved?.pythonVersion).to.equal("3.12");
         expect(r.resolved?.dbconnectVersion).to.equal("17.2.0");
         expect(r.error).to.equal(null);

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
@@ -99,9 +99,9 @@ export interface PythonSetupResult {
     dryRun: boolean;
     /**
      * The resolved compute the environment was provisioned against. Mirrors the
-     * CLI's `compute` result key (renamed from `target` in databricks/cli#6100,
-     * DECO-27794) so the structural cast in {@link parsePythonSetupResult} keeps
-     * matching the wire shape.
+     * CLI's `compute` result key (renamed from `target` in databricks/cli#6100)
+     * so the structural cast in {@link parsePythonSetupResult} keeps matching the
+     * wire shape.
      */
     compute?: PythonSetupComputeInfo;
     resolved?: PythonSetupResolvedInfo;

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
@@ -47,7 +47,7 @@ export type PythonSetupErrorCode =
     | "E_PROVISION"
     | "E_VALIDATE";
 
-export interface PythonSetupTargetInfo {
+export interface PythonSetupComputeInfo {
     source: string;
     clusterId?: string;
     serverlessVersion?: string;
@@ -97,11 +97,13 @@ export interface PythonSetupResult {
     ok: boolean;
     mode: PythonSetupMode;
     dryRun: boolean;
-    // TODO: rename to `compute` (+ PythonSetupTargetInfo -> PythonSetupComputeInfo)
-    // to match SetupLocalInvocation.compute. This field mirrors the CLI's wire
-    // key `target`, so the rename must land in the CLI's --output json first
-    // (with a schemaVersion bump), then here.
-    target?: PythonSetupTargetInfo;
+    /**
+     * The resolved compute the environment was provisioned against. Mirrors the
+     * CLI's `compute` result key (renamed from `target` in databricks/cli#6100,
+     * DECO-27794) so the structural cast in {@link parsePythonSetupResult} keeps
+     * matching the wire shape.
+     */
+    compute?: PythonSetupComputeInfo;
     resolved?: PythonSetupResolvedInfo;
     greenfield: boolean;
     plan?: PythonSetupPlan;

--- a/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
+++ b/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
@@ -31,7 +31,7 @@ export const SUCCESS_DEFAULT: PythonSetupResult = {
     ok: true,
     mode: "default",
     dryRun: true,
-    target: {
+    compute: {
         source: "serverless",
         serverlessVersion: "v4",
         envKey: "serverless/serverless-v4",
@@ -67,7 +67,7 @@ export const SUCCESS_CONSTRAINTS_ONLY: PythonSetupResult = {
     ok: true,
     mode: "constraints-only",
     dryRun: true,
-    target: {
+    compute: {
         source: "serverless",
         serverlessVersion: "v4",
         envKey: "serverless/serverless-v4",
@@ -164,7 +164,7 @@ export const SUCCESS_REAL_RUN: PythonSetupResult = {
     ok: true,
     mode: "default",
     dryRun: false,
-    target: {
+    compute: {
         source: "serverless",
         serverlessVersion: "v4",
         envKey: "serverless/serverless-v4",

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -47,14 +47,14 @@ describe("getPythonSetupErrorMessage", () => {
         const r = failure(
             "E_ENV_UNSUPPORTED",
             {failurePhase: "fetch"},
-            {target: {source: "cluster", envKey: "dbr/15.4.x-scala2.12"}}
+            {compute: {source: "cluster", envKey: "dbr/15.4.x-scala2.12"}}
         );
         const msg = getPythonSetupErrorMessage(r);
         expect(msg).to.contain("dbr/15.4.x-scala2.12");
         expect(msg).to.match(/lts|latest/i);
     });
 
-    it("maps E_ENV_UNSUPPORTED without a target gracefully", () => {
+    it("maps E_ENV_UNSUPPORTED without a compute gracefully", () => {
         const msg = getPythonSetupErrorMessage(failure("E_ENV_UNSUPPORTED"));
         expect(msg).to.match(/no matched environment/i);
         expect(msg).to.not.contain("undefined");

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -35,7 +35,7 @@ const BASE_MESSAGE: Record<
     E_RESOLVE: () =>
         "Could not resolve the selected compute. Check the cluster/serverless selection and try again.",
     E_ENV_UNSUPPORTED: (r) => {
-        const key = r.target?.envKey;
+        const key = r.compute?.envKey;
         const which = key ? `for ${key}` : "for the selected compute";
         return (
             `No matched environment ${which}. ` +


### PR DESCRIPTION
## What

Extension-side half of the `setup-local --output json` `target` → `compute`
rename. Follows the CLI half in databricks/cli#6100.

```diff
- "target": { "source": "serverless", "envKey": "serverless/serverless-v5", ... }
+ "compute": { "source": "serverless", "envKey": "serverless/serverless-v5", ... }
```

- `PythonSetupTargetInfo` → `PythonSetupComputeInfo`; `PythonSetupResult.target?` → `compute?` (inner fields unchanged — only the outer key renames, mirroring #6100's `result.go`).
- Golden fixtures (`setupLocalResults.ts`): 3× `target:` → `compute:`, kept verbatim from the CLI acceptance goldens.
- Consumers updated: orchestrator (`isLocalEnvironmentReady` / `saveState`), `errorMessages.ts` (`r.compute?.envKey`), and their tests.
- Dropped the placeholder TODO on the field.

## Why the extension field name must match the wire key

The extension parses the CLI result with a bare structural cast (no field mapping), so the TypeScript field name must equal the JSON key the CLI emits. The fixtures are compile-coupled to the contract type, so this is proven at build time.

## Deliberately NOT renamed

- **`E_NO_TARGET` / `ERROR_NO_TARGET`** — mirror the stable wire error-code string, which #6100 keeps.

## Blocked on

⛔ **databricks/cli#6100** (CLI side) must merge first, so the CLI's `--output json` emits `compute` and the acceptance goldens flip. Until then the fixtures here would diverge from the upstream goldens they mirror. schemaVersion stays 1 (command still hidden, no shipped consumer).

## Test

`yarn build`, `yarn test:lint`, `yarn test:unit` (415 passing) — all green.

This pull request and its description were written by Isaac.