### PR TITLE
docs: add a convention for where module documentation goes

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -100,6 +100,8 @@ makes it hard to unit-test (see section 8).
    dependencies, register commands.
 7. **Add a barrel (`index.ts`) only if the feature has a clear public surface**
    other modules import — and make it a _selective_ re-export, not `export *`.
+8. **If the feature needs a prose doc, add `README.md` to its folder** — see
+   section 4a. Most features don't.
 
 A typical new feature:
 
@@ -176,6 +178,66 @@ Three decorators are in use — prefer them over hand-rolled equivalents:
   `console.log`** (`no-console` is an ESLint error outside tests).
 - Define new telemetry events in `telemetry/constants.ts`. User-facing commands are
   instrumented automatically by the `telemetry.registerCommand` wrapper (section 6).
+- **`EventTypes` in `telemetry/constants.ts` is the only source of truth for an
+  event's schema.** Each field carries a `comment`; `telemetry.json` is generated
+  from the class by `scripts/generateTelemetry.ts` and is gitignored. Never
+  hand-maintain a field list elsewhere — including in prose docs, which go stale
+  silently while the generated file stays correct.
+
+---
+
+## 4a. Where module documentation goes
+
+Most code needs no prose doc — a class doc-comment and good names are enough.
+When a module genuinely needs one (a design rationale, a privacy posture, a
+protocol), write a **`README.md` in the module's folder**, next to the code it
+describes.
+
+- **`README.md`, not a descriptive name.** Prefer `src/telemetry/README.md` over
+  `src/telemetry/MY_FEATURE_TELEMETRY.md`. A file named for one feature inside a
+  shared folder is undiscoverable — nothing links to it, and the next person adds
+  a second one rather than extending it. `README.md` is the name tooling and humans
+  already look for, and GitHub renders it when browsing the folder.
+  (`src/telemetry/PACKAGE_MANAGER_DETECTION.md` predates this rule; fold such files
+  into the folder's `README.md` when you next touch them.)
+- **Document the _why_, not the _what_.** Schemas, field lists, and signatures
+  belong in the code (or, for telemetry, in generated output). A doc that restates
+  them acquires a second source of truth that drifts. Record the decisions and
+  trade-offs that have nowhere else to live.
+- **No top-level `docs/`.** It is gitignored in this repo (local scratch only), so
+  anything committed must live beside the code or in an existing root file
+  (`README.md`, `CONTRIBUTING.md`, this file).
+
+### Why colocation
+
+Surveyed when this convention was written (August 2026):
+
+| Project                             | Practice                                                                                                        |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [microsoft/vscode][vsc]             | Colocated docs, **no top-level `docs/`**: ~29 architecture docs under `src/` (e.g. `src/vs/sessions/LAYOUT.md`) |
+| [facebook/react][react]             | Colocated `README.md` per package (`packages/react-reconciler/README.md`)                                       |
+| [rust-lang/rust][rust]              | Colocated `README.md` per crate, a few lines, pointing at the external dev guide                                |
+| [vscode-pull-request-github][vscpr] | Centralized `documentation/` directory                                                                          |
+| [kubernetes][k8s], [eslint][eslint] | Centralized `docs/` + external enhancement proposals                                                            |
+
+Both colocation and centralization are well-established; there is no universal
+answer. We colocate because this repo has no committed `docs/` tree, and we
+standardize on `README.md` (React/Rust style) rather than VS Code's
+descriptive-filename style because the latter only stays navigable when a folder is
+one subsystem — `src/telemetry/` serves every feature.
+
+**Telemetry specifically:** VS Code documents events _inline in TypeScript_ — GDPR
+classification, purpose, and comment in a type beside the emit call — with no
+per-event markdown ([`telemetry.instructions.md`][vsctel]). Our `EventTypes`
+`comment` fields are the same idea, which is why prose docs must not duplicate them.
+
+[vsc]: https://github.com/microsoft/vscode/tree/main/src/vs/sessions
+[vsctel]: https://github.com/microsoft/vscode/blob/main/.github/instructions/telemetry.instructions.md
+[react]: https://github.com/facebook/react/blob/main/packages/react-reconciler/README.md
+[rust]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/README.md
+[vscpr]: https://github.com/microsoft/vscode-pull-request-github/tree/main/documentation
+[k8s]: https://github.com/kubernetes/enhancements
+[eslint]: https://github.com/eslint/eslint/tree/main/docs
 
 ---
 


### PR DESCRIPTION
## Why

We have no rule for where a module's prose documentation lives, and the result drifts. `src/telemetry/` picked up a feature-specific `PACKAGE_MANAGER_DETECTION.md` that nothing links to, and a second such file was about to land beside it. A folder that accumulates one markdown file per feature is a folder nobody reads.

## What

Adds `CODE_CONVENTIONS.md` section 4a with three rules:

- **When a module needs a prose doc, it is `README.md` in the module's folder** — the name tooling and humans already look for, and what GitHub renders when browsing. Not a per-feature descriptive filename.
- **Document the *why*, not the *what*.** Schemas, field lists and signatures belong in the code or in generated output; prose that restates them becomes a second source of truth that drifts.
- **No top-level `docs/`** — it's gitignored in this repo, so anything committed lives beside the code or in an existing root file.

Also states explicitly (here and in the section 4 telemetry bullet) that `EventTypes` in `telemetry/constants.ts` is the only place an event schema may be maintained, since `telemetry.json` is generated from it.

## The survey behind it

The section records the evidence rather than just asserting a preference, so the premise can be argued with:

| Project | Practice |
|---|---|
| microsoft/vscode | Colocated docs, **no top-level `docs/`** — ~29 architecture docs under `src/` (e.g. `src/vs/sessions/LAYOUT.md`) |
| facebook/react | Colocated `README.md` per package |
| rust-lang/rust | Colocated `README.md` per crate, pointing at the external dev guide |
| vscode-pull-request-github | Centralized `documentation/` |
| kubernetes, eslint | Centralized `docs/` + external enhancement proposals |

Both colocation and centralization are well-established; there is no universal answer. We colocate because `docs/` is gitignored here, and standardize on `README.md` rather than VS Code's descriptive-filename style because the latter only stays navigable when a folder is one subsystem — `src/telemetry/` serves every feature.

Worth noting for telemetry specifically: VS Code documents events *inline in TypeScript* (GDPR classification and comment in a type beside the emit call), with no per-event markdown. Our `EventTypes` `comment` fields are the same idea, which is why prose docs must not duplicate them.

## Notes

- Split out of #2074 on review feedback — a repo-wide rule shouldn't ride in on a feature PR. That PR keeps only its own `src/telemetry/README.md`.
- The existing `PACKAGE_MANAGER_DETECTION.md` is left in place; the section says to fold such files in when next touched, rather than churning a file this PR has no other reason to open.
- This documents a convention, it doesn't enforce one. No lint rule.

## Verification

Docs only, no code touched. I verified every path and claim the section cites exists on `main` (`PACKAGE_MANAGER_DETECTION.md`, `python-setup/README.md`, `scripts/generateTelemetry.ts`, `docs/` in `.gitignore`) and that the external references resolve. Prettier clean with the repo-pinned 3.1.1.

This pull request and its description were written by Isaac.