### PR TITLE
fix(shellUtils): generate terminal commands for the shell that runs them (#1822)

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
+++ b/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
@@ -15,8 +15,11 @@ import {CliWrapper} from "../cli/CliWrapper";
 import {getSubProjects} from "./BundleFileSet";
 import {tmpdir} from "os";
 import {Events, Telemetry} from "../telemetry";
-import {detectShellKind} from "../utils/shellUtils";
-import {buildBundleInitCommand} from "./bundleInitCommand";
+import {currentShellKind, defaultProfileShellArgs} from "../utils/shellUtils";
+import {
+    buildBundleInitCommand,
+    unsafeOutputDirReason,
+} from "./bundleInitCommand";
 import {promptToSelectActiveProjectFolder} from "./activeBundleUtils";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 
@@ -135,6 +138,23 @@ export class BundleInitWizard {
         parentFolder: Uri,
         authProvider: AuthProvider
     ) {
+        const shell = env.shell;
+        // currentShellKind falls back to the configured default profile when
+        // env.shell is empty, which is the shell VS Code will actually launch
+        // when shellPath is left undefined below.
+        const kind = currentShellKind();
+        // Refuse a directory the target shell would rewrite, rather than
+        // scaffolding somewhere the user never chose and then reporting "no
+        // projects detected".
+        const unsafeReason = unsafeOutputDirReason(parentFolder.fsPath, kind);
+        if (unsafeReason !== undefined) {
+            this.logger.error(
+                `Refusing to run bundle init: ${unsafeReason}`,
+                new Error(unsafeReason)
+            );
+            window.showErrorMessage(unsafeReason);
+            return;
+        }
         const terminalDidClosePromise = new Promise<void>((resolve) => {
             const closeEvent = window.onDidCloseTerminal((t) => {
                 if (t === terminal) {
@@ -160,12 +180,18 @@ export class BundleInitWizard {
         // this, a cmd.exe-shaped command (` & ` separators) sent to a PowerShell
         // profile fails to parse, nothing executes — not even the trailing
         // `exit` — and the await below would hang until the user closes the tab.
-        const shell = env.shell;
+        //
+        // `env.shell` is the default profile's *path* only, so pinning it would
+        // drop the profile's args: a default profile of
+        // `{path: "wsl.exe", args: ["-d", "Ubuntu-22.04"]}` would land in the
+        // default distro and scaffold into the wrong filesystem. Forward the
+        // configured args alongside the path to keep the two consistent.
         const terminal = window.createTerminal({
             name: "Databricks Project Init",
             isTransient: true,
             location: TerminalLocation.Editor,
             shellPath: shell === "" ? undefined : shell,
+            shellArgs: shell === "" ? undefined : defaultProfileShellArgs(),
             env: {
                 // Without supplying full environment and with `strictEnv: true` PowerShell will fail to start.
                 // On unix-like systems we don't require full environment, but it doesn't hurt.
@@ -180,7 +206,6 @@ export class BundleInitWizard {
             cwd: tmpdir(),
         });
         await terminalDidOpenPromise;
-        const kind = detectShellKind(shell, process.platform);
         terminal.sendText(
             buildBundleInitCommand(
                 this.cli.escapedCliPathFor(kind),

--- a/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
+++ b/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
@@ -5,7 +5,6 @@ import {
     window,
     TerminalLocation,
     commands,
-    env,
 } from "vscode";
 import {logging} from "@databricks/sdk-experimental";
 import {Loggers} from "../logger";
@@ -15,7 +14,7 @@ import {CliWrapper} from "../cli/CliWrapper";
 import {getSubProjects} from "./BundleFileSet";
 import {tmpdir} from "os";
 import {Events, Telemetry} from "../telemetry";
-import {currentShellKind, defaultProfileShellArgs} from "../utils/shellUtils";
+import {currentTerminalShell} from "../utils/shellUtils";
 import {
     buildBundleInitCommand,
     unsafeOutputDirReason,
@@ -138,11 +137,10 @@ export class BundleInitWizard {
         parentFolder: Uri,
         authProvider: AuthProvider
     ) {
-        const shell = env.shell;
-        // currentShellKind falls back to the configured default profile when
-        // env.shell is empty, which is the shell VS Code will actually launch
-        // when shellPath is left undefined below.
-        const kind = currentShellKind();
+        // Resolves the shell VS Code will launch together with how to launch it,
+        // so the command below cannot be generated for a different shell than
+        // the one that parses it. See resolveTerminalShell.
+        const {kind, shellPath, shellArgs} = currentTerminalShell();
         // Refuse a directory the target shell would rewrite, rather than
         // scaffolding somewhere the user never chose and then reporting "no
         // projects detected".
@@ -175,23 +173,19 @@ export class BundleInitWizard {
                 }
             });
         });
-        // Pin the shell instead of inheriting the user's default profile, so the
-        // shell that runs the command is the one we generated it for. Without
-        // this, a cmd.exe-shaped command (` & ` separators) sent to a PowerShell
-        // profile fails to parse, nothing executes — not even the trailing
-        // `exit` — and the await below would hang until the user closes the tab.
-        //
-        // `env.shell` is the default profile's *path* only, so pinning it would
-        // drop the profile's args: a default profile of
-        // `{path: "wsl.exe", args: ["-d", "Ubuntu-22.04"]}` would land in the
-        // default distro and scaffold into the wrong filesystem. Forward the
-        // configured args alongside the path to keep the two consistent.
+        // Pinning the shell keeps the shell that runs the command identical to
+        // the one we generated it for: a cmd.exe-shaped command (` & `
+        // separators) sent to a PowerShell profile fails to parse, nothing
+        // executes — not even the trailing `exit` — and the await below would
+        // hang until the user closes the tab. `shellPath` is undefined when the
+        // profile cannot be pinned without dropping its args, in which case VS
+        // Code launches it and `kind` describes what it launches either way.
         const terminal = window.createTerminal({
             name: "Databricks Project Init",
             isTransient: true,
             location: TerminalLocation.Editor,
-            shellPath: shell === "" ? undefined : shell,
-            shellArgs: shell === "" ? undefined : defaultProfileShellArgs(),
+            shellPath,
+            shellArgs,
             env: {
                 // Without supplying full environment and with `strictEnv: true` PowerShell will fail to start.
                 // On unix-like systems we don't require full environment, but it doesn't hurt.

--- a/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
+++ b/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
@@ -5,6 +5,7 @@ import {
     window,
     TerminalLocation,
     commands,
+    env,
 } from "vscode";
 import {logging} from "@databricks/sdk-experimental";
 import {Loggers} from "../logger";
@@ -13,9 +14,9 @@ import {LoginWizard} from "../configuration/LoginWizard";
 import {CliWrapper} from "../cli/CliWrapper";
 import {getSubProjects} from "./BundleFileSet";
 import {tmpdir} from "os";
-import {ShellUtils} from "../utils";
 import {Events, Telemetry} from "../telemetry";
-import {escapePathArgument} from "../utils/shellUtils";
+import {detectShellKind} from "../utils/shellUtils";
+import {buildBundleInitCommand} from "./bundleInitCommand";
 import {promptToSelectActiveProjectFolder} from "./activeBundleUtils";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 
@@ -154,10 +155,17 @@ export class BundleInitWizard {
                 }
             });
         });
+        // Pin the shell instead of inheriting the user's default profile, so the
+        // shell that runs the command is the one we generated it for. Without
+        // this, a cmd.exe-shaped command (` & ` separators) sent to a PowerShell
+        // profile fails to parse, nothing executes — not even the trailing
+        // `exit` — and the await below would hang until the user closes the tab.
+        const shell = env.shell;
         const terminal = window.createTerminal({
             name: "Databricks Project Init",
             isTransient: true,
             location: TerminalLocation.Editor,
+            shellPath: shell === "" ? undefined : shell,
             env: {
                 // Without supplying full environment and with `strictEnv: true` PowerShell will fail to start.
                 // On unix-like systems we don't require full environment, but it doesn't hurt.
@@ -172,16 +180,13 @@ export class BundleInitWizard {
             cwd: tmpdir(),
         });
         await terminalDidOpenPromise;
-        const args = [
-            "bundle",
-            "init",
-            "--output-dir",
-            escapePathArgument(parentFolder.fsPath),
-        ].join(" ");
-        const initialPrompt = `clear; echo "Executing: databricks ${args}\nFollow the steps below to create your new Databricks project.\n"`;
-        const finalPrompt = `echo "\nPress any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`;
+        const kind = detectShellKind(shell, process.platform);
         terminal.sendText(
-            `${initialPrompt}; ${this.cli.escapedCliPath} ${args}; ${finalPrompt}`
+            buildBundleInitCommand(
+                this.cli.escapedCliPathFor(kind),
+                parentFolder.fsPath,
+                kind
+            )
         );
         return terminalDidClosePromise;
     }

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,0 +1,136 @@
+import assert from "assert";
+import {execFile} from "child_process";
+import {promisify} from "util";
+import {buildBundleInitCommand} from "./bundleInitCommand";
+import {escapeExecutableForTerminal} from "../utils/shellUtils";
+
+const execFileAsync = promisify(execFile);
+
+describe(__filename, () => {
+    describe("buildBundleInitCommand", () => {
+        it("builds the command for posix shells", () => {
+            const command = buildBundleInitCommand(
+                escapeExecutableForTerminal("/usr/bin/databricks", "posix"),
+                "/home/me/projects",
+                "posix"
+            );
+            assert.strictEqual(
+                command,
+                "clear; " +
+                    `printf '%s\\n' 'Executing: databricks bundle init --output-dir '\\''/home/me/projects'\\'''; ` +
+                    `printf '%s\\n' 'Follow the steps below to create your new Databricks project.'; ` +
+                    `printf '%s\\n' ''; ` +
+                    `'/usr/bin/databricks' bundle init --output-dir '/home/me/projects'; ` +
+                    `printf '%s\\n' ''; ` +
+                    `printf '%s\\n' 'Press any key to close the terminal and continue ...'; ` +
+                    "read _; " +
+                    "exit"
+            );
+        });
+
+        it("builds the command for powershell", () => {
+            const command = buildBundleInitCommand(
+                escapeExecutableForTerminal(
+                    "C:\\Program Files\\databricks.exe",
+                    "powershell"
+                ),
+                "C:\\Users\\me\\projects",
+                "powershell"
+            );
+            assert.strictEqual(
+                command,
+                "Clear-Host; " +
+                    `Write-Host 'Executing: databricks bundle init --output-dir ''C:\\Users\\me\\projects'''; ` +
+                    `Write-Host 'Follow the steps below to create your new Databricks project.'; ` +
+                    `Write-Host ''; ` +
+                    `& 'C:\\Program Files\\databricks.exe' bundle init --output-dir 'C:\\Users\\me\\projects'; ` +
+                    `Write-Host ''; ` +
+                    `Write-Host 'Press any key to close the terminal and continue ...'; ` +
+                    "Read-Host; " +
+                    "exit"
+            );
+        });
+
+        it("builds the command for cmd.exe", () => {
+            // cmd.exe gets & separators, cls/pause, and per-line echo with the
+            // quotes in the message escaped as ^" rather than wrapped.
+            const command = buildBundleInitCommand(
+                escapeExecutableForTerminal(
+                    "C:\\Program Files\\databricks.exe",
+                    "cmd"
+                ),
+                "C:\\Users\\me\\projects",
+                "cmd"
+            );
+            assert.strictEqual(
+                command,
+                "cls & " +
+                    'echo Executing: databricks bundle init --output-dir ^"C:\\Users\\me\\projects^" & ' +
+                    "echo Follow the steps below to create your new Databricks project. & " +
+                    "echo. & " +
+                    '"C:\\Program Files\\databricks.exe" bundle init --output-dir "C:\\Users\\me\\projects" & ' +
+                    "echo. & " +
+                    "echo Press any key to close the terminal and continue ... & " +
+                    "pause & " +
+                    "exit"
+            );
+        });
+
+        it("does not emit a bare newline that would truncate the command", () => {
+            // The message contains real newlines; every shell must fold them
+            // into separate print commands rather than embedding them.
+            (["cmd", "powershell", "posix"] as const).forEach((kind) => {
+                const command = buildBundleInitCommand("db", "/tmp/out", kind);
+                assert.ok(
+                    !command.includes("\n"),
+                    `${kind} embedded a raw newline: ${command}`
+                );
+            });
+        });
+
+        it("quotes an output dir containing spaces", () => {
+            const command = buildBundleInitCommand(
+                "db",
+                "/home/me/My Projects",
+                "posix"
+            );
+            assert.ok(
+                command.includes(
+                    "db bundle init --output-dir '/home/me/My Projects'"
+                ),
+                command
+            );
+        });
+
+        it("passes an awkward output dir through a real shell intact", async function () {
+            // String equality only proves we built what we meant to. Run the
+            // command for real and check the CLI receives the directory as one
+            // unexpanded argument. /bin/sh is POSIX-only, so skip on Windows.
+            if (process.platform === "win32") {
+                this.skip();
+            }
+            const outputDir = `/tmp/My Dir's "odd" $HOME`;
+            const command = buildBundleInitCommand(
+                // Stand in for the CLI: print the arguments one per line.
+                `printf '%s\\n'`,
+                outputDir,
+                "posix"
+            );
+
+            // Run the command exactly as shipped, with stdin closed for the whole
+            // shell so the hold-open read returns at once. Rewriting the command
+            // to strip that read would silently stop matching whenever the
+            // command changes, and the test would hang instead of failing.
+            // `read` at EOF exits non-zero, so the exit code is ignored; only the
+            // output matters here.
+            const {stdout} = await execFileAsync("/bin/sh", [
+                "-c",
+                `{ ${command} ; } < /dev/null`,
+            ]).catch((e: {stdout: string}) => e);
+            assert.ok(
+                stdout.includes(`\n${outputDir}\n`),
+                `output dir did not survive the shell:\n${stdout}`
+            );
+        });
+    });
+});

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import {execFile} from "child_process";
+import {existsSync, readFileSync} from "fs";
 import {promisify} from "util";
 import {createArgvPrinter, runWindowsScript} from "../test/windowsShellHarness";
 import {
@@ -235,13 +236,14 @@ describe(__filename, () => {
         after(() => argvPrinter?.dispose());
 
         it("runs the CLI with the output dir as one argument", async () => {
-            // A script that prints its argv stands in for the CLI, which cmd
+            // A script recording its argv stands in for the CLI, which cmd
             // invokes with a quoted path: it proves the directory survives cmd's
             // parsing *and* the Windows argv round-trip as a single argument.
             // The directory need not exist.
             const outputDir = "C:\\tmp\\My Dir (odd) & co";
+            const argvFile = argvPrinter.outFileFor("bundleInit");
             const command = buildBundleInitCommand(
-                argvPrinter.invocation("cmd"),
+                argvPrinter.invocation("cmd", argvFile),
                 outputDir,
                 "cmd"
             );
@@ -249,10 +251,17 @@ describe(__filename, () => {
             const stdout = (
                 await runWindowsScript("cmd", [command])
             ).replaceAll("\r\n", "\n");
-            // The CLI stand-in prints one argument per line, so a directory that
-            // got split or expanded does not appear on a line of its own.
+
+            // The banner and the absence of a rejection come from the shell's own
+            // output, which is ordered; the arguments are read from the file the
+            // stand-in wrote, because a native process's stdout is not.
             assert.ok(
-                stdout.includes(`\n${outputDir}\n`),
+                existsSync(argvFile),
+                `the CLI stand-in never ran:\n${stdout}`
+            );
+            assert.deepStrictEqual(
+                readFileSync(argvFile, "utf8").split("\n"),
+                ["bundle", "init", "--output-dir", outputDir],
                 `output dir did not survive cmd.exe:\n${stdout}`
             );
             // Every step of the chain must have run: a parse error anywhere would

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,7 +1,10 @@
 import assert from "assert";
 import {execFile} from "child_process";
 import {promisify} from "util";
-import {buildBundleInitCommand} from "./bundleInitCommand";
+import {
+    buildBundleInitCommand,
+    unsafeOutputDirReason,
+} from "./bundleInitCommand";
 import {escapeExecutableForTerminal} from "../utils/shellUtils";
 
 const execFileAsync = promisify(execFile);
@@ -99,6 +102,72 @@ describe(__filename, () => {
                     "db bundle init --output-dir '/home/me/My Projects'"
                 ),
                 command
+            );
+        });
+
+        it("refuses a cmd.exe output dir containing % or !", () => {
+            // cmd expands %TEMP% (and !TEMP! under delayed expansion) even
+            // inside double quotes, so the CLI would scaffold into a directory
+            // the user never chose and getSubProjects would then report "we
+            // haven't detected any Databricks projects in ...". The reason is
+            // surfaced to the user rather than silently sending the command.
+            const reason = unsafeOutputDirReason("C:\\p%TEMP%q\\proj", "cmd");
+            assert.ok(reason !== undefined);
+            assert.ok(
+                reason.includes("C:\\p%TEMP%q\\proj"),
+                `reason should name the path: ${reason}`
+            );
+            assert.ok(
+                unsafeOutputDirReason("C:\\p!TEMP!q\\proj", "cmd") !== undefined
+            );
+        });
+
+        it("allows a % or ! output dir in shells that do not expand it", () => {
+            // PowerShell and POSIX single quotes are literal, so refusing there
+            // would block directories that work fine.
+            assert.strictEqual(
+                unsafeOutputDirReason("/tmp/p%TEMP%q", "posix"),
+                undefined
+            );
+            assert.strictEqual(
+                unsafeOutputDirReason("C:\\p%TEMP%q", "powershell"),
+                undefined
+            );
+            assert.strictEqual(
+                unsafeOutputDirReason("C:\\Users\\me\\proj", "cmd"),
+                undefined
+            );
+        });
+
+        it("throws rather than emitting a command cmd.exe would rewrite", () => {
+            // The guard is enforced in the builder too, so no caller can send a
+            // silently-corrupted path even if it skips the check above.
+            assert.throws(
+                () => buildBundleInitCommand("db", "C:\\p%TEMP%q", "cmd"),
+                /%/
+            );
+            // The same path is fine for the shells that quote it literally.
+            assert.ok(
+                buildBundleInitCommand("db", "C:\\p%TEMP%q", "powershell")
+            );
+        });
+
+        it("keeps % literal in the banner for shells that support it", async function () {
+            // The "Executing:" banner must show the path the CLI actually
+            // receives; a banner that expands differently would mislead anyone
+            // debugging a wrong-directory report.
+            if (process.platform === "win32") {
+                this.skip();
+            }
+            const outputDir = "/tmp/p%TEMP%q";
+            const command = buildBundleInitCommand("true", outputDir, "posix");
+            const {stdout} = await execFileAsync("/bin/sh", [
+                "-c",
+                `{ ${command} ; } < /dev/null`,
+            ]).catch((e: {stdout: string}) => e);
+            assert.ok(
+                stdout.includes(`--output-dir '${outputDir}'`),
+                `banner did not show the literal path:\n${stdout}`
             );
         });
 

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {execFile} from "child_process";
+import {execFile, spawn} from "child_process";
 import {promisify} from "util";
 import {
     buildBundleInitCommand,
@@ -151,54 +151,128 @@ describe(__filename, () => {
                 buildBundleInitCommand("db", "C:\\p%TEMP%q", "powershell")
             );
         });
+    });
 
-        it("keeps % literal in the banner for shells that support it", async function () {
-            // The "Executing:" banner must show the path the CLI actually
-            // receives; a banner that expands differently would mislead anyone
-            // debugging a wrong-directory report.
+    // String equality only proves the builder produced what its author
+    // intended. These run the assembled line through a real shell, exactly as
+    // shipped, to prove the shell agrees. CI covers Linux, macOS and Windows;
+    // each suite skips itself off its own platform.
+    describe("executed by a real posix shell", () => {
+        before(function () {
             if (process.platform === "win32") {
                 this.skip();
             }
-            const outputDir = "/tmp/p%TEMP%q";
-            const command = buildBundleInitCommand("true", outputDir, "posix");
+        });
+
+        // Run the command as shipped, with stdin closed for the whole shell so
+        // the hold-open read returns at once. Rewriting the command to strip
+        // that read would silently stop matching whenever the command changes,
+        // and the test would hang instead of failing. `read` at EOF exits
+        // non-zero, so the exit code is ignored; only the output matters.
+        async function runSh(command: string): Promise<string> {
             const {stdout} = await execFileAsync("/bin/sh", [
                 "-c",
                 `{ ${command} ; } < /dev/null`,
-            ]).catch((e: {stdout: string}) => e);
+            ]).catch((e: {stdout?: string}) => {
+                assert.ok(
+                    typeof e.stdout === "string",
+                    `/bin/sh produced no output: ${String(e)}`
+                );
+                return e as {stdout: string};
+            });
+            return stdout;
+        }
+
+        it("keeps % literal in the banner", async () => {
+            // The "Executing:" banner must show the path the CLI actually
+            // receives; a banner that expands differently would mislead anyone
+            // debugging a wrong-directory report.
+            const outputDir = "/tmp/p%TEMP%q";
+            const stdout = await runSh(
+                buildBundleInitCommand("true", outputDir, "posix")
+            );
             assert.ok(
                 stdout.includes(`--output-dir '${outputDir}'`),
                 `banner did not show the literal path:\n${stdout}`
             );
         });
 
-        it("passes an awkward output dir through a real shell intact", async function () {
-            // String equality only proves we built what we meant to. Run the
-            // command for real and check the CLI receives the directory as one
-            // unexpanded argument. /bin/sh is POSIX-only, so skip on Windows.
-            if (process.platform === "win32") {
-                this.skip();
-            }
+        it("passes an awkward output dir through intact", async () => {
             const outputDir = `/tmp/My Dir's "odd" $HOME`;
-            const command = buildBundleInitCommand(
-                // Stand in for the CLI: print the arguments one per line.
-                `printf '%s\\n'`,
-                outputDir,
-                "posix"
+            const stdout = await runSh(
+                buildBundleInitCommand(
+                    // Stand in for the CLI: print the arguments one per line.
+                    `printf '%s\\n'`,
+                    outputDir,
+                    "posix"
+                )
             );
-
-            // Run the command exactly as shipped, with stdin closed for the whole
-            // shell so the hold-open read returns at once. Rewriting the command
-            // to strip that read would silently stop matching whenever the
-            // command changes, and the test would hang instead of failing.
-            // `read` at EOF exits non-zero, so the exit code is ignored; only the
-            // output matters here.
-            const {stdout} = await execFileAsync("/bin/sh", [
-                "-c",
-                `{ ${command} ; } < /dev/null`,
-            ]).catch((e: {stdout: string}) => e);
             assert.ok(
                 stdout.includes(`\n${outputDir}\n`),
                 `output dir did not survive the shell:\n${stdout}`
+            );
+        });
+    });
+
+    // cmd.exe is the shell #1822 was reported against, so the assembled line is
+    // executed there rather than only compared as a string. The unit-test matrix
+    // includes a windows-server runner.
+    describe("executed by real cmd.exe", () => {
+        before(function () {
+            if (process.platform !== "win32") {
+                this.skip();
+            }
+        });
+
+        // Piped to stdin, which is what terminal.sendText does, and which keeps
+        // Node's own Windows argv quoting out of the measurement. `pause` reads
+        // from the same stdin and returns at EOF, so the script drives itself to
+        // completion without a console.
+        function runCmd(script: string): Promise<string> {
+            return new Promise((resolve, reject) => {
+                const child = spawn(
+                    process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe",
+                    [],
+                    {stdio: ["pipe", "pipe", "pipe"]}
+                );
+                let stdout = "";
+                child.stdout.setEncoding("utf8");
+                child.stdout.on("data", (chunk) => (stdout += chunk));
+                child.on("error", reject);
+                child.on("close", () => resolve(stdout));
+                child.stdin.end(`@echo off\r\n${script}\r\n`);
+            });
+        }
+
+        it("runs the CLI with the output dir as one argument", async () => {
+            // Invoking Node and printing its own argv stands in for the real
+            // command line, which invokes databricks.exe with a quoted path: it
+            // proves the directory survives cmd's parsing *and* the Windows argv
+            // round-trip as a single argument. The directory need not exist.
+            const outputDir = "C:\\tmp\\My Dir (odd) & co";
+            const command = buildBundleInitCommand(
+                `${escapeExecutableForTerminal(process.execPath, "cmd")} -e ` +
+                    '"console.log(process.argv.slice(1).join(String.fromCharCode(10)))"',
+                outputDir,
+                "cmd"
+            );
+
+            const stdout = (await runCmd(command)).replaceAll("\r\n", "\n");
+            // The CLI stand-in prints one argument per line, so a directory that
+            // got split or expanded does not appear on a line of its own.
+            assert.ok(
+                stdout.includes(`\n${outputDir}\n`),
+                `output dir did not survive cmd.exe:\n${stdout}`
+            );
+            // Every step of the chain must have run: a parse error anywhere would
+            // stop the line, which is the #1822 failure mode.
+            assert.ok(
+                stdout.includes("Follow the steps below"),
+                `banner is missing, so the chain did not run:\n${stdout}`
+            );
+            assert.ok(
+                !stdout.includes("not recognized"),
+                `cmd rejected part of the command:\n${stdout}`
             );
         });
     });

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import {execFile} from "child_process";
 import {promisify} from "util";
-import {runWindowsScript} from "../test/windowsShellHarness";
+import {createArgvPrinter, runWindowsScript} from "../test/windowsShellHarness";
 import {
     buildBundleInitCommand,
     unsafeOutputDirReason,
@@ -223,21 +223,25 @@ describe(__filename, () => {
         // enforces its own per-spawn deadline, so this only has to not fire first.
         this.timeout(120_000);
 
+        let argvPrinter: ReturnType<typeof createArgvPrinter>;
+
         before(function () {
             if (process.platform !== "win32") {
                 this.skip();
             }
+            argvPrinter = createArgvPrinter();
         });
 
+        after(() => argvPrinter?.dispose());
+
         it("runs the CLI with the output dir as one argument", async () => {
-            // Invoking Node and printing its own argv stands in for the real
-            // command line, which invokes databricks.exe with a quoted path: it
-            // proves the directory survives cmd's parsing *and* the Windows argv
-            // round-trip as a single argument. The directory need not exist.
+            // A script that prints its argv stands in for the CLI, which cmd
+            // invokes with a quoted path: it proves the directory survives cmd's
+            // parsing *and* the Windows argv round-trip as a single argument.
+            // The directory need not exist.
             const outputDir = "C:\\tmp\\My Dir (odd) & co";
             const command = buildBundleInitCommand(
-                `${escapeExecutableForTerminal(process.execPath, "cmd")} -e ` +
-                    '"console.log(process.argv.slice(1).join(String.fromCharCode(10)))"',
+                argvPrinter.invocation("cmd"),
                 outputDir,
                 "cmd"
             );

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.test.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
-import {execFile, spawn} from "child_process";
+import {execFile} from "child_process";
 import {promisify} from "util";
+import {runWindowsScript} from "../test/windowsShellHarness";
 import {
     buildBundleInitCommand,
     unsafeOutputDirReason,
@@ -217,32 +218,16 @@ describe(__filename, () => {
     // cmd.exe is the shell #1822 was reported against, so the assembled line is
     // executed there rather than only compared as a string. The unit-test matrix
     // includes a windows-server runner.
-    describe("executed by real cmd.exe", () => {
+    describe("executed by real cmd.exe", function () {
+        // Well past a cold shell start on a scanned CI runner; the harness
+        // enforces its own per-spawn deadline, so this only has to not fire first.
+        this.timeout(120_000);
+
         before(function () {
             if (process.platform !== "win32") {
                 this.skip();
             }
         });
-
-        // Piped to stdin, which is what terminal.sendText does, and which keeps
-        // Node's own Windows argv quoting out of the measurement. `pause` reads
-        // from the same stdin and returns at EOF, so the script drives itself to
-        // completion without a console.
-        function runCmd(script: string): Promise<string> {
-            return new Promise((resolve, reject) => {
-                const child = spawn(
-                    process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe",
-                    [],
-                    {stdio: ["pipe", "pipe", "pipe"]}
-                );
-                let stdout = "";
-                child.stdout.setEncoding("utf8");
-                child.stdout.on("data", (chunk) => (stdout += chunk));
-                child.on("error", reject);
-                child.on("close", () => resolve(stdout));
-                child.stdin.end(`@echo off\r\n${script}\r\n`);
-            });
-        }
 
         it("runs the CLI with the output dir as one argument", async () => {
             // Invoking Node and printing its own argv stands in for the real
@@ -257,7 +242,9 @@ describe(__filename, () => {
                 "cmd"
             );
 
-            const stdout = (await runCmd(command)).replaceAll("\r\n", "\n");
+            const stdout = (
+                await runWindowsScript("cmd", [command])
+            ).replaceAll("\r\n", "\n");
             // The CLI stand-in prints one argument per line, so a directory that
             // got split or expanded does not appear on a line of its own.
             assert.ok(

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.ts
@@ -1,0 +1,41 @@
+import {
+    clearCmd,
+    commandSeparator,
+    echoCmd,
+    escapePathArgument,
+    readCmd,
+    ShellKind,
+} from "../utils/shellUtils";
+
+/**
+ * The full `databricks bundle init` line sent to the wizard terminal: clear the
+ * screen, explain what is running, run the CLI, then hold the terminal open
+ * until the user acknowledges so any CLI error stays readable.
+ *
+ * Kept in its own module, free of `vscode` imports, so it stays a pure function
+ * of (cli path, output dir, shell) and can be asserted for every shell family.
+ * `escapedCliPath` is passed in because it is derived from CLI state.
+ */
+export function buildBundleInitCommand(
+    escapedCliPath: string,
+    outputDir: string,
+    kind: ShellKind
+): string {
+    const args = [
+        "bundle",
+        "init",
+        "--output-dir",
+        escapePathArgument(outputDir, kind),
+    ].join(" ");
+    return [
+        clearCmd(kind),
+        echoCmd(
+            `Executing: databricks ${args}\nFollow the steps below to create your new Databricks project.\n`,
+            kind
+        ),
+        `${escapedCliPath} ${args}`,
+        echoCmd("\nPress any key to close the terminal and continue ...", kind),
+        readCmd(kind),
+        "exit",
+    ].join(commandSeparator(kind));
+}

--- a/packages/databricks-vscode/src/bundle/bundleInitCommand.ts
+++ b/packages/databricks-vscode/src/bundle/bundleInitCommand.ts
@@ -3,9 +3,34 @@ import {
     commandSeparator,
     echoCmd,
     escapePathArgument,
+    hasCmdUnsafeChars,
     readCmd,
     ShellKind,
 } from "../utils/shellUtils";
+
+/**
+ * Why `outputDir` cannot be passed through `kind` faithfully, or undefined when
+ * it can.
+ *
+ * cmd.exe expands `%VAR%` — and `!VAR!` under delayed expansion — even inside
+ * double quotes, and an interactive command line has no escape for either. The
+ * CLI would scaffold into a directory the user never chose, after which
+ * `getSubProjects` reports "we haven't detected any Databricks projects in …":
+ * a silent wrong-directory, so callers must refuse rather than send.
+ */
+export function unsafeOutputDirReason(
+    outputDir: string,
+    kind: ShellKind
+): string | undefined {
+    if (kind === "cmd" && hasCmdUnsafeChars(outputDir)) {
+        return (
+            `The folder path "${outputDir}" contains a "%" or "!" character, which cmd.exe always expands ` +
+            `as a variable, so the project would be created somewhere else. Choose a folder without those ` +
+            `characters, or set terminal.integrated.defaultProfile.windows to PowerShell.`
+        );
+    }
+    return undefined;
+}
 
 /**
  * The full `databricks bundle init` line sent to the wizard terminal: clear the
@@ -15,12 +40,21 @@ import {
  * Kept in its own module, free of `vscode` imports, so it stays a pure function
  * of (cli path, output dir, shell) and can be asserted for every shell family.
  * `escapedCliPath` is passed in because it is derived from CLI state.
+ *
+ * Throws when `outputDir` cannot be represented in `kind` — see
+ * {@link unsafeOutputDirReason}. Callers should check that first and surface the
+ * reason; the throw is a backstop so no path can reach a shell that would
+ * silently rewrite it.
  */
 export function buildBundleInitCommand(
     escapedCliPath: string,
     outputDir: string,
     kind: ShellKind
 ): string {
+    const reason = unsafeOutputDirReason(outputDir, kind);
+    if (reason !== undefined) {
+        throw new Error(reason);
+    }
     const args = [
         "bundle",
         "init",

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -25,7 +25,7 @@ import {quote} from "shell-quote";
 import {BundleVariableModel} from "../bundle/models/BundleVariableModel";
 import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
 import path from "path";
-import {isPowershell} from "../utils/shellUtils";
+import {escapeExecutableForTerminal, ShellKind} from "../utils/shellUtils";
 
 const withLogContext = logging.withLogContext;
 function getEscapedCommandAndAgrs(
@@ -368,10 +368,16 @@ export class CliWrapper {
         };
     }
 
+    /**
+     * The CLI path quoted for a terminal. Takes the shell kind so it cannot
+     * disagree with the shell the rest of the command line was built for.
+     */
+    escapedCliPathFor(kind: ShellKind): string {
+        return escapeExecutableForTerminal(this.cliPath, kind);
+    }
+
     get escapedCliPath(): string {
-        return isPowershell()
-            ? `& "${this.cliPath.replace('"', '\\"')}"`
-            : `'${this.cliPath.replaceAll("'", "\\'")}'`;
+        return escapeExecutableForTerminal(this.cliPath);
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -4,7 +4,14 @@ import {
     WorkspaceClient,
     logging,
 } from "@databricks/sdk-experimental";
-import {CancellationToken, commands, Disposable, Uri, window} from "vscode";
+import {
+    CancellationToken,
+    commands,
+    Disposable,
+    env,
+    Uri,
+    window,
+} from "vscode";
 import {Loggers} from "../../logger";
 import {AzureCliAuthProvider} from "./AuthProvider";
 import {orchestrate, OrchestrationLoopError, Step} from "./orchestrate";
@@ -363,18 +370,41 @@ export class AzureCliCheck implements Disposable {
         );
 
         if (choice === "Run command") {
-            const terminal = window.createTerminal("az login");
+            // Pin the shell so the command we generate is parsed by the shell we
+            // detected, rather than by whatever the user's default profile is.
+            const shell = env.shell;
+            const terminal = window.createTerminal({
+                name: "az login",
+                shellPath: shell === "" ? undefined : shell,
+            });
             this.disposables.push(terminal);
             terminal.show();
 
             const useDeviceCode = this.isCodeSpaces ? "--use-device-code" : "";
 
+            const kind = ShellUtils.detectShellKind(shell, process.platform);
+            const separator = ShellUtils.commandSeparator(kind);
+            const azLogin = [
+                ShellUtils.escapeExecutableForTerminal(this.azBinPath, kind),
+                "login",
+                "--allow-no-subscriptions",
+                useDeviceCode,
+                tenant
+                    ? `-t ${ShellUtils.escapePathArgument(tenant, kind)}`
+                    : "",
+            ]
+                .filter((part) => part !== "")
+                .join(" ");
             terminal.sendText(
-                `${
-                    this.azBinPath
-                } login --allow-no-subscriptions ${useDeviceCode} ${
-                    tenant ? "-t " + tenant : ""
-                }; echo "Press any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`
+                [
+                    azLogin,
+                    ShellUtils.echoCmd(
+                        "Press any key to close the terminal and continue ...",
+                        kind
+                    ),
+                    ShellUtils.readCmd(kind),
+                    "exit",
+                ].join(separator)
             );
 
             cancellationToken?.onCancellationRequested(() =>

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -376,13 +376,20 @@ export class AzureCliCheck implements Disposable {
             const terminal = window.createTerminal({
                 name: "az login",
                 shellPath: shell === "" ? undefined : shell,
+                // env.shell is the default profile's path only; without its args
+                // a profile such as `wsl.exe -d Ubuntu-22.04` would launch the
+                // wrong distro. See resolveProfileShellArgs.
+                shellArgs:
+                    shell === ""
+                        ? undefined
+                        : ShellUtils.defaultProfileShellArgs(),
             });
             this.disposables.push(terminal);
             terminal.show();
 
             const useDeviceCode = this.isCodeSpaces ? "--use-device-code" : "";
 
-            const kind = ShellUtils.detectShellKind(shell, process.platform);
+            const kind = ShellUtils.currentShellKind();
             const separator = ShellUtils.commandSeparator(kind);
             const azLogin = [
                 ShellUtils.escapeExecutableForTerminal(this.azBinPath, kind),

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -4,14 +4,7 @@ import {
     WorkspaceClient,
     logging,
 } from "@databricks/sdk-experimental";
-import {
-    CancellationToken,
-    commands,
-    Disposable,
-    env,
-    Uri,
-    window,
-} from "vscode";
+import {CancellationToken, commands, Disposable, Uri, window} from "vscode";
 import {Loggers} from "../../logger";
 import {AzureCliAuthProvider} from "./AuthProvider";
 import {orchestrate, OrchestrationLoopError, Step} from "./orchestrate";
@@ -371,25 +364,20 @@ export class AzureCliCheck implements Disposable {
 
         if (choice === "Run command") {
             // Pin the shell so the command we generate is parsed by the shell we
-            // detected, rather than by whatever the user's default profile is.
-            const shell = env.shell;
+            // generated it for, rather than by whatever the user's default
+            // profile is. See resolveTerminalShell for when pinning is skipped.
+            const {kind, shellPath, shellArgs} =
+                ShellUtils.currentTerminalShell();
             const terminal = window.createTerminal({
                 name: "az login",
-                shellPath: shell === "" ? undefined : shell,
-                // env.shell is the default profile's path only; without its args
-                // a profile such as `wsl.exe -d Ubuntu-22.04` would launch the
-                // wrong distro. See resolveProfileShellArgs.
-                shellArgs:
-                    shell === ""
-                        ? undefined
-                        : ShellUtils.defaultProfileShellArgs(),
+                shellPath,
+                shellArgs,
             });
             this.disposables.push(terminal);
             terminal.show();
 
             const useDeviceCode = this.isCodeSpaces ? "--use-device-code" : "";
 
-            const kind = ShellUtils.currentShellKind();
             const separator = ShellUtils.commandSeparator(kind);
             const azLogin = [
                 ShellUtils.escapeExecutableForTerminal(this.azBinPath, kind),

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -7,6 +7,7 @@ import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
 import path from "path";
 import {FeatureManager, FeatureState} from "../feature-manager/FeatureManager";
 import {
+    currentShellKind,
     escapeExecutableForTerminal,
     escapePathArgument,
 } from "../utils/shellUtils";
@@ -244,10 +245,13 @@ export class RunCommands {
             path.join("resources", "python", "dbconnect-bootstrap.py")
         );
         terminal.show();
+        const kind = currentShellKind();
         terminal.sendText(
-            `${escapeExecutableForTerminal(executable)} ${escapePathArgument(
-                bootstrapPath
-            )} ${escapePathArgument(targetResource.fsPath)}`
+            [
+                escapeExecutableForTerminal(executable, kind),
+                escapePathArgument(bootstrapPath, kind),
+                escapePathArgument(targetResource.fsPath, kind),
+            ].join(" ")
         );
 
         this.telemetry.recordEvent(Events.DBCONNECT_RUN, {

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -7,9 +7,9 @@ import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
 import path from "path";
 import {FeatureManager, FeatureState} from "../feature-manager/FeatureManager";
 import {
-    currentShellKind,
     escapeExecutableForTerminal,
     escapePathArgument,
+    terminalShellKind,
 } from "../utils/shellUtils";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
@@ -245,7 +245,10 @@ export class RunCommands {
             path.join("resources", "python", "dbconnect-bootstrap.py")
         );
         terminal.show();
-        const kind = currentShellKind();
+        // Classify the terminal we are actually sending to. This may be a
+        // pre-existing tab running any profile, so `env.shell` (the *default*
+        // profile) is not necessarily the shell that parses this line.
+        const kind = terminalShellKind(terminal);
         terminal.sendText(
             [
                 escapeExecutableForTerminal(executable, kind),

--- a/packages/databricks-vscode/src/test/windowsShellHarness.ts
+++ b/packages/databricks-vscode/src/test/windowsShellHarness.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, rmSync, writeFileSync} from "fs";
+import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "fs";
 import {spawn} from "child_process";
 import {tmpdir} from "os";
 import path from "path";
@@ -28,6 +28,10 @@ import {
  *
  * PowerShell has neither problem and is fed on stdin, exactly as `sendText`
  * would.
+ *
+ * What the shell itself prints is ordered against the markers and can be read
+ * from this stdout. What a *native command* prints is not — see
+ * {@link createArgvPrinter}, which collects arguments through a file instead.
  */
 export type WindowsShell = "cmd" | "powershell";
 
@@ -108,7 +112,7 @@ export async function runWindowsScript(
 }
 
 /**
- * A stand-in for the CLI: a script that prints each argument it receives on its
+ * A stand-in for the CLI: a script that records each argument it receives on its
  * own line, so a path that got split or expanded is visible as more or fewer
  * lines than expected.
  *
@@ -123,23 +127,74 @@ export async function runWindowsScript(
  * is a deliberate trade: duplicating quoting rules in a test helper would let
  * the two drift. Both have their own direct unit tests, so a break there fails
  * those too rather than only showing up here.
+ *
+ * Arguments come back through a *file*, not the shell's stdout. A native process
+ * writes to the inherited pipe itself, with its own buffering, so its output is
+ * not ordered against the marker lines the shell prints around it: under
+ * `powershell -Command -` it landed outside the markers altogether and every
+ * case read back empty, with nothing on stderr to explain it. A file the process
+ * finishes writing before it exits cannot be reordered that way.
  */
 export function createArgvPrinter() {
     const dir = mkdtempSync(path.join(tmpdir(), "dbx-argv-printer-"));
     const script = path.join(dir, "printArgv.js");
-    // argv[0] is node, argv[1] this script, so the arguments start at 2.
+    // Writes to the path given as the first argument; the arguments under test
+    // follow it. argv[0] is node and argv[1] this script, so they start at 3.
     writeFileSync(
         script,
-        "process.argv.slice(2).forEach((a) => console.log(a));\n"
+        [
+            "const fs = require('fs');",
+            "fs.writeFileSync(process.argv[2], process.argv.slice(3).join('\\n'));",
+            "",
+        ].join("\n")
     );
+
+    function invocation(kind: WindowsShell, outFile: string): string {
+        return [
+            escapeExecutableForTerminal(process.execPath, kind),
+            escapePathArgument(script, kind),
+            escapePathArgument(outFile, kind),
+        ].join(" ");
+    }
+
     return {
-        /** The `node printArgv.js` prefix; append the escaped argument(s). */
-        invocation(kind: WindowsShell): string {
-            return [
-                escapeExecutableForTerminal(process.execPath, kind),
-                escapePathArgument(script, kind),
-            ].join(" ");
+        /**
+         * The `node printArgv.js <outFile>` prefix for a caller assembling its
+         * own command line; append the escaped argument(s) under test.
+         */
+        invocation(kind: WindowsShell, outFile: string): string {
+            return invocation(kind, outFile);
         },
+
+        /** Where {@link invocation}'s callee will write, for reading back. */
+        outFileFor(name: string): string {
+            return path.join(dir, `${name}.txt`);
+        },
+
+        /**
+         * Run one case per argument in a single shell and return the arguments
+         * each invocation actually received.
+         */
+        async collect(kind: WindowsShell, args: string[]): Promise<string[][]> {
+            const outFiles = args.map((_, i) => path.join(dir, `out${i}.txt`));
+            await runWindowsScript(
+                kind,
+                args.map(
+                    (arg, i) =>
+                        `${invocation(kind, outFiles[i])} ${escapePathArgument(
+                            arg,
+                            kind
+                        )}`
+                )
+            );
+            return outFiles.map((f) =>
+                // A missing file means the command never ran at all, which is a
+                // different failure from receiving the wrong arguments; keep them
+                // distinguishable rather than reporting both as [].
+                existsSync(f) ? readFileSync(f, "utf8").split("\n") : []
+            );
+        },
+
         dispose() {
             rmSync(dir, {recursive: true, force: true});
         },

--- a/packages/databricks-vscode/src/test/windowsShellHarness.ts
+++ b/packages/databricks-vscode/src/test/windowsShellHarness.ts
@@ -2,6 +2,10 @@ import {mkdtempSync, rmSync, writeFileSync} from "fs";
 import {spawn} from "child_process";
 import {tmpdir} from "os";
 import path from "path";
+import {
+    escapeExecutableForTerminal,
+    escapePathArgument,
+} from "../utils/shellUtils";
 
 /**
  * Runs generated command lines through a real cmd.exe or PowerShell, so tests
@@ -43,16 +47,22 @@ function echoMarker(marker: string, shell: WindowsShell): string {
 /** Shells are slow to start, and slower under CI endpoint scanning. */
 const SPAWN_TIMEOUT_MS = 60_000;
 
-function spawnCollectingStdout(
+function spawnCollectingOutput(
     exe: string,
     args: string[],
     stdin: string
 ): Promise<string> {
     return new Promise((resolve, reject) => {
         const child = spawn(exe, args, {stdio: ["pipe", "pipe", "pipe"]});
-        let stdout = "";
+        let output = "";
+        // stderr is interleaved into the same buffer rather than dropped. A
+        // command that fails prints only to stderr, so discarding it makes the
+        // capture look simply empty and the assertion failure unreadable: the
+        // reason is precisely what we need to see.
         child.stdout.setEncoding("utf8");
-        child.stdout.on("data", (chunk) => (stdout += chunk));
+        child.stderr.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => (output += chunk));
+        child.stderr.on("data", (chunk) => (output += chunk));
         // Killed on a deadline rather than left to Mocha: a shell still waiting
         // for input would otherwise leak a process and report a bare timeout
         // instead of the output collected so far.
@@ -63,7 +73,7 @@ function spawnCollectingStdout(
         });
         child.on("close", () => {
             clearTimeout(deadline);
-            resolve(stdout);
+            resolve(output);
         });
         // Closing stdin lets `pause`/`read` return at EOF instead of blocking.
         child.stdin.end(stdin);
@@ -76,7 +86,7 @@ export async function runWindowsScript(
     lines: string[]
 ): Promise<string> {
     if (shell === "powershell") {
-        return spawnCollectingStdout(
+        return spawnCollectingOutput(
             "powershell.exe",
             ["-NoProfile", "-NonInteractive", "-Command", "-"],
             `${lines.join("\n")}\n`
@@ -87,7 +97,7 @@ export async function runWindowsScript(
     try {
         // cmd requires CRLF, and `@echo off` must be the first line.
         writeFileSync(script, ["@echo off", ...lines, ""].join("\r\n"));
-        return await spawnCollectingStdout(
+        return await spawnCollectingOutput(
             process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe",
             ["/c", script],
             ""
@@ -95,6 +105,45 @@ export async function runWindowsScript(
     } finally {
         rmSync(dir, {recursive: true, force: true});
     }
+}
+
+/**
+ * A stand-in for the CLI: a script that prints each argument it receives on its
+ * own line, so a path that got split or expanded is visible as more or fewer
+ * lines than expected.
+ *
+ * The script lives in a file rather than being passed to `node -e`. An inline
+ * one-liner has to survive the shell's *own* quoting on the way in — and in
+ * Windows PowerShell 5.1 native-command argument passing re-parses and re-quotes
+ * what it forwards, so a bracketed one-liner is a second, unrelated variable in
+ * a test whose subject is `escapePathArgument`. A file removes it: the only
+ * awkward token left on the line is the path under test.
+ *
+ * Quoting the interpreter and the script path uses the module under test, which
+ * is a deliberate trade: duplicating quoting rules in a test helper would let
+ * the two drift. Both have their own direct unit tests, so a break there fails
+ * those too rather than only showing up here.
+ */
+export function createArgvPrinter() {
+    const dir = mkdtempSync(path.join(tmpdir(), "dbx-argv-printer-"));
+    const script = path.join(dir, "printArgv.js");
+    // argv[0] is node, argv[1] this script, so the arguments start at 2.
+    writeFileSync(
+        script,
+        "process.argv.slice(2).forEach((a) => console.log(a));\n"
+    );
+    return {
+        /** The `node printArgv.js` prefix; append the escaped argument(s). */
+        invocation(kind: WindowsShell): string {
+            return [
+                escapeExecutableForTerminal(process.execPath, kind),
+                escapePathArgument(script, kind),
+            ].join(" ");
+        },
+        dispose() {
+            rmSync(dir, {recursive: true, force: true});
+        },
+    };
 }
 
 /**

--- a/packages/databricks-vscode/src/test/windowsShellHarness.ts
+++ b/packages/databricks-vscode/src/test/windowsShellHarness.ts
@@ -1,0 +1,141 @@
+import {mkdtempSync, rmSync, writeFileSync} from "fs";
+import {spawn} from "child_process";
+import {tmpdir} from "os";
+import path from "path";
+
+/**
+ * Runs generated command lines through a real cmd.exe or PowerShell, so tests
+ * can check what the shell *does* rather than only what string we produced.
+ * Windows-only; callers gate on `process.platform`.
+ *
+ * Why not pipe the commands to the shell's stdin, which is what
+ * `terminal.sendText` does? Two reasons, both learned from CI:
+ *
+ * - cmd.exe echoes each line it reads from a non-console stdin, even after
+ *   `@echo off`, so the command text lands in stdout next to its output.
+ * - `pause` reads a keypress from that same stdin and swallows the first byte
+ *   of the following line.
+ *
+ * cmd therefore runs from a batch file, where `@echo off` works as documented
+ * and `pause` reads a stdin we close. The remaining divergence from an
+ * interactive line is `%`: a batch file also treats `%%` as an escape and `%1`
+ * as a parameter. Nothing here relies on that, because `%` cannot be passed
+ * through cmd faithfully at all — see `hasCmdUnsafeChars`.
+ *
+ * PowerShell has neither problem and is fed on stdin, exactly as `sendText`
+ * would.
+ */
+export type WindowsShell = "cmd" | "powershell";
+
+/** Bracketing markers, so one shell start can serve many cases. */
+function beginMarker(index: number): string {
+    return `@@BEGIN${index}@@`;
+}
+
+function endMarker(index: number): string {
+    return `@@END${index}@@`;
+}
+
+function echoMarker(marker: string, shell: WindowsShell): string {
+    return shell === "cmd" ? `echo ${marker}` : `Write-Host '${marker}'`;
+}
+
+/** Shells are slow to start, and slower under CI endpoint scanning. */
+const SPAWN_TIMEOUT_MS = 60_000;
+
+function spawnCollectingStdout(
+    exe: string,
+    args: string[],
+    stdin: string
+): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(exe, args, {stdio: ["pipe", "pipe", "pipe"]});
+        let stdout = "";
+        child.stdout.setEncoding("utf8");
+        child.stdout.on("data", (chunk) => (stdout += chunk));
+        // Killed on a deadline rather than left to Mocha: a shell still waiting
+        // for input would otherwise leak a process and report a bare timeout
+        // instead of the output collected so far.
+        const deadline = setTimeout(() => child.kill(), SPAWN_TIMEOUT_MS);
+        child.on("error", (e) => {
+            clearTimeout(deadline);
+            reject(e);
+        });
+        child.on("close", () => {
+            clearTimeout(deadline);
+            resolve(stdout);
+        });
+        // Closing stdin lets `pause`/`read` return at EOF instead of blocking.
+        child.stdin.end(stdin);
+    });
+}
+
+/** Run `lines` as one script and return its raw stdout. */
+export async function runWindowsScript(
+    shell: WindowsShell,
+    lines: string[]
+): Promise<string> {
+    if (shell === "powershell") {
+        return spawnCollectingStdout(
+            "powershell.exe",
+            ["-NoProfile", "-NonInteractive", "-Command", "-"],
+            `${lines.join("\n")}\n`
+        );
+    }
+    const dir = mkdtempSync(path.join(tmpdir(), "dbx-shell-test-"));
+    const script = path.join(dir, "run.bat");
+    try {
+        // cmd requires CRLF, and `@echo off` must be the first line.
+        writeFileSync(script, ["@echo off", ...lines, ""].join("\r\n"));
+        return await spawnCollectingStdout(
+            process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe",
+            ["/c", script],
+            ""
+        );
+    } finally {
+        rmSync(dir, {recursive: true, force: true});
+    }
+}
+
+/**
+ * Run every command in one shell invocation and return each one's output lines,
+ * indexed as passed. Batched because a shell start costs about a second, and
+ * these suites have dozens of cases.
+ */
+export async function runWindowsCases(
+    shell: WindowsShell,
+    commands: string[]
+): Promise<string[][]> {
+    const script = commands.flatMap((command, i) => [
+        echoMarker(beginMarker(i), shell),
+        command,
+        echoMarker(endMarker(i), shell),
+    ]);
+    const stdout = await runWindowsScript(shell, script);
+    return commands.map((_, i) => sliceCase(stdout, i, shell));
+}
+
+function sliceCase(
+    stdout: string,
+    index: number,
+    shell: WindowsShell
+): string[] {
+    const lines = stdout.replaceAll("\r\n", "\n").split("\n");
+    // cmd's `echo` prints everything up to a ` & ` separator, the space
+    // included, so chained lines arrive with one trailing space. That is
+    // cosmetic — it only affects a banner — and orthogonal to what these suites
+    // measure, so it is normalised away here rather than asserted. No case
+    // deliberately ends in a space.
+    const normalise = (line: string) =>
+        shell === "cmd" ? line.replace(/ +$/, "") : line;
+    const from = lines.findIndex((l) => normalise(l) === beginMarker(index));
+    const to = lines.findIndex(
+        (l, i) => i > from && normalise(l) === endMarker(index)
+    );
+    if (from === -1 || to === -1) {
+        throw new Error(
+            `markers for case ${index} missing from ${shell} output:\n${stdout}`
+        );
+    }
+    return lines.slice(from + 1, to).map(normalise);
+}

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -1,7 +1,8 @@
 import assert from "assert";
-import {execFile, spawn} from "child_process";
+import {execFile} from "child_process";
 import {existsSync} from "fs";
 import {promisify} from "util";
+import {runWindowsCases} from "../test/windowsShellHarness";
 import {
     clearCmd,
     commandSeparator,
@@ -832,104 +833,21 @@ describe(__filename, () => {
 
     // The cmd.exe and PowerShell branches are the ones #1822 was actually about,
     // and string equality alone is what let the original bug ship. The unit-test
-    // matrix includes a windows-server runner, so they can be executed for real
-    // rather than only asserted as strings.
-    describe("round-trip against a real windows shell", () => {
+    // matrix includes a windows-server runner, so they run for real here.
+    //
+    // Cases are batched into one shell invocation per assertion group: starting
+    // a shell costs about a second, and more under CI endpoint scanning. See
+    // windowsShellHarness for why cmd runs from a batch file rather than stdin.
+    describe("round-trip against a real windows shell", function () {
+        // Well past a cold shell start on a scanned CI runner; the harness
+        // enforces its own per-spawn deadline, so this only has to not fire first.
+        this.timeout(120_000);
+
         before(function () {
             if (process.platform !== "win32") {
                 this.skip();
             }
         });
-
-        // Commands are piped to the shell's *stdin* rather than passed as argv.
-        // This is what `terminal.sendText` does, and it keeps Node's own
-        // Windows argv quoting out of the measurement — passing the command as
-        // an argument would test that quoting instead of ours.
-        //
-        // Killed after a deadline rather than left to Mocha's timeout: a shell
-        // that sits waiting for input would otherwise leak a process and report
-        // a bare timeout instead of the output collected so far.
-        function runViaStdin(
-            exe: string,
-            args: string[],
-            script: string
-        ): Promise<string> {
-            return new Promise((resolve, reject) => {
-                const child = spawn(exe, args, {
-                    stdio: ["pipe", "pipe", "pipe"],
-                });
-                let stdout = "";
-                child.stdout.setEncoding("utf8");
-                child.stdout.on("data", (chunk) => (stdout += chunk));
-                const deadline = setTimeout(() => child.kill(), 10_000);
-                child.on("error", (e) => {
-                    clearTimeout(deadline);
-                    reject(e);
-                });
-                child.on("close", () => {
-                    clearTimeout(deadline);
-                    resolve(stdout);
-                });
-                child.stdin.end(script);
-            });
-        }
-
-        // Both shells print a banner and (for cmd) a prompt, so the output under
-        // test is delimited rather than compared against the whole stream.
-        const start = "---BEGIN---";
-        const end = "---END---";
-
-        function captured(stdout: string): string[] {
-            const lines = stdout.replaceAll("\r\n", "\n").split("\n");
-            const from = lines.lastIndexOf(start);
-            const to = lines.indexOf(end, from + 1);
-            assert.ok(
-                from !== -1 && to !== -1,
-                `markers missing from output:\n${stdout}`
-            );
-            return lines.slice(from + 1, to);
-        }
-
-        const comSpec = process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe";
-        const powershell = "powershell.exe";
-
-        async function runCmd(command: string): Promise<string[]> {
-            // `@echo off` suppresses the prompt as well as command echoing, so
-            // only the markers and the command's own output land in between.
-            const stdout = await runViaStdin(
-                comSpec,
-                [],
-                [
-                    "@echo off",
-                    `echo ${start}`,
-                    command,
-                    `echo ${end}`,
-                    "exit",
-                    "",
-                ].join("\r\n")
-            );
-            // cmd's `echo` treats everything up to the ` & ` separator as part
-            // of the message, including the space before it, so chained lines
-            // arrive with one trailing space. That is cosmetic (it only affects
-            // the wizard's banner) and orthogonal to what these tests measure,
-            // so trailing blanks are normalised away rather than asserted.
-            return captured(stdout).map((line) => line.replace(/ +$/, ""));
-        }
-
-        async function runPowershell(command: string): Promise<string[]> {
-            const stdout = await runViaStdin(
-                powershell,
-                ["-NoProfile", "-NonInteractive", "-Command", "-"],
-                [
-                    `Write-Host '${start}'`,
-                    command,
-                    `Write-Host '${end}'`,
-                    "exit",
-                    "",
-                ].join("\n")
-            );
-            return captured(stdout);
-        }
 
         // `%` and `!` are excluded deliberately: cmd expands them even inside
         // quotes and has no interactive escape, which is a documented limit of
@@ -945,32 +863,6 @@ describe(__filename, () => {
             "has \\ backslash",
             "multi\nline\nmessage",
         ];
-
-        messages.forEach((message) => {
-            it(`prints ${JSON.stringify(
-                message
-            )} verbatim in cmd.exe`, async () => {
-                assert.deepStrictEqual(
-                    await runCmd(echoCmd(message, "cmd")),
-                    message.split("\n")
-                );
-            });
-
-            it(`prints ${JSON.stringify(
-                message
-            )} verbatim in powershell`, async () => {
-                assert.deepStrictEqual(
-                    await runPowershell(echoCmd(message, "powershell")),
-                    message.split("\n")
-                );
-            });
-        });
-
-        it("emits a blank line rather than the echo state in cmd.exe", async () => {
-            // Regression: bare `echo` prints "ECHO is off." and `echo .` prints
-            // a dot; only `echo.` prints an empty line.
-            assert.deepStrictEqual(await runCmd(echoCmd("", "cmd")), [""]);
-        });
 
         // Windows paths cannot contain " < > | * ? :, so the awkward cases here
         // are the ones a real user can actually produce.
@@ -988,40 +880,61 @@ describe(__filename, () => {
             "C:\\tmp\\with[bracket]",
         ];
 
-        // Invoking Node and printing its own argv is the closest stand-in for
-        // the real command line, which invokes databricks.exe or python.exe with
-        // a quoted path: it proves the path survives the shell *and* the
-        // Windows argv round-trip as a single argument. The path need not exist.
-        const printArgv = "console.log(process.argv[1])";
+        // Invoking Node and printing its own argv is the closest stand-in for the
+        // real command line, which invokes databricks.exe or python.exe with a
+        // quoted path: it proves the path survives the shell *and* the Windows
+        // argv round-trip as one argument. The path need not exist.
+        function printArgvCommand(p: string, kind: "cmd" | "powershell") {
+            const script = "console.log(process.argv[1])";
+            return [
+                escapeExecutableForTerminal(process.execPath, kind),
+                "-e",
+                kind === "cmd" ? `"${script}"` : `'${script}'`,
+                escapePathArgument(p, kind),
+            ].join(" ");
+        }
 
-        paths.forEach((p) => {
-            it(`passes ${JSON.stringify(
-                p
-            )} as one argument in cmd.exe`, async () => {
-                const command = [
-                    escapeExecutableForTerminal(process.execPath, "cmd"),
-                    "-e",
-                    `"${printArgv}"`,
-                    escapePathArgument(p, "cmd"),
-                ].join(" ");
-                assert.deepStrictEqual(await runCmd(command), [p]);
-            });
+        (["cmd", "powershell"] as const).forEach((kind) => {
+            describe(kind, () => {
+                // Each group runs once in `before`, then the `it`s assert over
+                // the collected output.
+                let printed: string[][];
+                let argv: string[][];
 
-            it(`passes ${JSON.stringify(
-                p
-            )} as one argument in powershell`, async () => {
-                const command = [
-                    escapeExecutableForTerminal(process.execPath, "powershell"),
-                    "-e",
-                    `'${printArgv}'`,
-                    escapePathArgument(p, "powershell"),
-                ].join(" ");
-                assert.deepStrictEqual(await runPowershell(command), [p]);
+                before(async () => {
+                    printed = await runWindowsCases(
+                        kind,
+                        messages.map((m) => echoCmd(m, kind))
+                    );
+                    argv = await runWindowsCases(
+                        kind,
+                        paths.map((p) => printArgvCommand(p, kind))
+                    );
+                });
+
+                messages.forEach((message, i) => {
+                    it(`prints ${JSON.stringify(message)} verbatim`, () => {
+                        assert.deepStrictEqual(printed[i], message.split("\n"));
+                    });
+                });
+
+                paths.forEach((p, i) => {
+                    it(`passes ${JSON.stringify(p)} as one argument`, () => {
+                        assert.deepStrictEqual(argv[i], [p]);
+                    });
+                });
             });
         });
 
+        it("emits a blank line rather than the echo state in cmd.exe", async () => {
+            // Regression: bare `echo` prints "ECHO is off." and `echo .` prints
+            // a dot; only `echo.` prints an empty line.
+            const [blank] = await runWindowsCases("cmd", [echoCmd("", "cmd")]);
+            assert.deepStrictEqual(blank, [""]);
+        });
+
         it("runs the whole chain in cmd.exe, hold-open step included", async () => {
-            // `pause` returns at EOF on a piped stdin. What matters is that cmd
+            // `pause` returns at EOF on a closed stdin. What matters is that cmd
             // accepts every link: if any were unrecognised the chain would stop
             // there, and in the wizard the trailing `exit` would close the tab
             // and discard the CLI error the hold-open step exists to preserve.
@@ -1030,14 +943,15 @@ describe(__filename, () => {
                 readCmd("cmd"),
                 echoCmd("after", "cmd"),
             ].join(commandSeparator("cmd"));
-            const output = (await runCmd(command)).join("\n");
+            const [lines] = await runWindowsCases("cmd", [command]);
+            const output = lines.join("\n");
             assert.ok(
                 !output.includes("not recognized"),
                 `cmd rejected part of ${command}: ${output}`
             );
             // "after" only prints if `pause` ran and returned.
             assert.ok(
-                output.includes("before") && output.includes("after"),
+                lines.includes("before") && lines.includes("after"),
                 `chain did not run to completion: ${output}`
             );
         });
@@ -1048,25 +962,26 @@ describe(__filename, () => {
             // wizard hangs awaiting a terminal-close event. PowerShell's own
             // parser answers that directly, and unlike executing the line it
             // does not require Read-Host to have a console to read from.
-            async function parseErrorCount(command: string): Promise<number> {
+            function parseErrorProbe(command: string): string {
                 const quoted = escapePathArgument(command, "powershell");
                 // @() forces a collection, so .Count is 0 rather than $null when
                 // the parser reports no errors.
-                const lines = await runPowershell(
-                    [
-                        "$errs = $null",
-                        `$null = [System.Management.Automation.Language.Parser]::ParseInput(${quoted}, [ref]$null, [ref]$errs)`,
-                        "Write-Host @($errs).Count",
-                    ].join("; ")
-                );
-                const count = Number(lines.join("").trim());
+                return [
+                    "$errs = $null",
+                    `$null = [System.Management.Automation.Language.Parser]::ParseInput(${quoted}, [ref]$null, [ref]$errs)`,
+                    "Write-Host @($errs).Count",
+                ].join("; ");
+            }
+
+            function count(lines: string[]): number {
+                const parsed = Number(lines.join("").trim());
                 assert.ok(
-                    Number.isInteger(count),
+                    Number.isInteger(parsed),
                     `could not read a parse-error count from: ${lines.join(
                         "|"
                     )}`
                 );
-                return count;
+                return parsed;
             }
 
             const powershellLine = [
@@ -1074,22 +989,26 @@ describe(__filename, () => {
                 readCmd("powershell"),
                 "exit",
             ].join(commandSeparator("powershell"));
-            assert.strictEqual(await parseErrorCount(powershellLine), 0);
-
-            // The same line shaped for cmd does not parse, which is why the
-            // shell kind and the terminal's shell must be resolved together.
+            // The same line shaped for cmd must *not* parse, which is why the
+            // shell kind and the terminal's shell are resolved together.
             // Windows PowerShell (`powershell.exe`, 5.1 — what this suite runs)
-            // rejects a bare `&` outright: "The ampersand (&) character is not
-            // allowed. The & operator is reserved for future use." PowerShell 7
-            // repurposed a trailing `&` as the background operator, so if this
-            // is ever pointed at pwsh, expect this half to need revisiting.
+            // rejects a bare `&`: "The ampersand (&) character is not allowed."
+            // PowerShell 7 repurposed a trailing `&` as the background operator,
+            // so if this is ever pointed at pwsh, expect to revisit the second
+            // half of this assertion.
             const cmdLine = [
                 echoCmd("Press any key to close ...", "cmd"),
                 readCmd("cmd"),
                 "exit",
             ].join(commandSeparator("cmd"));
+
+            const [ok, bad] = await runWindowsCases("powershell", [
+                parseErrorProbe(powershellLine),
+                parseErrorProbe(cmdLine),
+            ]);
+            assert.strictEqual(count(ok), 0);
             assert.ok(
-                (await parseErrorCount(cmdLine)) > 0,
+                count(bad) > 0,
                 `a cmd-shaped line unexpectedly parsed in PowerShell: ${cmdLine}`
             );
         });

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -901,15 +901,14 @@ describe(__filename, () => {
                         kind,
                         messages.map((m) => echoCmd(m, kind))
                     );
-                    argv = await runWindowsCases(
-                        kind,
-                        paths.map(
-                            (p) =>
-                                `${argvPrinter.invocation(
-                                    kind
-                                )} ${escapePathArgument(p, kind)}`
-                        )
-                    );
+                    // Arguments are collected via a file rather than from the
+                    // shell's stdout. A native process writes to the pipe
+                    // directly, with its own buffering, so its output is not
+                    // ordered against the `echo`/`Write-Host` markers around it:
+                    // under `powershell -Command -` it landed outside them
+                    // entirely and every case read back empty. Buffering cannot
+                    // reorder a file the process wrote before it exited.
+                    argv = await argvPrinter.collect(kind, paths);
                 });
 
                 messages.forEach((message, i) => {

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -7,11 +7,14 @@ import {
     commandSeparator,
     detectShellKind,
     echoCmd,
+    effectiveShellPath,
     escapeExecutableForTerminal,
     escapePathArgument,
     hasCmdUnsafeChars,
     readCmd,
+    resolveProfileShellArgs,
     ShellKind,
+    terminalShellKind,
 } from "./shellUtils";
 
 const execFileAsync = promisify(execFile);
@@ -93,6 +96,245 @@ describe(__filename, () => {
             );
         });
     });
+
+    describe("terminalShellKind", () => {
+        // A reused terminal is whatever profile the user had focused, so the
+        // kind must come from the terminal's own shellPath. Deriving it from
+        // env.shell (the *default* profile) is #1822 with the shells swapped.
+        function terminal(shellPath?: string) {
+            return {creationOptions: {shellPath}};
+        }
+
+        it("classifies a reused terminal from its own shellPath", () => {
+            assert.strictEqual(
+                terminalShellKind(
+                    terminal("C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+                    "win32"
+                ),
+                "powershell"
+            );
+            assert.strictEqual(
+                terminalShellKind(terminal("/bin/zsh"), "darwin"),
+                "posix"
+            );
+        });
+
+        it("classifies a cmd.exe tab as cmd, not as the default profile", () => {
+            // The regression this guards: a Windows user whose default profile
+            // is Git Bash (env.shell = bash.exe -> posix) with a cmd tab
+            // focused got POSIX single quotes, which cmd does not treat as
+            // quoting at all — it looks for a program named literally
+            // "'C:\Python\python.exe'", quotes included, and fails. main
+            // survived the mismatch by accident because it double-quoted, which
+            // parses in both shells.
+            assert.strictEqual(
+                terminalShellKind(
+                    terminal("C:\\Windows\\System32\\cmd.exe"),
+                    "win32"
+                ),
+                "cmd"
+            );
+        });
+
+        it("does not emit a powershell call operator into a cmd tab", () => {
+            // The reverse mismatch: `& 'C:\...\python.exe'` is what PowerShell
+            // needs and what cmd chokes on. Deriving the kind from the terminal
+            // keeps the two in step.
+            const cmdTab = terminal("C:\\Windows\\System32\\cmd.exe");
+            const kind = terminalShellKind(cmdTab, "win32");
+            const line = escapeExecutableForTerminal(
+                "C:\\Python\\python.exe",
+                kind
+            );
+            assert.strictEqual(line, '"C:\\Python\\python.exe"');
+            assert.ok(!line.startsWith("&"), line);
+            assert.ok(!line.startsWith("'"), line);
+        });
+
+        it("falls back to the ambient shell when shellPath is unset", () => {
+            // An inherited-profile terminal reports no shellPath, and that is
+            // exactly the case env.shell does describe. Must not throw or
+            // misclassify for extension pseudoterminals either.
+            const expected = terminalShellKind(terminal(undefined));
+            assert.ok(ALL_KINDS.includes(expected));
+            assert.strictEqual(terminalShellKind(terminal("")), expected);
+        });
+    });
+
+    // The profile keys below are VS Code's own display names
+    // ("Ubuntu-22.04", "Git Bash", "Command Prompt"), so they cannot be
+    // camelCased without ceasing to match real settings.
+    /* eslint-disable @typescript-eslint/naming-convention */
+    describe("resolveProfileShellArgs", () => {
+        // env.shell reports the default profile's *path* only. VS Code builds a
+        // fresh profile from an explicit executable and never fills args back
+        // in, so pinning shellPath alone drops them.
+        const wslProfiles = {
+            "Ubuntu-22.04": {
+                path: "wsl.exe",
+                args: ["-d", "Ubuntu-22.04"],
+            },
+        };
+
+        it("forwards the configured args for the default profile", () => {
+            // Without this the terminal lands in the *default* distro, so
+            // bundle init scaffolds into a different filesystem than the user
+            // configured and getSubProjects then reports no projects found.
+            assert.deepStrictEqual(
+                resolveProfileShellArgs("wsl.exe", "Ubuntu-22.04", wslProfiles),
+                ["-d", "Ubuntu-22.04"]
+            );
+        });
+
+        it("matches the profile path case-insensitively and by basename", () => {
+            assert.deepStrictEqual(
+                resolveProfileShellArgs(
+                    "C:\\Windows\\System32\\wsl.exe",
+                    "Ubuntu-22.04",
+                    wslProfiles
+                ),
+                ["-d", "Ubuntu-22.04"]
+            );
+        });
+
+        it("forwards Git Bash's --login", () => {
+            assert.deepStrictEqual(
+                resolveProfileShellArgs(
+                    "C:\\Program Files\\Git\\bin\\bash.exe",
+                    "Git Bash",
+                    {
+                        "Git Bash": {
+                            path: "C:\\Program Files\\Git\\bin\\bash.exe",
+                            args: ["--login"],
+                        },
+                    }
+                ),
+                ["--login"]
+            );
+        });
+
+        it("returns undefined when the profile is for a different shell", () => {
+            // Passing another shell's args is worse than passing none: a
+            // renamed or source-based profile can point at a different
+            // executable than env.shell reports.
+            assert.strictEqual(
+                resolveProfileShellArgs(
+                    "pwsh.exe",
+                    "Ubuntu-22.04",
+                    wslProfiles
+                ),
+                undefined
+            );
+        });
+
+        it("returns undefined when there is nothing to forward", () => {
+            assert.strictEqual(
+                resolveProfileShellArgs("wsl.exe", undefined, wslProfiles),
+                undefined
+            );
+            assert.strictEqual(
+                resolveProfileShellArgs("wsl.exe", "Ubuntu-22.04", undefined),
+                undefined
+            );
+            assert.strictEqual(
+                resolveProfileShellArgs("pwsh.exe", "PowerShell", {
+                    PowerShell: {path: "pwsh.exe"},
+                }),
+                undefined
+            );
+            // A null entry is how VS Code settings mark a profile as removed.
+            assert.strictEqual(
+                resolveProfileShellArgs("pwsh.exe", "PowerShell", {
+                    PowerShell: null,
+                }),
+                undefined
+            );
+        });
+    });
+
+    describe("effectiveShellPath", () => {
+        // When env.shell is empty the callers pass shellPath: undefined, so VS
+        // Code launches the configured default profile. Guessing the platform
+        // default instead can disagree with what actually starts, and a
+        // mis-shaped line means nothing runs — not even the trailing `exit` —
+        // leaving the wizard awaiting a terminal-close event forever.
+        it("prefers env.shell when VS Code reports one", () => {
+            assert.strictEqual(
+                effectiveShellPath(
+                    "/bin/zsh",
+                    "Command Prompt",
+                    {"Command Prompt": {path: "cmd.exe"}},
+                    "C:\\Windows\\System32\\cmd.exe"
+                ),
+                "/bin/zsh"
+            );
+        });
+
+        it("uses the configured default profile when env.shell is empty", () => {
+            assert.strictEqual(
+                detectShellKind(
+                    effectiveShellPath(
+                        "",
+                        "Command Prompt",
+                        {"Command Prompt": {path: "cmd.exe"}},
+                        undefined
+                    ),
+                    "win32"
+                ),
+                "cmd"
+            );
+            // Git Bash as the default profile must resolve to posix, not to the
+            // PowerShell a bare platform-default guess would assume.
+            assert.strictEqual(
+                detectShellKind(
+                    effectiveShellPath(
+                        "",
+                        "Git Bash",
+                        {
+                            "Git Bash": {
+                                path: "C:\\Program Files\\Git\\bin\\bash.exe",
+                            },
+                        },
+                        undefined
+                    ),
+                    "win32"
+                ),
+                "posix"
+            );
+        });
+
+        it("takes the first candidate when a profile lists several paths", () => {
+            assert.strictEqual(
+                effectiveShellPath(
+                    "",
+                    "PowerShell",
+                    {PowerShell: {path: ["pwsh.exe", "powershell.exe"]}},
+                    undefined
+                ),
+                "pwsh.exe"
+            );
+        });
+
+        it("falls back to ComSpec, then to the platform default", () => {
+            assert.strictEqual(
+                effectiveShellPath("", undefined, undefined, "C:\\W\\cmd.exe"),
+                "C:\\W\\cmd.exe"
+            );
+            // Nothing known at all: detectShellKind's platform default applies.
+            assert.strictEqual(
+                effectiveShellPath("", undefined, undefined, undefined),
+                ""
+            );
+            assert.strictEqual(
+                detectShellKind(
+                    effectiveShellPath("", undefined, undefined, undefined),
+                    "win32"
+                ),
+                "powershell"
+            );
+        });
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
 
     describe("clearCmd", () => {
         it("returns the clear command for each shell", () => {
@@ -204,6 +446,12 @@ describe(__filename, () => {
             // the wrong directory to the CLI.
             assert.ok(hasCmdUnsafeChars("C:\\p%TEMP%q"));
             assert.ok(!hasCmdUnsafeChars("C:\\Users\\me\\project"));
+        });
+
+        it("also flags !, which expands under delayed expansion", () => {
+            // `cmd /V:ON` (or DelayedExpansion in the registry, which some
+            // corporate images enable) expands !VAR! inside double quotes too.
+            assert.ok(hasCmdUnsafeChars("C:\\p!TEMP!q"));
         });
 
         it("escapes every embedded quote, not just the first", () => {

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import {execFile} from "child_process";
 import {existsSync} from "fs";
 import {promisify} from "util";
-import {runWindowsCases} from "../test/windowsShellHarness";
+import {createArgvPrinter, runWindowsCases} from "../test/windowsShellHarness";
 import {
     clearCmd,
     commandSeparator,
@@ -843,12 +843,6 @@ describe(__filename, () => {
         // enforces its own per-spawn deadline, so this only has to not fire first.
         this.timeout(120_000);
 
-        before(function () {
-            if (process.platform !== "win32") {
-                this.skip();
-            }
-        });
-
         // `%` and `!` are excluded deliberately: cmd expands them even inside
         // quotes and has no interactive escape, which is a documented limit of
         // this module rather than something echoCmd promises — see
@@ -880,19 +874,20 @@ describe(__filename, () => {
             "C:\\tmp\\with[bracket]",
         ];
 
-        // Invoking Node and printing its own argv is the closest stand-in for the
-        // real command line, which invokes databricks.exe or python.exe with a
-        // quoted path: it proves the path survives the shell *and* the Windows
-        // argv round-trip as one argument. The path need not exist.
-        function printArgvCommand(p: string, kind: "cmd" | "powershell") {
-            const script = "console.log(process.argv[1])";
-            return [
-                escapeExecutableForTerminal(process.execPath, kind),
-                "-e",
-                kind === "cmd" ? `"${script}"` : `'${script}'`,
-                escapePathArgument(p, kind),
-            ].join(" ");
-        }
+        // Stands in for the real command line, which invokes databricks.exe or
+        // python.exe with a quoted path: it proves the path survives the shell
+        // *and* the Windows argv round-trip as one argument. The path under test
+        // need not exist — only its spelling matters.
+        let argvPrinter: ReturnType<typeof createArgvPrinter>;
+
+        before(function () {
+            if (process.platform !== "win32") {
+                this.skip();
+            }
+            argvPrinter = createArgvPrinter();
+        });
+
+        after(() => argvPrinter?.dispose());
 
         (["cmd", "powershell"] as const).forEach((kind) => {
             describe(kind, () => {
@@ -908,7 +903,12 @@ describe(__filename, () => {
                     );
                     argv = await runWindowsCases(
                         kind,
-                        paths.map((p) => printArgvCommand(p, kind))
+                        paths.map(
+                            (p) =>
+                                `${argvPrinter.invocation(
+                                    kind
+                                )} ${escapePathArgument(p, kind)}`
+                        )
                     );
                 });
 

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {execFile} from "child_process";
+import {execFile, spawn} from "child_process";
 import {existsSync} from "fs";
 import {promisify} from "util";
 import {
@@ -7,12 +7,11 @@ import {
     commandSeparator,
     detectShellKind,
     echoCmd,
-    effectiveShellPath,
     escapeExecutableForTerminal,
     escapePathArgument,
     hasCmdUnsafeChars,
     readCmd,
-    resolveProfileShellArgs,
+    resolveTerminalShell,
     ShellKind,
     terminalShellKind,
 } from "./shellUtils";
@@ -165,10 +164,11 @@ describe(__filename, () => {
     // ("Ubuntu-22.04", "Git Bash", "Command Prompt"), so they cannot be
     // camelCased without ceasing to match real settings.
     /* eslint-disable @typescript-eslint/naming-convention */
-    describe("resolveProfileShellArgs", () => {
-        // env.shell reports the default profile's *path* only. VS Code builds a
-        // fresh profile from an explicit executable and never fills args back
-        // in, so pinning shellPath alone drops them.
+    describe("resolveTerminalShell", () => {
+        // env.shell reports a *path* only. VS Code builds a fresh profile from
+        // an explicit executable and never fills args back in, so pinning
+        // shellPath alone drops them — hence the rule that the shell is pinned
+        // only when the configured profile proves the args belong to it.
         const wslProfiles = {
             "Ubuntu-22.04": {
                 path: "wsl.exe",
@@ -176,30 +176,44 @@ describe(__filename, () => {
             },
         };
 
-        it("forwards the configured args for the default profile", () => {
-            // Without this the terminal lands in the *default* distro, so
+        it("pins the shell and forwards its args when the profile matches", () => {
+            // Without the args the terminal lands in the *default* distro, so
             // bundle init scaffolds into a different filesystem than the user
             // configured and getSubProjects then reports no projects found.
             assert.deepStrictEqual(
-                resolveProfileShellArgs("wsl.exe", "Ubuntu-22.04", wslProfiles),
-                ["-d", "Ubuntu-22.04"]
+                resolveTerminalShell(
+                    "wsl.exe",
+                    "Ubuntu-22.04",
+                    wslProfiles,
+                    "win32"
+                ),
+                {
+                    kind: "posix",
+                    shellPath: "wsl.exe",
+                    shellArgs: wslProfiles["Ubuntu-22.04"].args,
+                }
             );
         });
 
         it("matches the profile path case-insensitively and by basename", () => {
             assert.deepStrictEqual(
-                resolveProfileShellArgs(
+                resolveTerminalShell(
                     "C:\\Windows\\System32\\wsl.exe",
                     "Ubuntu-22.04",
-                    wslProfiles
+                    wslProfiles,
+                    "win32"
                 ),
-                ["-d", "Ubuntu-22.04"]
+                {
+                    kind: "posix",
+                    shellPath: "C:\\Windows\\System32\\wsl.exe",
+                    shellArgs: ["-d", "Ubuntu-22.04"],
+                }
             );
         });
 
-        it("forwards Git Bash's --login", () => {
+        it("forwards Git Bash's --login when the profile names a path", () => {
             assert.deepStrictEqual(
-                resolveProfileShellArgs(
+                resolveTerminalShell(
                     "C:\\Program Files\\Git\\bin\\bash.exe",
                     "Git Bash",
                     {
@@ -207,87 +221,141 @@ describe(__filename, () => {
                             path: "C:\\Program Files\\Git\\bin\\bash.exe",
                             args: ["--login"],
                         },
-                    }
+                    },
+                    "win32"
                 ),
-                ["--login"]
+                {
+                    kind: "posix",
+                    shellPath: "C:\\Program Files\\Git\\bin\\bash.exe",
+                    shellArgs: ["--login"],
+                }
             );
         });
 
-        it("returns undefined when the profile is for a different shell", () => {
+        it("does not pin a source-based profile, whose args it cannot see", () => {
+            // Regression: VS Code's own default Windows profiles are written
+            // `{"Git Bash": {"source": "Git Bash"}}` — no path, and the args it
+            // launches with (`--login`) are not in settings at all. Pinning
+            // bash.exe with no args gives a *non-login* shell: a different PATH
+            // and no profile scripts, unlike every other terminal the user
+            // opens. Classify the shell, but let VS Code launch it.
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "C:\\Program Files\\Git\\bin\\bash.exe",
+                    "Git Bash",
+                    {"Git Bash": {source: "Git Bash"}},
+                    "win32"
+                ),
+                {kind: "posix"}
+            );
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                    "PowerShell",
+                    {PowerShell: {source: "PowerShell"}},
+                    "win32"
+                ),
+                {kind: "powershell"}
+            );
+        });
+
+        it("does not pin when the profile is for a different shell", () => {
             // Passing another shell's args is worse than passing none: a
             // renamed or source-based profile can point at a different
             // executable than env.shell reports.
-            assert.strictEqual(
-                resolveProfileShellArgs(
+            assert.deepStrictEqual(
+                resolveTerminalShell(
                     "pwsh.exe",
                     "Ubuntu-22.04",
-                    wslProfiles
+                    wslProfiles,
+                    "win32"
                 ),
-                undefined
+                {kind: "powershell"}
             );
         });
 
-        it("returns undefined when there is nothing to forward", () => {
-            assert.strictEqual(
-                resolveProfileShellArgs("wsl.exe", undefined, wslProfiles),
-                undefined
+        it("still classifies env.shell when there is no profile to consult", () => {
+            // Not pinning costs nothing: env.shell *is* the resolved path of the
+            // default profile, so it describes the shell VS Code will launch.
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "/bin/zsh",
+                    undefined,
+                    undefined,
+                    "darwin"
+                ),
+                {kind: "posix"}
             );
-            assert.strictEqual(
-                resolveProfileShellArgs("wsl.exe", "Ubuntu-22.04", undefined),
-                undefined
-            );
-            assert.strictEqual(
-                resolveProfileShellArgs("pwsh.exe", "PowerShell", {
-                    PowerShell: {path: "pwsh.exe"},
-                }),
-                undefined
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "C:\\Windows\\System32\\cmd.exe",
+                    undefined,
+                    undefined,
+                    "win32"
+                ),
+                {kind: "cmd"}
             );
             // A null entry is how VS Code settings mark a profile as removed.
-            assert.strictEqual(
-                resolveProfileShellArgs("pwsh.exe", "PowerShell", {
-                    PowerShell: null,
-                }),
-                undefined
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "pwsh.exe",
+                    "PowerShell",
+                    {PowerShell: null},
+                    "win32"
+                ),
+                {kind: "powershell"}
             );
         });
-    });
 
-    describe("effectiveShellPath", () => {
-        // When env.shell is empty the callers pass shellPath: undefined, so VS
-        // Code launches the configured default profile. Guessing the platform
-        // default instead can disagree with what actually starts, and a
-        // mis-shaped line means nothing runs — not even the trailing `exit` —
-        // leaving the wizard awaiting a terminal-close event forever.
-        it("prefers env.shell when VS Code reports one", () => {
-            assert.strictEqual(
-                effectiveShellPath(
+        it("pins with no args when the matching profile has none", () => {
+            assert.deepStrictEqual(
+                resolveTerminalShell(
+                    "pwsh.exe",
+                    "PowerShell",
+                    {PowerShell: {path: "pwsh.exe"}},
+                    "win32"
+                ),
+                {
+                    kind: "powershell",
+                    shellPath: "pwsh.exe",
+                    shellArgs: undefined,
+                }
+            );
+        });
+
+        it("prefers env.shell over the configured profile's path", () => {
+            // env.shell is what VS Code resolved; the profile is only consulted
+            // for the args that go with it.
+            assert.deepStrictEqual(
+                resolveTerminalShell(
                     "/bin/zsh",
                     "Command Prompt",
                     {"Command Prompt": {path: "cmd.exe"}},
-                    "C:\\Windows\\System32\\cmd.exe"
+                    "win32"
                 ),
-                "/bin/zsh"
+                {kind: "posix"}
             );
         });
 
-        it("uses the configured default profile when env.shell is empty", () => {
-            assert.strictEqual(
-                detectShellKind(
-                    effectiveShellPath(
+        describe("when env.shell is empty", () => {
+            // Shell-less environments report "". Callers then pass
+            // shellPath: undefined, so VS Code launches the configured default
+            // profile — which may well be cmd.exe or Git Bash, not the
+            // PowerShell a bare platform-default guess assumes. A mis-shaped
+            // line means nothing runs (not even the trailing `exit`), leaving
+            // the wizard awaiting a terminal-close event forever.
+            it("classifies from the configured default profile", () => {
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
                         "",
                         "Command Prompt",
                         {"Command Prompt": {path: "cmd.exe"}},
-                        undefined
+                        "win32"
                     ),
-                    "win32"
-                ),
-                "cmd"
-            );
-            // Git Bash as the default profile must resolve to posix, not to the
-            // PowerShell a bare platform-default guess would assume.
-            assert.strictEqual(
-                detectShellKind(
-                    effectiveShellPath(
+                    {kind: "cmd"}
+                );
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
                         "",
                         "Git Bash",
                         {
@@ -295,43 +363,98 @@ describe(__filename, () => {
                                 path: "C:\\Program Files\\Git\\bin\\bash.exe",
                             },
                         },
-                        undefined
+                        "win32"
                     ),
-                    "win32"
-                ),
-                "posix"
-            );
-        });
+                    {kind: "posix"}
+                );
+            });
 
-        it("takes the first candidate when a profile lists several paths", () => {
-            assert.strictEqual(
-                effectiveShellPath(
-                    "",
-                    "PowerShell",
-                    {PowerShell: {path: ["pwsh.exe", "powershell.exe"]}},
-                    undefined
-                ),
-                "pwsh.exe"
-            );
-        });
+            it("takes the first candidate when a profile lists several paths", () => {
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
+                        "",
+                        "PowerShell",
+                        {PowerShell: {path: ["pwsh.exe", "powershell.exe"]}},
+                        "win32"
+                    ),
+                    {kind: "powershell"}
+                );
+            });
 
-        it("falls back to ComSpec, then to the platform default", () => {
-            assert.strictEqual(
-                effectiveShellPath("", undefined, undefined, "C:\\W\\cmd.exe"),
-                "C:\\W\\cmd.exe"
-            );
-            // Nothing known at all: detectShellKind's platform default applies.
-            assert.strictEqual(
-                effectiveShellPath("", undefined, undefined, undefined),
-                ""
-            );
-            assert.strictEqual(
-                detectShellKind(
-                    effectiveShellPath("", undefined, undefined, undefined),
-                    "win32"
-                ),
-                "powershell"
-            );
+            it("classifies a source-only default profile", () => {
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
+                        "",
+                        "Command Prompt",
+                        {"Command Prompt": {source: "PowerShell"}},
+                        "win32"
+                    ),
+                    {kind: "powershell"}
+                );
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
+                        "",
+                        "Git Bash",
+                        {"Git Bash": {source: "Git Bash"}},
+                        "win32"
+                    ),
+                    {kind: "posix"}
+                );
+            });
+
+            it("falls back to the platform default, never to cmd", () => {
+                // Regression: ComSpec was consulted here, and on Windows it is
+                // *always* cmd.exe — it describes what the OS would run, never
+                // what VS Code will. Every shell-less Windows environment was
+                // classified cmd while PowerShell actually started, so the
+                // ` & `-separated line failed to parse and nothing ran. This
+                // also made detectShellKind's win32 default unreachable.
+                assert.deepStrictEqual(
+                    resolveTerminalShell("", undefined, undefined, "win32"),
+                    {kind: "powershell"}
+                );
+                // An unrecognised source must not defeat the fallback either.
+                assert.deepStrictEqual(
+                    resolveTerminalShell(
+                        "",
+                        "Custom",
+                        {Custom: {source: "Something Else"}},
+                        "win32"
+                    ),
+                    {kind: "powershell"}
+                );
+                assert.deepStrictEqual(
+                    resolveTerminalShell("", undefined, undefined, "darwin"),
+                    {kind: "posix"}
+                );
+                assert.deepStrictEqual(
+                    resolveTerminalShell("", undefined, undefined, "linux"),
+                    {kind: "posix"}
+                );
+            });
+
+            it("never pins a shell it cannot name", () => {
+                // shellPath: "" is not a launchable path, so every empty-shell
+                // result must leave the launch to VS Code.
+                const profiles = {
+                    "Command Prompt": {path: "cmd.exe", args: ["/K"]},
+                };
+                (
+                    [
+                        ["Command Prompt", profiles],
+                        [undefined, undefined],
+                    ] as const
+                ).forEach(([name, ps]) => {
+                    const resolved = resolveTerminalShell(
+                        "",
+                        name,
+                        ps,
+                        "win32"
+                    );
+                    assert.strictEqual(resolved.shellPath, undefined);
+                    assert.strictEqual(resolved.shellArgs, undefined);
+                });
+            });
         });
     });
     /* eslint-enable @typescript-eslint/naming-convention */
@@ -592,15 +715,34 @@ describe(__filename, () => {
 
     // The assertions above only prove we produce the string we intended. These
     // run the generated command through a real shell to prove the shell agrees.
-    // Gated on platform: /bin/sh is only guaranteed on POSIX hosts, and CI runs
-    // Linux and macOS.
-    describe("round-trip against a real shell", () => {
-        const canRunPosix = process.platform !== "win32";
+    // CI runs Linux, macOS and Windows, so both suites below execute somewhere;
+    // each skips itself on the platforms whose shells do not exist.
+    describe("round-trip against a real posix shell", () => {
+        // /bin/sh is guaranteed on every POSIX host, so its absence is a broken
+        // environment rather than a reason to skip: silently passing would hide
+        // this entire suite. zsh, bash and dash are probed individually.
+        const requiredShell = "/bin/sh";
+
+        before(function () {
+            if (process.platform === "win32") {
+                this.skip();
+            }
+            assert.ok(
+                existsSync(requiredShell),
+                `${requiredShell} is missing on a POSIX host; the round-trip suite cannot run`
+            );
+        });
 
         // sh is usually dash, zsh is the macOS default, and bash is what most
         // Linux users get. Their builtin `echo` and `read` differ, so each shell
         // has to be checked rather than assumed equivalent.
-        const shells = ["/bin/sh", "/bin/zsh", "/bin/bash"];
+        const shells = [requiredShell, "/bin/zsh", "/bin/bash"];
+
+        function skipUnlessPresent(ctx: Mocha.Context, shell: string) {
+            if (shell !== requiredShell && !existsSync(shell)) {
+                ctx.skip();
+            }
+        }
 
         async function run(shell: string, command: string): Promise<string> {
             const {stdout} = await execFileAsync(shell, ["-c", command]);
@@ -627,9 +769,7 @@ describe(__filename, () => {
                 it(`prints ${JSON.stringify(
                     message
                 )} verbatim in ${shell}`, async function () {
-                    if (!canRunPosix || !existsSync(shell)) {
-                        this.skip();
-                    }
+                    skipUnlessPresent(this, shell);
                     const stdout = await run(shell, echoCmd(message, "posix"));
                     assert.strictEqual(stdout, `${message}\n`);
                 });
@@ -652,9 +792,7 @@ describe(__filename, () => {
                 it(`passes ${JSON.stringify(
                     p
                 )} as one argument in ${shell}`, async function () {
-                    if (!canRunPosix || !existsSync(shell)) {
-                        this.skip();
-                    }
+                    skipUnlessPresent(this, shell);
                     // printf %s\n prints each argument on its own line, so a path
                     // that got split shows up as more than one line.
                     const stdout = await run(
@@ -671,9 +809,7 @@ describe(__filename, () => {
         // installed on macOS, so it is probed separately from `shells`.
         [...shells, "/bin/dash"].forEach((shell) => {
             it(`readCmd is accepted by ${shell}`, async function () {
-                if (!canRunPosix || !existsSync(shell)) {
-                    this.skip();
-                }
+                skipUnlessPresent(this, shell);
                 // Regression: bare `read` is a usage error in dash ("arg count",
                 // exit 2), so the hold-open step failed and the following `exit`
                 // closed the terminal, hiding the CLI error it exists to keep
@@ -691,6 +827,271 @@ describe(__filename, () => {
                     `${shell} rejected ${readCmd("posix")}`
                 );
             });
+        });
+    });
+
+    // The cmd.exe and PowerShell branches are the ones #1822 was actually about,
+    // and string equality alone is what let the original bug ship. The unit-test
+    // matrix includes a windows-server runner, so they can be executed for real
+    // rather than only asserted as strings.
+    describe("round-trip against a real windows shell", () => {
+        before(function () {
+            if (process.platform !== "win32") {
+                this.skip();
+            }
+        });
+
+        // Commands are piped to the shell's *stdin* rather than passed as argv.
+        // This is what `terminal.sendText` does, and it keeps Node's own
+        // Windows argv quoting out of the measurement — passing the command as
+        // an argument would test that quoting instead of ours.
+        //
+        // Killed after a deadline rather than left to Mocha's timeout: a shell
+        // that sits waiting for input would otherwise leak a process and report
+        // a bare timeout instead of the output collected so far.
+        function runViaStdin(
+            exe: string,
+            args: string[],
+            script: string
+        ): Promise<string> {
+            return new Promise((resolve, reject) => {
+                const child = spawn(exe, args, {
+                    stdio: ["pipe", "pipe", "pipe"],
+                });
+                let stdout = "";
+                child.stdout.setEncoding("utf8");
+                child.stdout.on("data", (chunk) => (stdout += chunk));
+                const deadline = setTimeout(() => child.kill(), 10_000);
+                child.on("error", (e) => {
+                    clearTimeout(deadline);
+                    reject(e);
+                });
+                child.on("close", () => {
+                    clearTimeout(deadline);
+                    resolve(stdout);
+                });
+                child.stdin.end(script);
+            });
+        }
+
+        // Both shells print a banner and (for cmd) a prompt, so the output under
+        // test is delimited rather than compared against the whole stream.
+        const start = "---BEGIN---";
+        const end = "---END---";
+
+        function captured(stdout: string): string[] {
+            const lines = stdout.replaceAll("\r\n", "\n").split("\n");
+            const from = lines.lastIndexOf(start);
+            const to = lines.indexOf(end, from + 1);
+            assert.ok(
+                from !== -1 && to !== -1,
+                `markers missing from output:\n${stdout}`
+            );
+            return lines.slice(from + 1, to);
+        }
+
+        const comSpec = process.env.ComSpec ?? "C:\\Windows\\System32\\cmd.exe";
+        const powershell = "powershell.exe";
+
+        async function runCmd(command: string): Promise<string[]> {
+            // `@echo off` suppresses the prompt as well as command echoing, so
+            // only the markers and the command's own output land in between.
+            const stdout = await runViaStdin(
+                comSpec,
+                [],
+                [
+                    "@echo off",
+                    `echo ${start}`,
+                    command,
+                    `echo ${end}`,
+                    "exit",
+                    "",
+                ].join("\r\n")
+            );
+            // cmd's `echo` treats everything up to the ` & ` separator as part
+            // of the message, including the space before it, so chained lines
+            // arrive with one trailing space. That is cosmetic (it only affects
+            // the wizard's banner) and orthogonal to what these tests measure,
+            // so trailing blanks are normalised away rather than asserted.
+            return captured(stdout).map((line) => line.replace(/ +$/, ""));
+        }
+
+        async function runPowershell(command: string): Promise<string[]> {
+            const stdout = await runViaStdin(
+                powershell,
+                ["-NoProfile", "-NonInteractive", "-Command", "-"],
+                [
+                    `Write-Host '${start}'`,
+                    command,
+                    `Write-Host '${end}'`,
+                    "exit",
+                    "",
+                ].join("\n")
+            );
+            return captured(stdout);
+        }
+
+        // `%` and `!` are excluded deliberately: cmd expands them even inside
+        // quotes and has no interactive escape, which is a documented limit of
+        // this module rather than something echoCmd promises — see
+        // hasCmdUnsafeChars, and unsafeOutputDirReason for how callers refuse.
+        const messages = [
+            "plain message",
+            'has "double quotes"',
+            "has 'single quotes'",
+            "has $HOME and `backticks`",
+            "has & ampersand | pipe > gt < lt",
+            "has ^ caret and (parens)",
+            "has \\ backslash",
+            "multi\nline\nmessage",
+        ];
+
+        messages.forEach((message) => {
+            it(`prints ${JSON.stringify(
+                message
+            )} verbatim in cmd.exe`, async () => {
+                assert.deepStrictEqual(
+                    await runCmd(echoCmd(message, "cmd")),
+                    message.split("\n")
+                );
+            });
+
+            it(`prints ${JSON.stringify(
+                message
+            )} verbatim in powershell`, async () => {
+                assert.deepStrictEqual(
+                    await runPowershell(echoCmd(message, "powershell")),
+                    message.split("\n")
+                );
+            });
+        });
+
+        it("emits a blank line rather than the echo state in cmd.exe", async () => {
+            // Regression: bare `echo` prints "ECHO is off." and `echo .` prints
+            // a dot; only `echo.` prints an empty line.
+            assert.deepStrictEqual(await runCmd(echoCmd("", "cmd")), [""]);
+        });
+
+        // Windows paths cannot contain " < > | * ? :, so the awkward cases here
+        // are the ones a real user can actually produce.
+        const paths = [
+            "C:\\tmp\\plain",
+            "C:\\tmp\\with space",
+            "C:\\tmp\\with'quote",
+            "C:\\tmp\\with$var",
+            "C:\\tmp\\with`tick",
+            "C:\\tmp\\with&amp",
+            "C:\\tmp\\with(paren)",
+            "C:\\tmp\\with^caret",
+            "C:\\tmp\\with;semi,comma=eq",
+            "C:\\tmp\\with#hash@at+plus",
+            "C:\\tmp\\with[bracket]",
+        ];
+
+        // Invoking Node and printing its own argv is the closest stand-in for
+        // the real command line, which invokes databricks.exe or python.exe with
+        // a quoted path: it proves the path survives the shell *and* the
+        // Windows argv round-trip as a single argument. The path need not exist.
+        const printArgv = "console.log(process.argv[1])";
+
+        paths.forEach((p) => {
+            it(`passes ${JSON.stringify(
+                p
+            )} as one argument in cmd.exe`, async () => {
+                const command = [
+                    escapeExecutableForTerminal(process.execPath, "cmd"),
+                    "-e",
+                    `"${printArgv}"`,
+                    escapePathArgument(p, "cmd"),
+                ].join(" ");
+                assert.deepStrictEqual(await runCmd(command), [p]);
+            });
+
+            it(`passes ${JSON.stringify(
+                p
+            )} as one argument in powershell`, async () => {
+                const command = [
+                    escapeExecutableForTerminal(process.execPath, "powershell"),
+                    "-e",
+                    `'${printArgv}'`,
+                    escapePathArgument(p, "powershell"),
+                ].join(" ");
+                assert.deepStrictEqual(await runPowershell(command), [p]);
+            });
+        });
+
+        it("runs the whole chain in cmd.exe, hold-open step included", async () => {
+            // `pause` returns at EOF on a piped stdin. What matters is that cmd
+            // accepts every link: if any were unrecognised the chain would stop
+            // there, and in the wizard the trailing `exit` would close the tab
+            // and discard the CLI error the hold-open step exists to preserve.
+            const command = [
+                echoCmd("before", "cmd"),
+                readCmd("cmd"),
+                echoCmd("after", "cmd"),
+            ].join(commandSeparator("cmd"));
+            const output = (await runCmd(command)).join("\n");
+            assert.ok(
+                !output.includes("not recognized"),
+                `cmd rejected part of ${command}: ${output}`
+            );
+            // "after" only prints if `pause` ran and returned.
+            assert.ok(
+                output.includes("before") && output.includes("after"),
+                `chain did not run to completion: ${output}`
+            );
+        });
+
+        it("parses the generated powershell command without executing it", async () => {
+            // The failure mode #1822 describes for PowerShell is a *parse*
+            // error: nothing runs at all, not even the trailing `exit`, so the
+            // wizard hangs awaiting a terminal-close event. PowerShell's own
+            // parser answers that directly, and unlike executing the line it
+            // does not require Read-Host to have a console to read from.
+            async function parseErrorCount(command: string): Promise<number> {
+                const quoted = escapePathArgument(command, "powershell");
+                // @() forces a collection, so .Count is 0 rather than $null when
+                // the parser reports no errors.
+                const lines = await runPowershell(
+                    [
+                        "$errs = $null",
+                        `$null = [System.Management.Automation.Language.Parser]::ParseInput(${quoted}, [ref]$null, [ref]$errs)`,
+                        "Write-Host @($errs).Count",
+                    ].join("; ")
+                );
+                const count = Number(lines.join("").trim());
+                assert.ok(
+                    Number.isInteger(count),
+                    `could not read a parse-error count from: ${lines.join(
+                        "|"
+                    )}`
+                );
+                return count;
+            }
+
+            const powershellLine = [
+                echoCmd("Press any key to close ...", "powershell"),
+                readCmd("powershell"),
+                "exit",
+            ].join(commandSeparator("powershell"));
+            assert.strictEqual(await parseErrorCount(powershellLine), 0);
+
+            // The same line shaped for cmd does not parse, which is why the
+            // shell kind and the terminal's shell must be resolved together.
+            // Windows PowerShell (`powershell.exe`, 5.1 — what this suite runs)
+            // rejects a bare `&` outright: "The ampersand (&) character is not
+            // allowed. The & operator is reserved for future use." PowerShell 7
+            // repurposed a trailing `&` as the background operator, so if this
+            // is ever pointed at pwsh, expect this half to need revisiting.
+            const cmdLine = [
+                echoCmd("Press any key to close ...", "cmd"),
+                readCmd("cmd"),
+                "exit",
+            ].join(commandSeparator("cmd"));
+            assert.ok(
+                (await parseErrorCount(cmdLine)) > 0,
+                `a cmd-shaped line unexpectedly parsed in PowerShell: ${cmdLine}`
+            );
         });
     });
 });

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -1,0 +1,448 @@
+import assert from "assert";
+import {execFile} from "child_process";
+import {existsSync} from "fs";
+import {promisify} from "util";
+import {
+    clearCmd,
+    commandSeparator,
+    detectShellKind,
+    echoCmd,
+    escapeExecutableForTerminal,
+    escapePathArgument,
+    hasCmdUnsafeChars,
+    readCmd,
+    ShellKind,
+} from "./shellUtils";
+
+const execFileAsync = promisify(execFile);
+
+const ALL_KINDS: ShellKind[] = ["cmd", "powershell", "posix"];
+
+describe(__filename, () => {
+    describe("detectShellKind", () => {
+        const cases: [string, NodeJS.Platform, ShellKind][] = [
+            // Windows cmd, as VS Code reports it.
+            ["C:\\Windows\\System32\\cmd.exe", "win32", "cmd"],
+            // env.shell casing is not guaranteed.
+            ["C:\\Windows\\System32\\CMD.EXE", "win32", "cmd"],
+            ["cmd.exe", "win32", "cmd"],
+            // Windows PowerShell 5 and PowerShell 7+.
+            [
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "win32",
+                "powershell",
+            ],
+            [
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                "win32",
+                "powershell",
+            ],
+            // pwsh is cross-platform, so it is not gated on win32.
+            ["/usr/local/bin/pwsh", "darwin", "powershell"],
+            // Git Bash / WSL style shells on Windows are POSIX, not cmd.
+            ["C:\\Program Files\\Git\\bin\\bash.exe", "win32", "posix"],
+            ["C:\\Windows\\System32\\wsl.exe", "win32", "posix"],
+            ["/bin/bash", "linux", "posix"],
+            ["/bin/zsh", "darwin", "posix"],
+            ["/usr/bin/fish", "linux", "posix"],
+        ];
+
+        cases.forEach(([shell, platform, expected]) => {
+            it(`classifies ${shell} on ${platform} as ${expected}`, () => {
+                assert.strictEqual(detectShellKind(shell, platform), expected);
+            });
+        });
+
+        it("does not treat a path merely containing 'cmd' as cmd.exe", () => {
+            // Regression: a substring match on the full path misclassifies
+            // Cmder's bash, leaving the user with cls/pause in a POSIX shell.
+            assert.strictEqual(
+                detectShellKind(
+                    "C:\\cmder\\vendor\\git-for-windows\\bin\\bash.exe",
+                    "win32"
+                ),
+                "posix"
+            );
+        });
+
+        it("does not treat cmd.exe as cmd on non-Windows platforms", () => {
+            assert.strictEqual(
+                detectShellKind("/usr/bin/cmd", "linux"),
+                "posix"
+            );
+        });
+
+        it("falls back to the platform default when env.shell is empty", () => {
+            // Callers cannot pin shellPath to "", so VS Code launches the
+            // configured default profile. Assuming POSIX on Windows would send a
+            // `printf`/`read _` line to PowerShell.
+            assert.strictEqual(detectShellKind("", "win32"), "powershell");
+            assert.strictEqual(detectShellKind("", "darwin"), "posix");
+            assert.strictEqual(detectShellKind("", "linux"), "posix");
+        });
+
+        it("still treats a named but unrecognised windows shell as posix", () => {
+            // The empty-shell fallback must not swallow this case: bash.exe is a
+            // POSIX shell and is what actually gets launched.
+            assert.strictEqual(
+                detectShellKind(
+                    "C:\\Program Files\\Git\\bin\\bash.exe",
+                    "win32"
+                ),
+                "posix"
+            );
+        });
+    });
+
+    describe("clearCmd", () => {
+        it("returns the clear command for each shell", () => {
+            assert.strictEqual(clearCmd("cmd"), "cls");
+            assert.strictEqual(clearCmd("powershell"), "Clear-Host");
+            assert.strictEqual(clearCmd("posix"), "clear");
+        });
+    });
+
+    describe("readCmd", () => {
+        it("returns the hold-open command for each shell", () => {
+            assert.strictEqual(readCmd("cmd"), "pause");
+            assert.strictEqual(readCmd("powershell"), "Read-Host");
+            // `read` needs a variable name: bare `read` is a syntax error in
+            // dash, which would close the terminal instead of holding it.
+            assert.strictEqual(readCmd("posix"), "read _");
+        });
+    });
+
+    describe("commandSeparator", () => {
+        it("uses & for cmd.exe, which has no ; separator", () => {
+            assert.strictEqual(commandSeparator("cmd"), " & ");
+        });
+
+        it("uses ; for powershell and posix", () => {
+            assert.strictEqual(commandSeparator("powershell"), "; ");
+            assert.strictEqual(commandSeparator("posix"), "; ");
+        });
+    });
+
+    describe("escapePathArgument", () => {
+        it("wraps a plain path in quotes", () => {
+            assert.strictEqual(
+                escapePathArgument("C:\\Users\\me\\project", "cmd"),
+                '"C:\\Users\\me\\project"'
+            );
+            assert.strictEqual(
+                escapePathArgument("/home/me/project", "posix"),
+                "'/home/me/project'"
+            );
+        });
+
+        it("quotes paths containing spaces", () => {
+            assert.strictEqual(
+                escapePathArgument("C:\\Program Files\\db", "powershell"),
+                "'C:\\Program Files\\db'"
+            );
+            assert.strictEqual(
+                escapePathArgument("/Users/me/My Project", "posix"),
+                "'/Users/me/My Project'"
+            );
+        });
+
+        it("never doubles backslashes, which are path separators on Windows", () => {
+            ALL_KINDS.forEach((kind) => {
+                assert.ok(
+                    !escapePathArgument("C:\\a\\b", kind).includes("\\\\"),
+                    `${kind} must not escape backslashes`
+                );
+            });
+        });
+
+        it("doubles embedded quotes for cmd.exe", () => {
+            assert.strictEqual(
+                escapePathArgument('C:\\a"b', "cmd"),
+                '"C:\\a""b"'
+            );
+        });
+
+        it("single-quotes for powershell and doubles embedded quotes", () => {
+            assert.strictEqual(
+                escapePathArgument('C:\\a"b', "powershell"),
+                `'C:\\a"b'`
+            );
+            assert.strictEqual(
+                escapePathArgument("C:\\a'b", "powershell"),
+                "'C:\\a''b'"
+            );
+        });
+
+        it("stops powershell from interpolating $ and running $(...)", () => {
+            // Regression: double-quoted PowerShell strings interpolate, so
+            // "$RECYCLE.BIN" expanded to ".BIN" and "$(whoami)" *executed*.
+            // Single quotes are literal in PowerShell.
+            assert.strictEqual(
+                escapePathArgument("C:\\Users\\me\\$RECYCLE.BIN", "powershell"),
+                "'C:\\Users\\me\\$RECYCLE.BIN'"
+            );
+            assert.strictEqual(
+                escapePathArgument("C:\\a$(whoami)b", "powershell"),
+                "'C:\\a$(whoami)b'"
+            );
+            assert.strictEqual(
+                escapePathArgument("C:\\a`b", "powershell"),
+                "'C:\\a`b'"
+            );
+        });
+
+        it("single-quotes for posix so $ and backticks do not expand", () => {
+            assert.strictEqual(
+                escapePathArgument("/tmp/$HOME/`whoami`", "posix"),
+                "'/tmp/$HOME/`whoami`'"
+            );
+        });
+
+        it("flags % as unrepresentable in cmd.exe rather than corrupting it", () => {
+            // cmd expands %VAR% even inside double quotes and has no escape for
+            // it, so callers must detect and refuse instead of silently passing
+            // the wrong directory to the CLI.
+            assert.ok(hasCmdUnsafeChars("C:\\p%TEMP%q"));
+            assert.ok(!hasCmdUnsafeChars("C:\\Users\\me\\project"));
+        });
+
+        it("escapes every embedded quote, not just the first", () => {
+            // Regression: String.replace (vs replaceAll) left later quotes bare,
+            // which terminates the argument early.
+            assert.strictEqual(escapePathArgument('a"b"c', "cmd"), '"a""b""c"');
+            assert.strictEqual(
+                escapePathArgument("a'b'c", "posix"),
+                `'a'\\''b'\\''c'`
+            );
+        });
+
+        it("handles an empty argument", () => {
+            assert.strictEqual(escapePathArgument("", "cmd"), '""');
+            assert.strictEqual(escapePathArgument("", "posix"), "''");
+        });
+    });
+
+    describe("escapeExecutableForTerminal", () => {
+        it("prefixes the powershell call operator so the path is executed", () => {
+            // Without &, PowerShell echoes a quoted string instead of running it.
+            assert.strictEqual(
+                escapeExecutableForTerminal(
+                    "C:\\Program Files\\db.exe",
+                    "powershell"
+                ),
+                "& 'C:\\Program Files\\db.exe'"
+            );
+        });
+
+        it("only quotes for cmd and posix", () => {
+            assert.strictEqual(
+                escapeExecutableForTerminal("C:\\bin\\db.exe", "cmd"),
+                '"C:\\bin\\db.exe"'
+            );
+            assert.strictEqual(
+                escapeExecutableForTerminal("/usr/bin/db", "posix"),
+                "'/usr/bin/db'"
+            );
+        });
+
+        it("escapes quotes in the executable path", () => {
+            assert.strictEqual(
+                escapeExecutableForTerminal('/usr/bin/we"ird', "posix"),
+                `'/usr/bin/we"ird'`
+            );
+        });
+    });
+
+    describe("echoCmd", () => {
+        it("prints a single line", () => {
+            assert.strictEqual(
+                echoCmd("hello", "posix"),
+                `printf '%s\\n' 'hello'`
+            );
+            assert.strictEqual(echoCmd("hello", "cmd"), "echo hello");
+            assert.strictEqual(
+                echoCmd("hello", "powershell"),
+                "Write-Host 'hello'"
+            );
+        });
+
+        it("uses printf on posix, not echo, so backslashes stay literal", () => {
+            // Regression: zsh's and dash's builtin echo interpret \t and \c even
+            // inside single quotes, so `echo` mangled paths and `\c` truncated
+            // the line outright. Proven against real shells further down.
+            assert.strictEqual(
+                echoCmd("dir: /tmp/my\\test", "posix"),
+                `printf '%s\\n' 'dir: /tmp/my\\test'`
+            );
+        });
+
+        it("splits multiline messages into one command per line", () => {
+            // cmd.exe's echo cannot emit a newline, so each line needs its own
+            // echo joined by the separator.
+            assert.strictEqual(
+                echoCmd("one\ntwo", "cmd"),
+                "echo one & echo two"
+            );
+            assert.strictEqual(
+                echoCmd("one\ntwo", "posix"),
+                `printf '%s\\n' 'one'; printf '%s\\n' 'two'`
+            );
+            assert.strictEqual(
+                echoCmd("one\ntwo", "powershell"),
+                "Write-Host 'one'; Write-Host 'two'"
+            );
+        });
+
+        it("handles CRLF line endings", () => {
+            assert.strictEqual(
+                echoCmd("one\r\ntwo", "posix"),
+                `printf '%s\\n' 'one'; printf '%s\\n' 'two'`
+            );
+        });
+
+        it("emits a blank line without swallowing it", () => {
+            // Bare `echo` in cmd.exe prints the echo state, not a blank line.
+            assert.strictEqual(echoCmd("", "cmd"), "echo.");
+            assert.strictEqual(echoCmd("a\n", "cmd"), "echo a & echo.");
+            assert.strictEqual(echoCmd("", "posix"), `printf '%s\\n' ''`);
+        });
+
+        it("escapes cmd.exe metacharacters so the chain is not broken", () => {
+            // Unescaped, `echo a & b` would run b as a command, and `>` would
+            // redirect the message into a file.
+            assert.strictEqual(echoCmd("a & b", "cmd"), "echo a ^& b");
+            assert.strictEqual(echoCmd("a > f | g", "cmd"), "echo a ^> f ^| g");
+            assert.strictEqual(echoCmd('say "hi"', "cmd"), 'echo say ^"hi^"');
+        });
+
+        it("neutralises a quote in the message for every shell", () => {
+            // cmd escapes it with ^; PowerShell and POSIX single quotes make it
+            // literal already. The round-trip tests below prove the POSIX case
+            // actually survives a real shell.
+            assert.strictEqual(echoCmd('a"b', "cmd"), 'echo a^"b');
+            assert.strictEqual(
+                echoCmd('a"b', "powershell"),
+                `Write-Host 'a"b'`
+            );
+            assert.strictEqual(echoCmd('a"b', "posix"), `printf '%s\\n' 'a"b'`);
+        });
+
+        it("does not let a message interpolate in powershell", () => {
+            assert.strictEqual(
+                echoCmd("cost is $100 $(whoami)", "powershell"),
+                "Write-Host 'cost is $100 $(whoami)'"
+            );
+        });
+
+        it("keeps a single quote from terminating the posix argument", () => {
+            assert.strictEqual(
+                echoCmd("it's", "posix"),
+                `printf '%s\\n' 'it'\\''s'`
+            );
+        });
+    });
+
+    // The assertions above only prove we produce the string we intended. These
+    // run the generated command through a real shell to prove the shell agrees.
+    // Gated on platform: /bin/sh is only guaranteed on POSIX hosts, and CI runs
+    // Linux and macOS.
+    describe("round-trip against a real shell", () => {
+        const canRunPosix = process.platform !== "win32";
+
+        // sh is usually dash, zsh is the macOS default, and bash is what most
+        // Linux users get. Their builtin `echo` and `read` differ, so each shell
+        // has to be checked rather than assumed equivalent.
+        const shells = ["/bin/sh", "/bin/zsh", "/bin/bash"];
+
+        async function run(shell: string, command: string): Promise<string> {
+            const {stdout} = await execFileAsync(shell, ["-c", command]);
+            return stdout;
+        }
+
+        const messages = [
+            "plain message",
+            'has "double quotes"',
+            "has 'single quotes'",
+            "has $HOME and `backticks`",
+            "has & ampersand | pipe > gt < lt",
+            "has \\ backslash",
+            // \t and \c are the cases a builtin echo would mangle: a tab, and
+            // "stop output" which truncated the whole line.
+            "tab-ish /tmp/my\\test",
+            "truncating /tmp/a\\class",
+            "percent %s %d literal",
+            "multi\nline\nmessage",
+        ];
+
+        shells.forEach((shell) => {
+            messages.forEach((message) => {
+                it(`prints ${JSON.stringify(
+                    message
+                )} verbatim in ${shell}`, async function () {
+                    if (!canRunPosix || !existsSync(shell)) {
+                        this.skip();
+                    }
+                    const stdout = await run(shell, echoCmd(message, "posix"));
+                    assert.strictEqual(stdout, `${message}\n`);
+                });
+            });
+        });
+
+        const paths = [
+            "/tmp/plain",
+            "/tmp/with space",
+            "/tmp/with'quote",
+            '/tmp/with"dquote',
+            "/tmp/with$var",
+            "/tmp/with`tick`",
+            "/tmp/with\\backslash",
+            "/tmp/with$(whoami)subshell",
+        ];
+
+        shells.forEach((shell) => {
+            paths.forEach((p) => {
+                it(`passes ${JSON.stringify(
+                    p
+                )} as one argument in ${shell}`, async function () {
+                    if (!canRunPosix || !existsSync(shell)) {
+                        this.skip();
+                    }
+                    // printf %s\n prints each argument on its own line, so a path
+                    // that got split shows up as more than one line.
+                    const stdout = await run(
+                        shell,
+                        `printf '%s\\n' ${escapePathArgument(p, "posix")}`
+                    );
+                    assert.strictEqual(stdout, `${p}\n`);
+                });
+            });
+        });
+
+        // dash is the strictest of the bunch and the one that rejected bare
+        // `read`; it is the default /bin/sh on Debian/Ubuntu but is not always
+        // installed on macOS, so it is probed separately from `shells`.
+        [...shells, "/bin/dash"].forEach((shell) => {
+            it(`readCmd is accepted by ${shell}`, async function () {
+                if (!canRunPosix || !existsSync(shell)) {
+                    this.skip();
+                }
+                // Regression: bare `read` is a usage error in dash ("arg count",
+                // exit 2), so the hold-open step failed and the following `exit`
+                // closed the terminal, hiding the CLI error it exists to keep
+                // readable. Reading from /dev/null hits EOF immediately, so a
+                // non-zero exit is expected; what matters is that the shell does
+                // not complain about the syntax.
+                const {stderr} = await execFileAsync(
+                    shell,
+                    ["-c", `${readCmd("posix")} < /dev/null`]
+                    // A non-zero exit from EOF would reject the promise.
+                ).catch((e: {stderr: string}) => e);
+                assert.strictEqual(
+                    stderr,
+                    "",
+                    `${shell} rejected ${readCmd("posix")}`
+                );
+            });
+        });
+    });
+});

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -1,4 +1,8 @@
 import {env} from "vscode";
+import {
+    TerminalProfileConfig,
+    workspaceConfigs,
+} from "../vscode-objs/WorkspaceConfigs";
 
 /**
  * The shell families we generate terminal command strings for. Quoting and
@@ -58,15 +62,144 @@ export function detectShellKind(
 }
 
 /**
+ * The shell path a pinned-`shellPath`-less terminal will actually be launched
+ * with: `env.shell` when VS Code reports one, otherwise the configured default
+ * profile's path, otherwise `ComSpec`.
+ *
+ * When `env.shell` is empty the callers pass `shellPath: undefined`, so VS Code
+ * launches `terminal.integrated.defaultProfile` — which may well be cmd.exe or
+ * Git Bash, not the PowerShell that a bare platform-default guess assumes. When
+ * the guess and the launched shell disagree it is #1822 with the shells swapped:
+ * the line fails to parse, so nothing runs — not even the trailing `exit` — and
+ * a caller awaiting the terminal-close event hangs until the user closes the tab
+ * by hand. Reading the configured profile makes the two agree by construction.
+ *
+ * Pure so the precedence can be tested without VS Code.
+ */
+export function effectiveShellPath(
+    envShell: string,
+    defaultProfileName: string | undefined,
+    profiles: Record<string, TerminalProfileConfig | null> | undefined,
+    comSpec: string | undefined
+): string {
+    if (envShell !== "") {
+        return envShell;
+    }
+    const profile = defaultProfileName
+        ? profiles?.[defaultProfileName]
+        : undefined;
+    const profilePath = Array.isArray(profile?.path)
+        ? profile?.path[0]
+        : profile?.path;
+    return profilePath ?? comSpec ?? "";
+}
+
+/**
  * The shell kind of the integrated terminal. This is the only seam that reads
  * VS Code state; everything else takes a {@link ShellKind}, so callers should
  * resolve this once and thread the result through.
  *
- * `env.shell` is the empty string in environments that do not support a shell, in
- * which case the platform default is assumed — see {@link detectShellKind}.
+ * `env.shell` is the empty string in environments that do not support a shell;
+ * see {@link effectiveShellPath} for what is consulted instead.
  */
 export function currentShellKind(): ShellKind {
-    return detectShellKind(env.shell ?? "", process.platform);
+    return detectShellKind(
+        effectiveShellPath(
+            env.shell ?? "",
+            workspaceConfigs.terminalDefaultProfileName,
+            workspaceConfigs.terminalProfiles,
+            process.env.ComSpec
+        ),
+        process.platform
+    );
+}
+
+/**
+ * The shell kind of a terminal we did not create, classified from the
+ * `shellPath` it was actually launched with rather than from `env.shell`.
+ *
+ * `env.shell` is only the *default* profile's path, so using it for a reused
+ * terminal reintroduces #1822 with the shells swapped: a Windows user whose
+ * default profile is Git Bash but whose focused tab is cmd.exe would get
+ * POSIX single quotes, which cmd does not treat as quoting at all.
+ *
+ * `shellPath` is undefined when the terminal inherited the default profile
+ * (which is what `env.shell` reports) and for extension-owned pseudoterminals,
+ * which have no shell at all; both fall back to {@link currentShellKind}.
+ *
+ * `platform` is a parameter so the cmd.exe case is testable on any host OS.
+ */
+export function terminalShellKind(
+    terminal: {creationOptions: Readonly<{shellPath?: string} | object>},
+    platform: NodeJS.Platform = process.platform
+): ShellKind {
+    // ExtensionTerminalOptions (a pseudoterminal) has no shellPath at all, so
+    // the property is read off the union rather than destructured.
+    const shellPath =
+        "shellPath" in terminal.creationOptions
+            ? terminal.creationOptions.shellPath
+            : undefined;
+    return typeof shellPath !== "string" || shellPath === ""
+        ? currentShellKind()
+        : detectShellKind(shellPath, platform);
+}
+
+/**
+ * The `args` of the configured default terminal profile whose path matches
+ * `shell`, or undefined when there are none to forward.
+ *
+ * `env.shell` reports the default profile's *path* only, so pinning just the
+ * path silently drops its args. VS Code does not fill them back in: passing an
+ * explicit `executable` makes it build a fresh profile from
+ * `{path, args: shellLaunchConfig.args}`, and `args` being undefined stays
+ * undefined. A profile of `{path: "wsl.exe", args: ["-d", "Ubuntu-22.04"]}`
+ * would therefore launch the *default* distro.
+ *
+ * Kept pure so the lookup can be tested without VS Code; the settings read
+ * lives in {@link defaultProfileShellArgs}.
+ */
+export function resolveProfileShellArgs(
+    shell: string,
+    defaultProfileName: string | undefined,
+    profiles: Record<string, TerminalProfileConfig | null> | undefined
+): string[] | string | undefined {
+    if (!defaultProfileName || !profiles) {
+        return undefined;
+    }
+    const profile = profiles[defaultProfileName];
+    if (!profile || profile.args === undefined) {
+        return undefined;
+    }
+    // Only forward args we are sure belong to the shell we are pinning. A
+    // renamed or `source`-based profile can point at a different executable
+    // than env.shell reports, and passing another shell's args is worse than
+    // passing none.
+    const paths = Array.isArray(profile.path)
+        ? profile.path
+        : profile.path === undefined
+          ? []
+          : [profile.path];
+    const matches = paths.some(
+        (p) => p.toLowerCase() === shell.toLowerCase() || sameBasename(p, shell)
+    );
+    return matches ? profile.args : undefined;
+}
+
+function sameBasename(a: string, b: string): boolean {
+    return shellBasename(a) !== "" && shellBasename(a) === shellBasename(b);
+}
+
+/**
+ * The args of the user's configured default terminal profile, to pass alongside
+ * `shellPath` when pinning a terminal's shell. See
+ * {@link resolveProfileShellArgs} for why forwarding these matters.
+ */
+export function defaultProfileShellArgs(): string[] | string | undefined {
+    return resolveProfileShellArgs(
+        env.shell ?? "",
+        workspaceConfigs.terminalDefaultProfileName,
+        workspaceConfigs.terminalProfiles
+    );
 }
 
 /** Command that clears the terminal scrollback. */
@@ -163,9 +296,13 @@ export function escapePathArgument(
  * a path such as `C:\p%TEMP%q` cannot be passed through faithfully. Callers that
  * must not silently corrupt a user-chosen path should check this and surface an
  * error rather than generating a command that does the wrong thing.
+ *
+ * `!` is included because under delayed expansion (`cmd /V:ON`, or
+ * `DelayedExpansion` enabled in the registry — not the default, but present on
+ * some corporate images) `!VAR!` also expands inside double quotes.
  */
 export function hasCmdUnsafeChars(arg: string): boolean {
-    return arg.includes("%");
+    return /[%!]/.test(arg);
 }
 
 /**

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -30,11 +30,12 @@ function shellBasename(shellPath: string): string {
  * Matches on the basename, not a substring of the whole path: a path such as
  * `C:\cmder\vendor\git\bin\bash.exe` contains "cmd" but is a POSIX shell.
  *
- * An *empty* shell falls back to the platform default rather than to POSIX:
- * callers cannot pin `shellPath` to `""`, so VS Code launches
- * `terminal.integrated.defaultProfile`, which on Windows is PowerShell. A shell
- * that is named but unrecognised still resolves to POSIX — `bash.exe` on Windows
- * is a POSIX shell, and it is what actually gets launched.
+ * An *empty* shell falls back to the platform default rather than to POSIX,
+ * since VS Code then launches `terminal.integrated.defaultProfile`, which on
+ * Windows is PowerShell. This is the last resort: prefer
+ * {@link resolveTerminalShell}, which consults the configured profile first. A
+ * shell that is named but unrecognised still resolves to POSIX — `bash.exe` on
+ * Windows is a POSIX shell, and it is what actually gets launched.
  */
 export function detectShellKind(
     shell: string,
@@ -62,56 +63,139 @@ export function detectShellKind(
 }
 
 /**
- * The shell path a pinned-`shellPath`-less terminal will actually be launched
- * with: `env.shell` when VS Code reports one, otherwise the configured default
- * profile's path, otherwise `ComSpec`.
+ * Shell family implied by a profile's `source`. VS Code's own default Windows
+ * profiles are written this way — `{"PowerShell": {"source": "PowerShell"}}`,
+ * `{"Git Bash": {"source": "Git Bash"}}` — so a resolver that only looks at
+ * `path` sees nothing at all for the most common configurations.
  *
- * When `env.shell` is empty the callers pass `shellPath: undefined`, so VS Code
- * launches `terminal.integrated.defaultProfile` — which may well be cmd.exe or
- * Git Bash, not the PowerShell that a bare platform-default guess assumes. When
- * the guess and the launched shell disagree it is #1822 with the shells swapped:
- * the line fails to parse, so nothing runs — not even the trailing `exit` — and
- * a caller awaiting the terminal-close event hangs until the user closes the tab
- * by hand. Reading the configured profile makes the two agree by construction.
- *
- * Pure so the precedence can be tested without VS Code.
+ * A `source` names a *detector*, not an executable: there is no path to
+ * classify, and no way to know the args VS Code will launch it with. It is
+ * therefore enough to pick the kind, and never enough to pin the shell.
  */
-export function effectiveShellPath(
-    envShell: string,
-    defaultProfileName: string | undefined,
-    profiles: Record<string, TerminalProfileConfig | null> | undefined,
-    comSpec: string | undefined
-): string {
-    if (envShell !== "") {
-        return envShell;
+function shellKindFromSource(source: string): ShellKind | undefined {
+    switch (source.toLowerCase()) {
+        case "powershell":
+        case "pwsh":
+            return "powershell";
+        case "git bash":
+            return "posix";
+        default:
+            return undefined;
     }
-    const profile = defaultProfileName
-        ? profiles?.[defaultProfileName]
-        : undefined;
-    const profilePath = Array.isArray(profile?.path)
-        ? profile?.path[0]
-        : profile?.path;
-    return profilePath ?? comSpec ?? "";
+}
+
+/** Every path a profile may launch, in the order VS Code tries them. */
+function profilePaths(profile: TerminalProfileConfig | null | undefined) {
+    if (!profile?.path) {
+        return [];
+    }
+    return Array.isArray(profile.path) ? profile.path : [profile.path];
+}
+
+function sameShellPath(a: string, b: string): boolean {
+    return a.toLowerCase() === b.toLowerCase() || sameBasename(a, b);
 }
 
 /**
- * The shell kind of the integrated terminal. This is the only seam that reads
- * VS Code state; everything else takes a {@link ShellKind}, so callers should
- * resolve this once and thread the result through.
+ * How to launch a terminal, and the shell family whose syntax its command line
+ * must be written in.
  *
- * `env.shell` is the empty string in environments that do not support a shell;
- * see {@link effectiveShellPath} for what is consulted instead.
+ * The two are returned together because they are one decision: a command
+ * generated for a different shell than the terminal runs is #1822, and keeping
+ * the kind beside the launch options makes it impossible for a caller to take
+ * one without the other.
  */
-export function currentShellKind(): ShellKind {
-    return detectShellKind(
-        effectiveShellPath(
-            env.shell ?? "",
-            workspaceConfigs.terminalDefaultProfileName,
-            workspaceConfigs.terminalProfiles,
-            process.env.ComSpec
-        ),
+export type TerminalShell = {
+    /** Shell family to generate the command string for. */
+    kind: ShellKind;
+    /**
+     * `shellPath` for `createTerminal`, or undefined to let VS Code launch the
+     * configured default profile itself.
+     */
+    shellPath?: string;
+    /** `shellArgs` for `createTerminal`; only ever set alongside `shellPath`. */
+    shellArgs?: string[] | string;
+};
+
+/**
+ * Resolve which shell a terminal we create will run, and how to launch it.
+ *
+ * Pinning `shellPath` keeps the shell that parses the command line identical to
+ * the one it was generated for, but VS Code only accepts a path — so pinning a
+ * profile we cannot fully describe *drops its args*. A profile of
+ * `{path: "wsl.exe", args: ["-d", "Ubuntu-22.04"]}` would land in the default
+ * distro, and Git Bash — configured by `source`, whose args we cannot see —
+ * would launch non-login, with a different `PATH` than every other terminal the
+ * user opens. So the shell is pinned only when the configured profile
+ * demonstrably describes the same executable `env.shell` reports, which is the
+ * one case where its args are known to belong to it. Otherwise the launch is
+ * left to VS Code, which already knows how to start its own profiles.
+ *
+ * Not pinning costs nothing in correctness: `env.shell` *is* the resolved path
+ * of the default profile, so it still classifies the shell VS Code will launch.
+ *
+ * `ComSpec` is deliberately not consulted. On Windows it is always
+ * `cmd.exe` — it describes what the OS would run, never what VS Code will — so
+ * using it as a fallback would classify every shell-less Windows environment as
+ * cmd while PowerShell actually starts. That mismatch is #1822 with the shells
+ * swapped: a cmd-shaped line (` & ` separators) does not parse in PowerShell, so
+ * nothing runs, not even the trailing `exit`, and a caller awaiting the
+ * terminal-close event hangs until the user closes the tab by hand.
+ *
+ * Pure, so the precedence can be tested without VS Code.
+ */
+export function resolveTerminalShell(
+    envShell: string,
+    defaultProfileName: string | undefined,
+    profiles: Record<string, TerminalProfileConfig | null> | undefined,
+    platform: NodeJS.Platform
+): TerminalShell {
+    const profile = defaultProfileName
+        ? profiles?.[defaultProfileName]
+        : undefined;
+    const paths = profilePaths(profile);
+
+    if (envShell !== "") {
+        const kind = detectShellKind(envShell, platform);
+        return paths.some((p) => sameShellPath(p, envShell))
+            ? {kind, shellPath: envShell, shellArgs: profile?.args}
+            : {kind};
+    }
+
+    // `env.shell` is empty in environments that do not support a shell. The
+    // configured default profile is then the only record of what VS Code will
+    // launch, and it may well be cmd.exe or Git Bash rather than the PowerShell
+    // a bare platform-default guess assumes.
+    if (paths[0] !== undefined) {
+        return {kind: detectShellKind(paths[0], platform)};
+    }
+    const fromSource = profile?.source
+        ? shellKindFromSource(profile.source)
+        : undefined;
+    return {kind: fromSource ?? detectShellKind("", platform)};
+}
+
+/**
+ * {@link resolveTerminalShell} for the running window. This and
+ * {@link terminalShellKind} are the only seams that read VS Code state;
+ * everything else takes a {@link ShellKind}, so callers should resolve this once
+ * and thread the result through.
+ */
+export function currentTerminalShell(): TerminalShell {
+    return resolveTerminalShell(
+        env.shell ?? "",
+        workspaceConfigs.terminalDefaultProfileName,
+        workspaceConfigs.terminalProfiles,
         process.platform
     );
+}
+
+/**
+ * The shell kind of the integrated terminal, for callers that only generate a
+ * command string and do not create the terminal themselves.
+ */
+export function currentShellKind(): ShellKind {
+    return currentTerminalShell().kind;
 }
 
 /**
@@ -144,62 +228,8 @@ export function terminalShellKind(
         : detectShellKind(shellPath, platform);
 }
 
-/**
- * The `args` of the configured default terminal profile whose path matches
- * `shell`, or undefined when there are none to forward.
- *
- * `env.shell` reports the default profile's *path* only, so pinning just the
- * path silently drops its args. VS Code does not fill them back in: passing an
- * explicit `executable` makes it build a fresh profile from
- * `{path, args: shellLaunchConfig.args}`, and `args` being undefined stays
- * undefined. A profile of `{path: "wsl.exe", args: ["-d", "Ubuntu-22.04"]}`
- * would therefore launch the *default* distro.
- *
- * Kept pure so the lookup can be tested without VS Code; the settings read
- * lives in {@link defaultProfileShellArgs}.
- */
-export function resolveProfileShellArgs(
-    shell: string,
-    defaultProfileName: string | undefined,
-    profiles: Record<string, TerminalProfileConfig | null> | undefined
-): string[] | string | undefined {
-    if (!defaultProfileName || !profiles) {
-        return undefined;
-    }
-    const profile = profiles[defaultProfileName];
-    if (!profile || profile.args === undefined) {
-        return undefined;
-    }
-    // Only forward args we are sure belong to the shell we are pinning. A
-    // renamed or `source`-based profile can point at a different executable
-    // than env.shell reports, and passing another shell's args is worse than
-    // passing none.
-    const paths = Array.isArray(profile.path)
-        ? profile.path
-        : profile.path === undefined
-          ? []
-          : [profile.path];
-    const matches = paths.some(
-        (p) => p.toLowerCase() === shell.toLowerCase() || sameBasename(p, shell)
-    );
-    return matches ? profile.args : undefined;
-}
-
 function sameBasename(a: string, b: string): boolean {
     return shellBasename(a) !== "" && shellBasename(a) === shellBasename(b);
-}
-
-/**
- * The args of the user's configured default terminal profile, to pass alongside
- * `shellPath` when pinning a terminal's shell. See
- * {@link resolveProfileShellArgs} for why forwarding these matters.
- */
-export function defaultProfileShellArgs(): string[] | string | undefined {
-    return resolveProfileShellArgs(
-        env.shell ?? "",
-        workspaceConfigs.terminalDefaultProfileName,
-        workspaceConfigs.terminalProfiles
-    );
 }
 
 /** Command that clears the terminal scrollback. */

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -1,23 +1,214 @@
 import {env} from "vscode";
 
-export function isPowershell() {
-    return env.shell.toLowerCase().includes("powershell");
+/**
+ * The shell families we generate terminal command strings for. Quoting and
+ * built-in command names differ between them, so every helper below branches on
+ * this rather than re-inspecting `env.shell`.
+ */
+export type ShellKind = "cmd" | "powershell" | "posix";
+
+/**
+ * Lowercased final path segment of a shell path. Split on both separators
+ * explicitly: `path.basename` follows the *host* platform, so it would not
+ * split a Windows path when the tests (or a remote extension host) run on
+ * POSIX.
+ */
+function shellBasename(shellPath: string): string {
+    return shellPath.toLowerCase().split(/[\\/]/).pop() ?? "";
 }
 
-export function readCmd() {
-    if (isPowershell()) {
-        return "Read-Host";
+/**
+ * Classify a shell from its executable path. `shell` is what VS Code reports as
+ * `env.shell`; `platform` gates `cmd`, which only exists on Windows. Both are
+ * parameters so the classification is deterministic in tests regardless of the
+ * host OS.
+ *
+ * Matches on the basename, not a substring of the whole path: a path such as
+ * `C:\cmder\vendor\git\bin\bash.exe` contains "cmd" but is a POSIX shell.
+ *
+ * An *empty* shell falls back to the platform default rather than to POSIX:
+ * callers cannot pin `shellPath` to `""`, so VS Code launches
+ * `terminal.integrated.defaultProfile`, which on Windows is PowerShell. A shell
+ * that is named but unrecognised still resolves to POSIX — `bash.exe` on Windows
+ * is a POSIX shell, and it is what actually gets launched.
+ */
+export function detectShellKind(
+    shell: string,
+    platform: NodeJS.Platform
+): ShellKind {
+    const base = shellBasename(shell);
+    if (platform === "win32" && (base === "cmd.exe" || base === "cmd")) {
+        return "cmd";
     }
-    return "read";
-}
-
-export function escapeExecutableForTerminal(exe: string): string {
-    if (isPowershell()) {
-        return `& "${exe}"`;
+    // pwsh[.exe] is PowerShell 6+, including PowerShell on macOS and Linux, so
+    // it is deliberately not gated on win32.
+    if (
+        base === "powershell.exe" ||
+        base === "powershell" ||
+        base === "pwsh.exe" ||
+        base === "pwsh"
+    ) {
+        return "powershell";
     }
-    return `"${exe}"`;
+    if (base === "") {
+        // PowerShell has been the default Windows profile since VS Code 1.56.
+        return platform === "win32" ? "powershell" : "posix";
+    }
+    return "posix";
 }
 
-export function escapePathArgument(arg: string): string {
-    return `"${arg.replaceAll('"', '\\"')}"`;
+/**
+ * The shell kind of the integrated terminal. This is the only seam that reads
+ * VS Code state; everything else takes a {@link ShellKind}, so callers should
+ * resolve this once and thread the result through.
+ *
+ * `env.shell` is the empty string in environments that do not support a shell, in
+ * which case the platform default is assumed — see {@link detectShellKind}.
+ */
+export function currentShellKind(): ShellKind {
+    return detectShellKind(env.shell ?? "", process.platform);
+}
+
+/** Command that clears the terminal scrollback. */
+export function clearCmd(kind: ShellKind = currentShellKind()): string {
+    switch (kind) {
+        case "cmd":
+            return "cls";
+        case "powershell":
+            return "Clear-Host";
+        case "posix":
+            return "clear";
+    }
+}
+
+/**
+ * Command that waits for the user before continuing, used to hold a terminal
+ * open so a failing command's output stays readable.
+ *
+ * POSIX `read` needs a variable name: bare `read` is a syntax error in dash
+ * ("read: arg count", exit 2), which would let the following `exit` close the
+ * terminal immediately and discard the output we meant to keep. `read` waits for
+ * a newline rather than a single keypress; `pause` and `Read-Host` differ, but
+ * all three block until the user acts.
+ */
+export function readCmd(kind: ShellKind = currentShellKind()): string {
+    switch (kind) {
+        case "cmd":
+            return "pause";
+        case "powershell":
+            return "Read-Host";
+        case "posix":
+            return "read _";
+    }
+}
+
+/** Separator that chains commands unconditionally (cmd.exe has no `;`). */
+export function commandSeparator(kind: ShellKind = currentShellKind()): string {
+    switch (kind) {
+        case "cmd":
+            return " & ";
+        case "powershell":
+        case "posix":
+            return "; ";
+    }
+}
+
+/**
+ * Quote a path so the shell treats it as a single argument. PowerShell needs the
+ * call operator (`&`) in front of a quoted path, or it echoes the string instead
+ * of executing it.
+ */
+export function escapeExecutableForTerminal(
+    exe: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    const quoted = escapePathArgument(exe, kind);
+    return kind === "powershell" ? `& ${quoted}` : quoted;
+}
+
+/**
+ * Quote a path used as a command argument.
+ *
+ * Backslashes are never doubled: in cmd.exe and PowerShell `\` is a path
+ * separator, not an escape character, so escaping it would corrupt Windows
+ * paths. Each shell instead needs its own quoting:
+ *
+ * - PowerShell and POSIX both get *single* quotes, which are literal: they
+ *   suppress `$` interpolation (and `$(...)`/backtick command substitution)
+ *   rather than just the quote character. An embedded `'` is doubled in
+ *   PowerShell; POSIX has no in-quote escape, so the quote is closed, escaped
+ *   and reopened.
+ * - cmd.exe has only double quotes and no escape at all, so an embedded `"` is
+ *   doubled. Note this cannot protect `%VAR%`, which cmd expands inside double
+ *   quotes — see {@link hasCmdUnsafeChars}.
+ */
+export function escapePathArgument(
+    arg: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    switch (kind) {
+        case "cmd":
+            return `"${arg.replaceAll('"', '""')}"`;
+        case "powershell":
+            return `'${arg.replaceAll("'", "''")}'`;
+        case "posix":
+            return `'${arg.replaceAll("'", `'\\''`)}'`;
+    }
+}
+
+/**
+ * Whether `arg` contains a character cmd.exe expands even inside double quotes.
+ *
+ * cmd has no quoting that makes `%` literal in an interactive command line, so
+ * a path such as `C:\p%TEMP%q` cannot be passed through faithfully. Callers that
+ * must not silently corrupt a user-chosen path should check this and surface an
+ * error rather than generating a command that does the wrong thing.
+ */
+export function hasCmdUnsafeChars(arg: string): boolean {
+    return arg.includes("%");
+}
+
+/**
+ * Render `message` as a command that prints it verbatim, escaping any character
+ * the shell would otherwise interpret.
+ *
+ * Multi-line input is split into one print command per line: cmd.exe's `echo`
+ * emits its arguments literally and has no escape for a newline, so a single
+ * `echo` spanning lines would break the chain.
+ */
+export function echoCmd(
+    message: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    return message
+        .split(/\r?\n/)
+        .map((line) => echoLine(line, kind))
+        .join(commandSeparator(kind));
+}
+
+/**
+ * One command printing `line` literally.
+ *
+ * POSIX uses `printf '%s\n'` rather than `echo`: zsh's and dash's builtin `echo`
+ * interpret backslash escapes even inside single quotes, so a path containing
+ * `\t` would print a tab and one containing `\c` would truncate the output. The
+ * message is a printf *argument*, not the format string, so a literal `%` in it
+ * is safe.
+ *
+ * cmd.exe is the awkward one: inside double quotes it prints the quotes
+ * themselves, so metacharacters are escaped individually with `^` and left
+ * unquoted. A blank line must be exactly `echo.` with no space — bare `echo`
+ * prints the echo state instead, and `echo .` prints a dot.
+ */
+function echoLine(line: string, kind: ShellKind): string {
+    if (kind === "powershell") {
+        return `Write-Host ${escapePathArgument(line, kind)}`;
+    }
+    if (kind === "posix") {
+        return `printf '%s\\n' ${escapePathArgument(line, kind)}`;
+    }
+    if (line === "") {
+        return "echo.";
+    }
+    return `echo ${line.replaceAll(/[\^&|<>()"]/g, (char) => `^${char}`)}`;
 }

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -157,9 +157,9 @@ export const workspaceConfigs = {
     /**
      * Name of the default integrated terminal profile for this platform, and the
      * configured profiles it can name. Needed because `env.shell` reports only
-     * the profile's *path*: pinning a terminal's `shellPath` without its `args`
-     * would drop them, and when `env.shell` is empty the profile is the only
-     * record of which shell VS Code will actually launch. See `shellUtils`.
+     * a *path*: the profile says whether that path carries `args` we would drop
+     * by pinning it, and when `env.shell` is empty it is the only record of
+     * which shell VS Code will actually launch. See `shellUtils`.
      */
     get terminalDefaultProfileName(): string | undefined {
         return (
@@ -183,8 +183,14 @@ export const workspaceConfigs = {
 
 /** The subset of a `terminal.integrated.profiles.*` entry we consume. */
 export type TerminalProfileConfig = {
+    /** Candidate executables, tried in order. Absent for `source` profiles. */
     path?: string | string[];
     args?: string[] | string;
+    /**
+     * A VS Code shell *detector* ("PowerShell", "Git Bash") rather than an
+     * executable — how VS Code's own default Windows profiles are written. It
+     * implies a shell family but no path and no knowable args.
+     */
     source?: string;
 };
 

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -153,6 +153,51 @@ export const workspaceConfigs = {
 
         return new Time(config, TimeUnits.minutes).toMillSeconds().value;
     },
+
+    /**
+     * Name of the default integrated terminal profile for this platform, and the
+     * configured profiles it can name. Needed because `env.shell` reports only
+     * the profile's *path*: pinning a terminal's `shellPath` without its `args`
+     * would drop them, and when `env.shell` is empty the profile is the only
+     * record of which shell VS Code will actually launch. See `shellUtils`.
+     */
+    get terminalDefaultProfileName(): string | undefined {
+        return (
+            workspace
+                .getConfiguration("terminal.integrated")
+                .get<string>(`defaultProfile.${terminalSettingsPlatform()}`) ??
+            undefined
+        );
+    },
+
+    get terminalProfiles():
+        | Record<string, TerminalProfileConfig | null>
+        | undefined {
+        return workspace
+            .getConfiguration("terminal.integrated")
+            .get<Record<string, TerminalProfileConfig | null>>(
+                `profiles.${terminalSettingsPlatform()}`
+            );
+    },
 };
+
+/** The subset of a `terminal.integrated.profiles.*` entry we consume. */
+export type TerminalProfileConfig = {
+    path?: string | string[];
+    args?: string[] | string;
+    source?: string;
+};
+
+/** Platform suffix used by the `terminal.integrated.*` settings. */
+function terminalSettingsPlatform(): string {
+    switch (process.platform) {
+        case "win32":
+            return "windows";
+        case "darwin":
+            return "osx";
+        default:
+            return "linux";
+    }
+}
 
 export type WorkspaceConfigs = typeof workspaceConfigs;


### PR DESCRIPTION
Fixes #1822.

## Why

On Windows with cmd.exe as the terminal shell, "Create a new Databricks project"
was broken. The wizard built one POSIX command line and sent it to whatever shell
the terminal was running, so cmd rejected it token by token and the CLI never
started ([#1822](https://github.com/databricks/databricks-vscode/issues/1822)):

```
C:\...\Temp>clear; echo "Executing: databricks bundle init --output-dir "c:\...\databricks-test"
'clear' is not recognized as an internal or external command,
'Follow' is not recognized as an internal or external command,
'Press' is not recognized as an internal or external command,
```

`clear`, `;` as a separator, and `read` are all POSIX-only. cmd needs `cls`, ` & `
and `pause`.

The root cause is structural, not a missing branch. `shellUtils` read `env.shell`
inside every helper and split only "PowerShell" vs "everything else", using a
substring match on the full path. cmd.exe fell into the POSIX bucket. Because the
branching sat behind a module-level VS Code read, none of it could be reached from
a unit test — so this class of bug had no way to be caught. Fixing only the
`clear`/`read` symptoms would have left the next shell-specific bug just as
invisible, which is why this is a refactor rather than a two-line patch.

## What changed

**One classifier instead of scattered predicates.**
`detectShellKind(shell, platform) -> "cmd" | "powershell" | "posix"` is a pure
function; every helper takes that kind. `env.shell` is now read in exactly one
place, `currentShellKind()`, matching the existing `venvInterpreterPath`
injection pattern in this repo. Detection matches on the shell's **basename**, so
`C:\cmder\...\bash.exe` is no longer mistaken for cmd.

**Terminals pin their shell.** The two terminals we create pass `shellPath`, so
the shell that parses the command is the one it was generated for, instead of
whatever `terminal.integrated.defaultProfile` happens to be. This matters more
now: a cmd-shaped line (` & ` separators) is a *parse* error in PowerShell, so
nothing would run — not even the trailing `exit` — and the wizard would hang
awaiting a terminal-close event.

**Command construction extracted.** `bundleInitCommand.ts` holds the assembled
`databricks bundle init` line, deliberately free of `vscode` imports so it is a
pure function of (cli path, output dir, shell) and can be asserted for all three
shells.

Per file:

| File | Change |
|---|---|
| `utils/shellUtils.ts` | `ShellKind` + `detectShellKind`; all helpers parameterised; per-shell quoting; `clearCmd`/`commandSeparator`/`echoCmd`/`hasCmdUnsafeChars` added |
| `bundle/bundleInitCommand.ts` | New — pure builder for the bundle-init command line |
| `bundle/BundleInitWizard.ts` | Uses the builder; pins `shellPath` |
| `configuration/auth/AzureCliCheck.ts` | Same hardcoded `;`/`echo` problem fixed; pins `shellPath`; quotes `azBinPath` |
| `cli/CliWrapper.ts` | `escapedCliPathFor(kind)`; drops duplicated inline escaping |
| `run/RunCommands.ts` | Resolves the shell kind once and threads it through |

### Bugs found once the logic became testable

Each is a real defect on `main`, not a hypothetical:

- **`pwsh[.exe]` was unhandled** — PowerShell 6+/7, the default on modern
  Windows. It matched neither `"powershell"` nor cmd, so those users got POSIX
  `read`, which does not exist in PowerShell.
- **PowerShell paths were double-quoted, which interpolates.**
  `C:\Users\me\$RECYCLE.BIN` expanded to `C:\Users\me\.BIN`, and a directory
  named `C:\a$(whoami)b` would **execute** `whoami`. Both PowerShell and POSIX
  now use single quotes, which are literal.
- **`escapedCliPath` used `.replace`, not `.replaceAll`** — every quote after the
  first was left unescaped.
- **POSIX used `echo`**, whose builtin form interprets backslash escapes in zsh
  and dash *even inside single quotes*: `\t` printed a tab, and `\c` truncated
  the rest of the line. Now `printf '%s\n'`, which is verbatim everywhere. (The
  message is a printf *argument*, not the format string, so a literal `%` is
  safe.)
- **Bare `read` is a usage error in dash** (`read: arg count`, exit 2). The
  hold-open step failed and the following `exit` closed the terminal, discarding
  exactly the CLI error it exists to keep readable. Now `read _`.
- **`%VAR%` cannot be escaped in cmd** — it expands even inside double quotes.
  Added `hasCmdUnsafeChars` so callers can refuse rather than silently pass the
  wrong directory.
- **Empty `env.shell`** (shell-less environments) now falls back to the platform
  default rather than unconditionally POSIX, since `shellPath` cannot be pinned
  to `""` and Windows would launch PowerShell.

## How this was tested

Manual tests in a windows VM, setting `terminal.integrated.defaultProfile.windows` to "Command Prompt" (default is Powershell).
`yarn test:unit` — **554 passing, 0 failing** (was 505 before this branch), plus
`yarn test:lint` clean. 105 of those cases come from the two new suites.

Three layers, chosen so the weaknesses of each are covered by another:

**1. Table-driven classification.** `detectShellKind` is checked across 11
shell/platform pairs plus explicit regression cases: the cmder false positive,
`cmd` on Linux, `pwsh` on macOS, and the empty-shell fallback per platform.
Because both inputs are parameters, these are deterministic on any host OS — no
`process.platform` patching, and no mocking anywhere in the suite.

**2. Exact command strings.** The full bundle-init line is asserted verbatim for
cmd, PowerShell and POSIX, so a reviewer can read the expected output for each
shell directly in the test.

**3. Round-trip execution against real shells.** String equality only proves the
code built what the author intended — not that the shell agrees. So the generated
commands are executed through `/bin/sh`, `zsh`, `bash` and `dash` (each gated on
`existsSync`), asserting stdout matches the input byte for byte across 10 awkward
messages and 8 awkward paths: embedded quotes of both kinds, `$VAR`, `` `cmd` ``,
`$(cmd)`, `&`/`|`/`>`, backslashes and multi-line input. This layer is what caught
the `echo` and `read` bugs above; the string assertions alone had passed.

**Verifying the tests actually bite.** Since a test that passes either way proves
nothing, I reverted each fix individually in the compiled output and recorded the
failures:

| Fix reverted | Tests failing |
|---|---|
| PowerShell single-quoting | 9 |
| `printf` instead of `echo` | 12 (in `sh`/`zsh` only — `bash` passes, matching the real defect) |
| `read _` instead of `read` | 3 (incl. the `dash` round-trip) |
| `%` guard | 1 |
| empty-shell fallback | 1 |

Every fix has at least one test that fails without it.

## Reviewer notes

- **`escapedCliPath` is retained** alongside the new `escapedCliPathFor(kind)`
  because `SshCommands.ts` still uses it. Behaviour there is unchanged (it
  defaults to `currentShellKind()`), but it is the one remaining place a path
  could be escaped for a different shell than the command it lands in.
- `echoCmd` now splits on **real** newlines. The previous call site passed a
  literal `\n`; if you add a caller, pass an actual newline.

This pull request and its description were written by Isaac, then edited and reviewed by me.

