### PR TITLE
fix(python-setup): pass workspace auth to the setup-local CLI

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -347,6 +347,29 @@ token = dapitest5678
             throw e;
         }
     });
+
+    it("should forward auth to the setup-local env vars", async () => {
+        const logFilePath = getTempLogFilePath();
+        const cli = createCliWrapper(logFilePath);
+        const authProvider = new ProfileAuthProvider(
+            new URL("https://test.com"),
+            "PROFILE",
+            cli,
+            true
+        );
+
+        const env = cli.getSetupLocalEnvVars(authProvider);
+
+        // The two vars this exists for: the CLI resolves auth itself, so the
+        // profile and host must arrive via the environment.
+        assert.equal(env.DATABRICKS_CONFIG_PROFILE, "PROFILE");
+        assert.equal(env.DATABRICKS_HOST, "https://test.com/");
+        // Inherited from getEnvVarsForCli and left alone: it agrees with the
+        // explicit `--output json` on the argv that the result parser needs.
+        // The bundle-init/ssh-connect flows override this to "text" because they
+        // render CLI output to a terminal; this flow must not.
+        assert.equal(env.DATABRICKS_OUTPUT_FORMAT, "json");
+    });
 });
 
 describe("waitForProcess", () => {

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -358,7 +358,7 @@ token = dapitest5678
             true
         );
 
-        const env = cli.getSetupLocalEnvVars(authProvider);
+        const env = cli.getSetupLocalEnvVars(authProvider, "dev");
 
         // The two vars this exists for: the CLI resolves auth itself, so the
         // profile and host must arrive via the environment.
@@ -369,6 +369,36 @@ token = dapitest5678
         // The bundle-init/ssh-connect flows override this to "text" because they
         // render CLI output to a terminal; this flow must not.
         assert.equal(env.DATABRICKS_OUTPUT_FORMAT, "json");
+    });
+
+    it("should pin the bundle target alongside the profile for setup-local", async () => {
+        const logFilePath = getTempLogFilePath();
+        const cli = createCliWrapper(logFilePath);
+        const authProvider = new ProfileAuthProvider(
+            new URL("https://test.com"),
+            "PROFILE",
+            cli,
+            true
+        );
+
+        // Without a --profile flag the CLI loads the bundle and picks its
+        // *default* target, then rejects the run when that target's host
+        // disagrees with the injected profile's host. The target must travel
+        // with the profile so the two always refer to the same workspace.
+        assert.equal(
+            cli.getSetupLocalEnvVars(authProvider, "prod")
+                .DATABRICKS_BUNDLE_TARGET,
+            "prod"
+        );
+
+        // No target selected yet: omit the var rather than pass an empty
+        // string, which the CLI would treat as an explicit (invalid) target.
+        assert.ok(
+            !(
+                "DATABRICKS_BUNDLE_TARGET" in
+                cli.getSetupLocalEnvVars(authProvider, undefined)
+            )
+        );
     });
 });
 

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -624,6 +624,39 @@ export class CliWrapper {
         });
     }
 
