### PR TITLE
docs: tell agents not to reference the internal tracker in a public repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md
 
+## This repo is public
+
+Never reference the internal issue tracker — `DECO-*` keys, `databricks.atlassian.net`
+links — in code, comments, commit messages, PR titles, or PR descriptions. The
+direction is one-way: link the PR from the internal ticket, never the ticket from the
+PR. A handful of `DECO-*` mentions predate this rule and are not precedent.
+
 ## Code conventions
 
 Read [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md) before you:


### PR DESCRIPTION
## Why

This repo is public open source, but nothing tells an AI agent so. Internal ticket keys leak internal planning and are inaccessible to external contributors — they carry no information for the audience that actually reads the code.

Agents also copy what they see, and three tracked files still carry internal keys (`ConnectionCommands.ts`, `src/telemetry/README.md`, `unity_catalog.ucws.e2e.ts` — the last as a `TODO(...)` comment). Without a stated rule, that reads as house style.

## What

A `## This repo is public` section in `AGENTS.md`:

- No internal tracker keys or `atlassian.net` links in code, comments, commit messages, PR titles, or PR descriptions.
- The direction is one-way: link the PR from the internal ticket, never the ticket from the PR.
- The pre-existing mentions are explicitly not precedent.

Placed **above** `## Code conventions` on purpose — it applies to every change, including docs-only and dependency PRs, whereas the conventions section only fires when writing code.

Says "the internal issue tracker" rather than naming the system, since not naming internal tooling in a public file is the point. The key prefix is needed to make the rule actionable.

Deliberately not in scope: cleaning up the three existing mentions. That is a separate change, and each needs a judgement call about what replaces it (inline rationale, or nothing) rather than a blanket strip.

## Verification

- `npx prettier --check AGENTS.md` passes.
- `git grep -E "DECO-[0-9]+"` finds exactly the three pre-existing mentions and no `atlassian.net` URLs, confirming the "not precedent" wording is accurate.
- `CLAUDE.md` symlink still resolves to `AGENTS.md`, so both tools pick up the new section.
- Docs-only: no source, build, or test files touched.

This pull request and its description were written by Isaac.