### PR TITLE
docs: add AGENTS.md pointing AI agents at CODE_CONVENTIONS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Code conventions
+
+Read [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md) before you:
+
+- add a file, class, or feature folder under `packages/databricks-vscode/src/`
+- add persisted state, a `databricks.*` setting, or a when-clause flag
+- import or use the Databricks SDK
+- add a telemetry event or register a command
+- add a test, an `index.ts` barrel, or a `.md` inside the source tree
+
+Existing code predates parts of the doc, so surrounding code is not proof of a
+convention — follow the doc for all new code and refactors, and don't treat a legacy
+violation as license to add another.
+
+Formatting is not in scope — Prettier/ESLint own that; run `yarn fix`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Why

`CODE_CONVENTIONS.md` (added in #2043, extended in #2075) is currently invisible to AI coding agents:

- Nothing in the repo references it, and there is no instruction file that any agent loads automatically — so the conventions only apply when a human remembers to paste the link.
- Agents default to imitating neighbouring code. Because parts of `src/` predate the doc, that default quietly propagates the very patterns the doc moved away from.

## What

A root `AGENTS.md` that routes to the existing doc rather than restating it:

- Lists the situations that require reading `CODE_CONVENTIONS.md` — new files/classes/feature folders, persisted state and `databricks.*` settings, SDK usage, telemetry events and command registration, tests, `index.ts` barrels, and markdown inside the source tree.
- States that existing code is not evidence of a convention: new code and refactors follow the doc, and a legacy violation is not a licence to add another.
- Scopes formatting out, since Prettier/ESLint already enforce it via `yarn fix`.

Deliberately kept as triggers, not rules. Each bullet is a recognisable *action*, so an agent can tell the trigger fired without having read the doc first — while the rules themselves stay in one place and cannot drift out of sync.

`CLAUDE.md` is a symlink to `AGENTS.md` (git mode `120000`), so Claude Code, Codex, and Cursor all load the same file with nothing to keep in sync. All developers on this repo are on macOS, so symlink support is not a concern; Windows CI checks the file out but nothing in the build reads it.

Unrelated to the closed #2037 — that PR proposed a *new layered convention*, which was set aside. This adds no conventions of its own and only points at the doc that superseded it.

## Verification

- `git ls-files -s CLAUDE.md` reports mode `120000`, confirming git stores a symlink rather than a copy of the text.
- `npx prettier --check AGENTS.md` passes.
- Verified neither path is gitignored, and that `CODE_CONVENTIONS.md` is tracked on `main`.
- Docs-only: no source, build, or test files touched.

This pull request and its description were written by Isaac.