### PR TITLE
fix(ui): use sentence case for "SSH tunnel" in user-facing strings

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -54,7 +54,7 @@
         "commands": [
             {
                 "command": "databricks.ssh.startTunnel",
-                "title": "Start SSH Tunnel",
+                "title": "Start SSH tunnel",
                 "category": "Databricks",
                 "icon": "$(remote)",
                 "enablement": "!databricks.context.remoteMode"
@@ -729,7 +729,7 @@
             },
             {
                 "view": "sshTunnelView",
-                "contents": "Connect your IDE to a Databricks SSH Tunnel so you can run all Python and SQL workloads using Databricks compute.\n[Start SSH Tunnel](command:databricks.ssh.startTunnel)\nTo learn more about the SSH tunnel [read our docs](https://docs.databricks.com/aws/en/dev-tools/ssh-tunnel)."
+                "contents": "Connect your IDE to a Databricks SSH tunnel so you can run all Python and SQL workloads using Databricks compute.\n[Start SSH tunnel](command:databricks.ssh.startTunnel)\nTo learn more about the SSH tunnel [read our docs](https://docs.databricks.com/aws/en/dev-tools/ssh-tunnel)."
             }
         ],
         "menus": {


### PR DESCRIPTION


## Changes

Change the `databricks.ssh.startTunnel` command title and the sshTunnelView welcome text from "SSH Tunnel" to "SSH tunnel" to follow sentence-case capitalization for UI copy.

## Tests
Manually