+    /**
+     * Env vars for `environments setup-local` (the uv-native Python environment
+     * setup).
+     *
+     * Auth is forwarded the same way as the bundle-init and ssh-connect flows,
+     * so the command provisions against the workspace the extension is actually
+     * connected to: `authProvider.toEnv()` carries the host and profile, and
+     * `getEnvVarsForCli` carries `DATABRICKS_CONFIG_FILE` for users who have
+     * relocated their `.databrickscfg`. Without them the CLI's
+     * `MustWorkspaceClient` falls back to its own default-profile resolution.
+     *
+     * Like the sibling methods this returns only the Databricks vars; the caller
+     * overlays them onto the ambient environment, because `setup-local` shells
+     * out to `uv` and needs the real OS environment (platform paths, `UV_*`
+     * vars) as its base.
+     *
+     * Unlike those two this keeps `getEnvVarsForCli`'s `DATABRICKS_OUTPUT_FORMAT
+     * = json` rather than overriding it to "text": they render CLI output into a
+     * terminal for a human, whereas this run's stdout is parsed as the single
+     * JSON result object (the argv also passes `--output json` explicitly).
+     */
+    getSetupLocalEnvVars(authProvider: AuthProvider) {
+        return removeUndefinedKeys({
+            ...EnvVarGenerators.getEnvVarsForCli(
+                this.extensionContext,
+                workspaceConfigs.databrickscfgLocation
+            ),
+            ...EnvVarGenerators.getProxyEnvVars(),
+            ...this.getLogginEnvVars(),
+            ...authProvider.toEnv(),
+        });
+    }
+
     async bundleInit(
         templateDirPath: string,
         outputDirPath: string,

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -644,8 +644,17 @@ export class CliWrapper {
      * = json` rather than overriding it to "text": they render CLI output into a
      * terminal for a human, whereas this run's stdout is parsed as the single
      * JSON result object (the argv also passes `--output json` explicitly).
+     *
+     * `DATABRICKS_BUNDLE_TARGET` must accompany the profile. `setup-local` runs
+     * `MustWorkspaceClient` without a `--profile` flag, so the CLI does not skip
+     * loading the bundle and selects its *default* target; the profile we inject
+     * then reaches `Workspace.Client`, which rejects the run outright when that
+     * target's host disagrees with the profile's host ("the host in the profile
+     * doesn't match the host configured in the bundle"). Naming the target we
+     * are actually connected to keeps the two in agreement. `dbconnect` forwards
+     * this var for the same reason (see `getCommonDatabricksEnvVars`).
      */
-    getSetupLocalEnvVars(authProvider: AuthProvider) {
+    getSetupLocalEnvVars(authProvider: AuthProvider, target?: string) {
         return removeUndefinedKeys({
             ...EnvVarGenerators.getEnvVarsForCli(
                 this.extensionContext,
@@ -654,6 +663,8 @@ export class CliWrapper {
             ...EnvVarGenerators.getProxyEnvVars(),
             ...this.getLogginEnvVars(),
             ...authProvider.toEnv(),
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            DATABRICKS_BUNDLE_TARGET: target,
         });
     }
 

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -837,7 +837,7 @@ export async function activate(
             }
             return {
                 ...process.env,
-                ...cli.getSetupLocalEnvVars(authProvider),
+                ...cli.getSetupLocalEnvVars(authProvider, configModel.target),
             };
         }
     );

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -814,11 +814,32 @@ export async function activate(
                 await pythonExtensionWrapper.pythonEnvironment
             )
     );
-    const pythonSetupClient = new PythonSetupCliClient(() =>
-        resolveCliPath({
-            override: workspaceConfigs.pythonSetupCliPathOverride,
-            bundled: cli.cliPath,
-        })
+    const pythonSetupClient = new PythonSetupCliClient(
+        () =>
+            resolveCliPath({
+                override: workspaceConfigs.pythonSetupCliPathOverride,
+                bundled: cli.cliPath,
+            }),
+        () => {
+            // Overlay the extension's workspace auth onto the ambient
+            // environment, so the CLI provisions against the workspace we are
+            // connected to instead of resolving its own default profile. The
+            // ambient env is the base because `setup-local` shells out to `uv`,
+            // which needs the real OS environment; the Databricks vars are
+            // applied last so a stale ambient DATABRICKS_CONFIG_PROFILE cannot
+            // redirect the run.
+            const authProvider = configModel.authProvider;
+            if (authProvider === undefined) {
+                // Not connected: the setup command is unreachable in this state
+                // (the config view only renders it once logged in), but fall
+                // back to the ambient env rather than throwing out of a spawn.
+                return process.env;
+            }
+            return {
+                ...process.env,
+                ...cli.getSetupLocalEnvVars(authProvider),
+            };
+        }
     );
     // Created lazily on first setup output so a non-opted-in user never gets an
     // empty "Databricks Python Environment Setup" entry in the Output dropdown

--- a/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
+++ b/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
@@ -30,6 +30,7 @@ function fakeSpawn(script: {
         cwd: string,
         detached: boolean
     ) => void;
+    captureEnv?: (env: NodeJS.ProcessEnv) => void;
 }): SpawnFn {
     const toChunks = (v?: string | Buffer[]): Buffer[] => {
         if (v === undefined) {
@@ -39,6 +40,7 @@ function fakeSpawn(script: {
     };
     return (cmd, args, opts) => {
         script.captureArgs?.(cmd, args, opts.cwd, opts.detached);
+        script.captureEnv?.(opts.env);
         const child: any = new EventEmitter();
         child.stdout = new EventEmitter();
         child.stderr = new EventEmitter();
@@ -69,6 +71,7 @@ describe("PythonSetupCliClient", () => {
     it("parses the JSON result from stdout on success", async () => {
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({stdout: JSON.stringify(SUCCESS_DEFAULT), code: 0})
         );
         const result = await client.run(inv, {cwd: "/proj"});
@@ -79,6 +82,7 @@ describe("PythonSetupCliClient", () => {
     it("returns the parsed failure result on a non-zero exit with JSON", async () => {
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({stdout: JSON.stringify(ERROR_NO_TARGET), code: 1})
         );
         const result = await client.run(inv, {cwd: "/proj"});
@@ -92,6 +96,7 @@ describe("PythonSetupCliClient", () => {
         let seenCwd = "";
         const client = new PythonSetupCliClient(
             () => "/custom/databricks",
+            () => ({}),
             fakeSpawn({
                 stdout: JSON.stringify(SUCCESS_DEFAULT),
                 captureArgs: (c, a, cwd) => {
@@ -113,10 +118,62 @@ describe("PythonSetupCliClient", () => {
         expect(seenCwd).to.equal("/my/project");
     });
 
+    it("spawns the CLI with the env from the injected env function", async () => {
+        // The CLI resolves auth itself, so the workspace's host/profile (and the
+        // config-file location) have to arrive as environment variables or the
+        // run silently targets whatever profile the CLI resolves on its own.
+        let seenEnv: NodeJS.ProcessEnv | undefined;
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            () => ({
+                /* eslint-disable @typescript-eslint/naming-convention */
+                DATABRICKS_HOST: "https://example.cloud.databricks.com",
+                DATABRICKS_CONFIG_PROFILE: "my-profile",
+                DATABRICKS_CONFIG_FILE: "/custom/.databrickscfg",
+                /* eslint-enable @typescript-eslint/naming-convention */
+            }),
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                captureEnv: (env) => {
+                    seenEnv = env;
+                },
+            })
+        );
+        await client.run(inv, {cwd: "/proj"});
+        expect(seenEnv).to.deep.equal({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            DATABRICKS_HOST: "https://example.cloud.databricks.com",
+            DATABRICKS_CONFIG_PROFILE: "my-profile",
+            DATABRICKS_CONFIG_FILE: "/custom/.databrickscfg",
+            /* eslint-enable @typescript-eslint/naming-convention */
+        });
+    });
+
+    it("re-reads the env for every run so a reconnect is picked up", async () => {
+        // The env function is called per run, not once at construction: the user
+        // can switch workspace/profile between setups without a reload.
+        const profiles = ["first", "second"];
+        let call = 0;
+        const seen: (string | undefined)[] = [];
+        const client = new PythonSetupCliClient(
+            () => "/fake/databricks",
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            () => ({DATABRICKS_CONFIG_PROFILE: profiles[call++]}),
+            fakeSpawn({
+                stdout: JSON.stringify(SUCCESS_DEFAULT),
+                captureEnv: (env) => seen.push(env.DATABRICKS_CONFIG_PROFILE),
+            })
+        );
+        await client.run(inv, {cwd: "/proj"});
+        await client.run(inv, {cwd: "/proj"});
+        expect(seen).to.deep.equal(["first", "second"]);
+    });
+
     it("spawns detached on POSIX so the process group can be killed", async () => {
         let seenDetached: boolean | undefined;
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({
                 stdout: JSON.stringify(SUCCESS_DEFAULT),
                 captureArgs: (_c, _a, _cwd, detached) => {
@@ -134,6 +191,7 @@ describe("PythonSetupCliClient", () => {
         const logs: string[] = [];
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({
                 stdout: JSON.stringify(SUCCESS_DEFAULT),
                 stderr: "uv: resolving dependencies…\n",
@@ -152,6 +210,7 @@ describe("PythonSetupCliClient", () => {
         const logs: string[] = [];
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({
                 stdout: JSON.stringify(SUCCESS_DEFAULT),
                 stderr: [truncated],
@@ -168,6 +227,7 @@ describe("PythonSetupCliClient", () => {
     it("rejects with PythonSetupParseError, appending stderr, when stdout is not valid JSON", async () => {
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({stdout: "not json", stderr: "boom", code: 1})
         );
         let threw = false;
@@ -192,6 +252,7 @@ describe("PythonSetupCliClient", () => {
         const cut = bytes.indexOf(0xe2) + 1; // mid-ellipsis
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({stdout: [bytes.subarray(0, cut), bytes.subarray(cut)]})
         );
         const result = await client.run(inv, {cwd: "/proj"});
@@ -202,6 +263,7 @@ describe("PythonSetupCliClient", () => {
     it("rejects when the process fails to spawn", async () => {
         const client = new PythonSetupCliClient(
             () => "/missing/databricks",
+            () => ({}),
             fakeSpawn({spawnError: new Error("ENOENT")})
         );
         let threw = false;
@@ -256,6 +318,7 @@ describe("PythonSetupCliClient", () => {
         const {token} = nextTickToken();
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             hangingSpawn,
             (child) => {
                 terminatedChild = child;
@@ -270,6 +333,7 @@ describe("PythonSetupCliClient", () => {
         const {token} = nextTickToken();
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             hangingSpawn,
             (child) => child.kill()
         );
@@ -290,6 +354,7 @@ describe("PythonSetupCliClient", () => {
         };
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             spySpawn
         );
         let caught: unknown;
@@ -315,6 +380,7 @@ describe("PythonSetupCliClient", () => {
         };
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             fakeSpawn({stdout: JSON.stringify(SUCCESS_DEFAULT)})
         );
         const result = await client.run(inv, {cwd: "/proj", token});
@@ -326,6 +392,7 @@ describe("PythonSetupCliClient", () => {
         const {token} = nextTickToken();
         const client = new PythonSetupCliClient(
             () => "/fake/databricks",
+            () => ({}),
             hangingSpawn,
             (child) => {
                 // Emit close so the promise still settles, then throw.

--- a/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.ts
+++ b/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.ts
@@ -121,6 +121,18 @@ export interface RunOptions {
 }
 
 /**
+ * Supplies the environment the CLI child is spawned with. This is how the
+ * extension's workspace authentication reaches the command: the CLI resolves
+ * auth itself (via `MustWorkspaceClient`), so without these vars it would fall
+ * back to its own default-profile resolution and could provision against a
+ * different workspace than the one the extension is connected to.
+ *
+ * A seam rather than a direct read so the gateway keeps carrying no `vscode`
+ * import and the auth wiring is assertable in tests.
+ */
+export type EnvFn = () => NodeJS.ProcessEnv;
+
+/**
  * Gateway to the `databricks environments setup-local` CLI command.
  *
  * Runs the CLI with `--output json`, captures stdout (the single structured
@@ -141,6 +153,7 @@ export interface RunOptions {
 export class PythonSetupCliClient {
     constructor(
         private readonly resolvePath: () => string,
+        private readonly envFn: EnvFn,
         private readonly spawnFn: SpawnFn = nodeSpawn as unknown as SpawnFn,
         private readonly terminateFn: TerminateFn = defaultTerminate
     ) {}
@@ -161,7 +174,7 @@ export class PythonSetupCliClient {
             try {
                 child = this.spawnFn(this.resolvePath(), args, {
                     cwd: options.cwd,
-                    env: process.env,
+                    env: this.envFn(),
                     // Give the child its own process group on POSIX so cancel
                     // can kill the whole tree (see defaultTerminate). On Windows
                     // `detached` opens a new console; we use taskkill there, so

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
@@ -9,7 +9,6 @@ describe("buildSetupLocalArgs", () => {
     it("builds a default serverless invocation with JSON output", () => {
         const inv: SetupLocalInvocation = {
             mode: "default",
-            profile: "dev",
             compute: {kind: "serverless", version: "5"},
         };
         expect(buildSetupLocalArgs(inv)).to.deep.equal([
@@ -17,8 +16,6 @@ describe("buildSetupLocalArgs", () => {
             "setup-local",
             "--serverless-version",
             "5",
-            "--profile",
-            "dev",
             "--output",
             "json",
         ]);
@@ -51,7 +48,7 @@ describe("buildSetupLocalArgs", () => {
         expect(args).to.not.include("--constraints-only");
     });
 
-    it("omits --profile when none is given", () => {
+    it("never passes --profile (auth is forwarded via the environment)", () => {
         const args = buildSetupLocalArgs({
             mode: "default",
             compute: {kind: "serverless", version: "5"},
@@ -73,7 +70,6 @@ describe("buildSetupLocalArgs", () => {
     it("always ends with --output json", () => {
         const args = buildSetupLocalArgs({
             mode: "constraints-only",
-            profile: "p",
             compute: {kind: "cluster", clusterId: "c"},
             constraintSourceUrl: "u",
         });

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
@@ -2,14 +2,17 @@ import {PythonSetupMode} from "../models/PythonSetupResult";
 
 /**
  * A resolved `environments setup-local` invocation: the mode, the compute
- * target (cluster or serverless), and optional profile / dev-only
- * constraint-source override. This is the pure input to
- * {@link buildSetupLocalArgs}; the gateway turns the argv into a spawned
- * process.
+ * target (cluster or serverless), and an optional dev-only constraint-source
+ * override. This is the pure input to {@link buildSetupLocalArgs}; the gateway
+ * turns the argv into a spawned process.
+ *
+ * There is deliberately no profile here: authentication reaches the CLI through
+ * the spawned process's environment (see `CliWrapper.getSetupLocalEnvVars`),
+ * matching how the bundle and ssh-connect flows forward it, so a `--profile`
+ * flag would be a redundant second source of truth.
  */
 export interface SetupLocalInvocation {
     mode: PythonSetupMode;
-    profile?: string;
     compute:
         | {kind: "cluster"; clusterId: string}
         | {kind: "serverless"; version: string};
@@ -24,7 +27,7 @@ export interface SetupLocalInvocation {
 /**
  * Build the argv for `databricks environments setup-local --output json`.
  * Deterministic and side-effect-free so it is trivially unit-testable; the
- * order is fixed (compute → mode → profile → source → output) for stable tests.
+ * order is fixed (compute → mode → source → output) for stable tests.
  */
 export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
     const args = ["environments", "setup-local"];
@@ -37,9 +40,6 @@ export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
 
     if (inv.mode === "constraints-only") {
         args.push("--constraints-only");
-    }
-    if (inv.profile) {
-        args.push("--profile", inv.profile);
     }
     if (inv.constraintSourceUrl) {
         args.push("--constraint-source-url", inv.constraintSourceUrl);


### PR DESCRIPTION
## Changes

`environments setup-local` resolves its own authentication via `MustWorkspaceClient`, but the extension spawned it with a bare `process.env` and never told it which workspace we are connected to. The CLI therefore fell back to its own default-profile resolution.

Two user-visible consequences:

- **Wrong-workspace provisioning, silently.** A user on a non-default profile provisioned against a different workspace's cluster, so the environment was matched to the wrong DBR and constraints — with no error.
- **Hard failure on a relocated config.** A user who moved `.databrickscfg` (via `databricks.databrickscfgLocation`) failed outright, because `DATABRICKS_CONFIG_FILE` was never propagated, even though the extension itself was connected fine.

### Commits

**1. Forward the auth env** — adds `CliWrapper.getSetupLocalEnvVars`, alongside the existing `getBundleInitEnvVars` / `getSshConnectEnvVars`: `getEnvVarsForCli` (with the configured `.databrickscfg` location) + proxy + logging + `authProvider.toEnv()`. `PythonSetupCliClient` takes an injected `EnvFn` rather than reading `process.env` at the spawn site, keeping the gateway free of a `vscode` import and making the wiring assertable.

**2. Drop the unused `--profile` field** — `SetupLocalInvocation.profile` had no caller. With auth on the environment, a flag would be a redundant second source of truth that could disagree with it, so it is removed and a test pins that `--profile` is never emitted.

### Notes for reviewers

Three details are deliberate rather than incidental:

- **The `process.env` spread lives at the call site, not in the method.** Every `*EnvVars` method in `CliWrapper` returns only the curated Databricks vars and lets the caller decide (`BundleInitWizard` spreads the ambient env; `SshCommands` deliberately does not). This follows that convention.
- **Databricks vars are applied last.** `setup-local` shells out to `uv`, which needs the real OS environment (platform paths, `UV_*`) as its base — but overlaying the Databricks vars on top means a stale ambient `DATABRICKS_CONFIG_PROFILE` cannot redirect the run.
- **`DATABRICKS_OUTPUT_FORMAT` stays `json`.** The bundle-init and ssh-connect flows override it to `text` because they render into a terminal for a human; this run's stdout is parsed as the single JSON result object, so it must not.

The env is resolved per run rather than at construction, so switching workspace or profile mid-session is picked up without a reload.

## Tests

- `yarn tsc --noEmit` clean; `yarn test:lint` clean (eslint + prettier).
- `yarn test:unit`: **474 passing, 6 failing.** Those 6 (`CliWrapper` `listProfiles`) also fail on unmodified `main` — confirmed by stashing and re-running the baseline, which gives 471 passing / the same 6 failing. They shell out to a real CLI binary that is absent from the worktree. So all new tests pass and nothing regressed.
- New coverage: the env from the injected function reaches `spawn`; it is re-read on every run; `getSetupLocalEnvVars` forwards profile + host; and `--profile` is never emitted.

Not covered by automated tests: an end-to-end run against a real workspace on a non-default profile. That needs a bundled CLI that can fetch constraints, and is tracked separately.

This pull request and its description were written by Isaac.
