### PR TITLE
docs(python-setup): replace an internal tracker key with the actual reason

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -277,8 +277,13 @@ export class ConnectionCommands implements Disposable {
      * Gather serverless-version evidence from the project's local sources
      * (bundle config + notebooks). Each source is collected independently and
      * guarded, so one failing source never blocks the other or compute
-     * selection; the scorer merges and de-dupes across sources. (The
-     * workspace-default API source is not yet available — see DECO-27782.)
+     * selection; the scorer merges and de-dupes across sources.
+     *
+     * The scorer also defines a `workspaceDefault` source, which is not
+     * collected here: it would come from the workspace's default base
+     * environment, and the SDK we depend on exposes no base-environment API yet.
+     * Until it does, that weight simply never contributes and the ranking falls
+     * back to the local sources.
      */
     private async collectServerlessObservations(): Promise<
         VersionObservation[]


### PR DESCRIPTION
## Why

This repo is public, and an internal tracker key carries no information for the people who read the code here — they cannot open it. The comment on `collectServerlessObservations` used one to explain why the `workspaceDefault` version source is missing, so the single fact a reader actually needs was only available to Databricks employees.

The key was also stale: it named the ticket the source was deferred *from*, not the one now tracking it. Swapping in the newer key would have kept a reference that cannot be followed, so the reason is stated inline instead — which gives a reader strictly more than either key did.

Follows the rule added in #2081.

## What

```diff
- * selection; the scorer merges and de-dupes across sources. (The
- * workspace-default API source is not yet available — see <internal key>.)
+ * selection; the scorer merges and de-dupes across sources.
+ *
+ * The scorer also defines a `workspaceDefault` source, which is not
+ * collected here: it would come from the workspace's default base
+ * environment, and the SDK we depend on exposes no base-environment API yet.
+ * Until it does, that weight simply never contributes and the ranking falls
+ * back to the local sources.
```

The replacement states what is missing (`workspaceDefault`), why (no base-environment API in the pinned SDK), and what it means in practice (that weight never contributes; the local bundle/notebook sources decide the ranking).

## Scope

Comment-only — one doc comment, no source statement touched.

The two other pre-existing internal-key mentions (`src/telemetry/README.md` and `src/test/e2e/unity_catalog.ucws.e2e.ts`) are deliberately left alone. Each needs its own judgement call about what replaces it, and the e2e one in particular is a skipped test where dropping the only tracker link deserves a separate decision.

## Tests

- `yarn tsc --noEmit` clean.
- `yarn test:lint` clean (eslint + prettier).
- Re-verified the claim before writing it: no `BaseEnvironment` type anywhere in the bundled SDK, so the API genuinely is unavailable rather than merely unused.
- No unit run: the change cannot affect behaviour.

This pull request and its description were written by Isaac.