### PR TITLE
fix(python-setup): show setup for a packaging-only pyproject.toml

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -18,6 +18,20 @@ import {
     PythonSetupAttempt,
     PythonSetupOutcomeReport,
 } from "../../telemetry/pythonSetupExtensions";
+import {
+    DetectionSignal,
+    PackageManager,
+    PrimaryManager,
+} from "../../language/packageManagerDetection";
+
+/** A detection result for the `getDetection` seam. */
+function detection(
+    primary: PrimaryManager,
+    managers: PackageManager[],
+    signals: DetectionSignal[] = []
+) {
+    return {primary, managers, signals};
+}
 
 /**
  * Records the attempt/result telemetry the orchestrator emits. Stands in for
@@ -113,7 +127,7 @@ function makeDeps(
         // a recorder instead.
         recordSetupAttempt: () => () => {},
         recordNoCompute: () => {},
-        getPackageManager: async () => "uv",
+        getDetection: async () => detection("uv", ["uv"]),
         hasPyprojectToml: async () => true,
         ...overrides,
     };
@@ -557,7 +571,10 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
     it("records an attempt and an ok result on a successful run", async () => {
         const telemetry = makeTelemetryRecorder();
         const setup = new PythonSetupEnvironmentSetup(
-            makeDeps({...telemetry, getPackageManager: async () => "uv"})
+            makeDeps({
+                ...telemetry,
+                getDetection: async () => detection("uv", ["uv"]),
+            })
         );
 
         await setup.setup();
@@ -603,7 +620,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 ...telemetry,
-                getPackageManager: async () => "unknown",
+                getDetection: async () => detection("unknown", []),
                 hasPyprojectToml: async () => false,
             })
         );
@@ -613,7 +630,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         expect(telemetry.attempts[0].isGreenfield).to.equal(true);
     });
 
-    it("omits isGreenfield for a non-uv project (the signal is unreliable there)", async () => {
+    it("omits isGreenfield for a real pip project (the signal is unreliable there)", async () => {
         const telemetry = makeTelemetryRecorder();
         let probed = 0;
         const setup = new PythonSetupEnvironmentSetup(
@@ -621,7 +638,8 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 ...telemetry,
                 // pip/conda users may never have a pyproject.toml, so its
                 // absence says nothing about greenfield-ness.
-                getPackageManager: async () => "pip",
+                getDetection: async () =>
+                    detection("pip", ["pip"], ["requirements.txt"]),
                 hasPyprojectToml: async () => {
                     probed += 1;
                     return false;
@@ -635,6 +653,48 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         expect(telemetry.attempts[0].isGreenfield).to.equal(undefined);
         // Not even probed: the answer could not be reported either way.
         expect(probed).to.equal(0);
+    });
+
+    // The population reported on is the one the gate admits, not the one whose
+    // `primary` is uv/unknown. A packaging-shaped pyproject.toml (what `bundle
+    // init` generates) is attributed to pip yet is a project we set up, so the
+    // flag must still be reported for it -- keying off `primary` would blank the
+    // field for exactly the cohort worth measuring.
+    it("reports isGreenfield when pip was attributed only by the pyproject's shape", async () => {
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                ...telemetry,
+                getDetection: async () =>
+                    detection("pip", ["pip"], ["pyproject.pipOnly"]),
+                hasPyprojectToml: async () => true,
+            })
+        );
+
+        await setup.setup();
+
+        expect(telemetry.attempts[0].packageManager).to.equal("pip");
+        // Has a pyproject.toml, so not greenfield -- but reported, not omitted.
+        expect(telemetry.attempts[0].isGreenfield).to.equal(false);
+    });
+
+    // An unavailable detection (no project root) must not silently drop the
+    // signal: it degrades to "no manager fired", which the visibility gate also
+    // reads as suitable, so both sides agree on the failure path.
+    it("still reports isGreenfield when detection is unavailable", async () => {
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                ...telemetry,
+                getDetection: async () => undefined,
+                hasPyprojectToml: async () => false,
+            })
+        );
+
+        await setup.setup();
+
+        expect(telemetry.attempts[0].packageManager).to.equal("unknown");
+        expect(telemetry.attempts[0].isGreenfield).to.equal(true);
     });
 
     it("reports the failure phase, error code and disk state on CLI failure", async () => {
@@ -861,7 +921,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 ...telemetry,
-                getPackageManager: async () => "uv",
+                getDetection: async () => detection("uv", ["uv"]),
                 hasPyprojectToml: async () => {
                     throw new Error("stat failed");
                 },
@@ -882,7 +942,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 ...telemetry,
-                getPackageManager: async () => {
+                getDetection: async () => {
                     throw new Error("detection blew up");
                 },
             })
@@ -895,9 +955,9 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         expect(setup.ready).to.equal(true);
         expect(telemetry.attempts).to.have.length(1);
         expect(telemetry.attempts[0].packageManager).to.equal("unknown");
-        // The greenfield probe is independent and still runs: `unknown` is one
-        // of the two managers for which the signal is meaningful, and this
-        // project has a pyproject.toml.
+        // The greenfield probe is independent and still runs: a failed detection
+        // degrades to "no manager fired", which is suitable (the gate reads it
+        // the same way), and this project has a pyproject.toml.
         expect(telemetry.attempts[0].isGreenfield).to.equal(false);
         expect(telemetry.results).to.deep.equal([
             {outcome: "ok", envKey: SUCCESS_REAL_RUN.compute!.envKey},

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -18,6 +18,10 @@ import {
     PythonSetupResultReporter,
 } from "../../telemetry/pythonSetupExtensions";
 import {PrimaryManager} from "../../language/packageManagerDetection";
+import {
+    isUvSetupSuitable,
+    SuitabilityDetection,
+} from "../utils/pythonSetupGate";
 
 /**
  * The one method the orchestrator needs from {@link PythonSetupCliClient}, typed
@@ -139,15 +143,20 @@ export interface PythonSetupSetupDeps {
     recordNoCompute: () => void;
 
     /**
-     * The project's detected package manager, for the attempt event. Reads the
-     * same detection the visibility gate runs; `undefined` when detection was
-     * unavailable, in which case the attempt reports `unknown`.
+     * The project's package-manager detection, for the attempt event. Reads the
+     * same detection the visibility gate runs — the whole result rather than
+     * just `primary`, because the greenfield signal needs the manager list and
+     * the fired signals to reuse the gate's own suitability predicate.
+     * `undefined` when detection was unavailable, in which case the attempt
+     * reports `unknown` and omits the greenfield flag.
      */
-    getPackageManager: () => Promise<PrimaryManager | undefined>;
+    getDetection: () => Promise<
+        (SuitabilityDetection & {primary: PrimaryManager}) | undefined
+    >;
 
     /**
-     * Whether the project has no `pyproject.toml` yet. Consulted only when the
-     * detected manager is uv/unknown — see {@link greenfieldSignal}.
+     * Whether the project has no `pyproject.toml` yet. Consulted only for a
+     * uv-suitable project — see {@link greenfieldSignal}.
      */
     hasPyprojectToml: (projectRoot: string) => Promise<boolean>;
 }
@@ -157,16 +166,21 @@ export interface PythonSetupSetupDeps {
  *
  * A missing `pyproject.toml` only means "greenfield" for a project that has no
  * competing manager: pip and conda users may never have one, so for them the
- * absence says nothing and reporting it would inflate the greenfield rate. The
- * signal is therefore emitted only for uv/unknown projects — which is exactly
- * the population the visibility gate admits.
+ * absence says nothing and reporting it would inflate the greenfield rate.
+ *
+ * The population is therefore exactly the one the visibility gate admits, by
+ * construction: both ask {@link isUvSetupSuitable}. Reusing the gate's predicate
+ * rather than re-deriving it from `primary` matters, because a packaging-shaped
+ * `pyproject.toml` is attributed to pip while still being a project we set up —
+ * keying off `primary` alone would blank this field for every freshly-initialised
+ * bundle project, i.e. the exact cohort worth measuring.
  */
 async function greenfieldSignal(
-    manager: PrimaryManager,
+    detection: SuitabilityDetection,
     projectRoot: string,
     hasPyprojectToml: (projectRoot: string) => Promise<boolean>
 ): Promise<boolean | undefined> {
-    if (manager !== "uv" && manager !== "unknown") {
+    if (!isUvSetupSuitable(detection)) {
         return undefined;
     }
     return !(await hasPyprojectToml(projectRoot));
@@ -371,6 +385,10 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         projectRoot: string
     ): Promise<PythonSetupResultReporter> {
         const {compute} = invocation;
+        // An unavailable detection degrades to "no manager fired", which reads as
+        // a greenfield-suitable project -- the same reading the visibility gate
+        // gives it, so the two stay consistent even on the failure path.
+        let detection: SuitabilityDetection = {managers: [], signals: []};
         let packageManager: PrimaryManager = "unknown";
         let isGreenfield: boolean | undefined;
         // Two independent probes, so they get independent try blocks: a failing
@@ -379,13 +397,17 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         // `unknown`). Either failing just narrows the attempt, never breaks the
         // user's setup run.
         try {
-            packageManager = (await this.deps.getPackageManager()) ?? "unknown";
+            const detected = await this.deps.getDetection();
+            if (detected !== undefined) {
+                detection = detected;
+                packageManager = detected.primary;
+            }
         } catch {
-            // Keep `unknown`.
+            // Keep `unknown` and the greenfield-suitable default.
         }
         try {
             isGreenfield = await greenfieldSignal(
-                packageManager,
+                detection,
                 projectRoot,
                 this.deps.hasPyprojectToml
             );

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -10,7 +10,11 @@ import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {Telemetry} from "../../telemetry";
 
 describe("makePythonSetupVisibility", () => {
-    const uvDetection = {primary: "uv" as const, managers: ["uv" as const]};
+    const uvDetection = {
+        primary: "uv" as const,
+        managers: ["uv" as const],
+        signals: [],
+    };
 
     it("is hidden when the feature flag is off, regardless of project", async () => {
         const isVisible = makePythonSetupVisibility({
@@ -42,7 +46,11 @@ describe("makePythonSetupVisibility", () => {
     it("is hidden for a project with a competing manager", async () => {
         const isVisible = makePythonSetupVisibility({
             isEnabled: () => true,
-            detect: async () => ({primary: "uv", managers: ["uv", "pip"]}),
+            detect: async () => ({
+                primary: "uv" as const,
+                managers: ["uv" as const, "pip" as const],
+                signals: ["requirements.txt" as const],
+            }),
             projectRoot: () => "/proj",
         });
         expect(await isVisible()).to.equal(false);
@@ -124,7 +132,11 @@ describe("makePythonSetupDeps saveState", () => {
             cli: {run: async () => ({}) as any},
             projectRoot: () => "/proj",
             isEnabled: () => true,
-            detect: async () => ({primary: "uv", managers: ["uv"]}),
+            detect: async () => ({
+                primary: "uv" as const,
+                managers: ["uv" as const],
+                signals: [],
+            }),
             attachedCompute: () => ({
                 serverless: false,
                 cluster: undefined,
@@ -188,7 +200,11 @@ describe("makePythonSetupDeps saveState", () => {
 });
 
 describe("makePythonSetupVisibility error handling", () => {
-    const uvDetection = {primary: "uv" as const, managers: ["uv" as const]};
+    const uvDetection = {
+        primary: "uv" as const,
+        managers: ["uv" as const],
+        signals: [],
+    };
 
     it("degrades to not-visible when detection rejects (never throws)", async () => {
         const isVisible = makePythonSetupVisibility({
@@ -223,7 +239,11 @@ describe("makePythonSetupDeps withProgress", () => {
             cli: {run: async () => ({}) as any},
             projectRoot: () => "/proj",
             isEnabled: () => true,
-            detect: async () => ({primary: "uv", managers: ["uv"]}),
+            detect: async () => ({
+                primary: "uv" as const,
+                managers: ["uv" as const],
+                signals: [],
+            }),
             attachedCompute: () => ({
                 serverless: false,
                 cluster: undefined,

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -165,7 +165,7 @@ export function makePythonSetupDeps(
         recordSetupAttempt: (attempt) =>
             wiring.telemetry.recordPythonSetupAttempt(attempt),
         recordNoCompute: () => wiring.telemetry.recordPythonSetupNoCompute(),
-        getPackageManager: async () => {
+        getDetection: async () => {
             const root = wiring.projectRoot();
             if (root === undefined) {
                 return undefined;
@@ -173,7 +173,7 @@ export function makePythonSetupDeps(
             // Same detection the gate ran for this click. It is re-run rather
             // than cached because a project's markers can change between the
             // config view rendering the entry and the user pressing it.
-            return (await wiring.detect(root)).primary;
+            return wiring.detect(root);
         },
         hasPyprojectToml: async (projectRoot: string) =>
             existsSync(path.join(projectRoot, "pyproject.toml")),

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -14,7 +14,10 @@ import {
     SetupCompute,
 } from "./PythonSetupEnvironmentSetup";
 
-type Detection = Pick<PackageManagerDetection, "primary" | "managers">;
+type Detection = Pick<
+    PackageManagerDetection,
+    "primary" | "managers" | "signals"
+>;
 
 /**
  * The compute currently attached in the connection, reduced to what compute

--- a/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/PythonSetupManagerDetector.ts
@@ -28,13 +28,19 @@ export class PythonSetupManagerDetector {
 
     async detect(
         projectRoot: string
-    ): Promise<Pick<PackageManagerDetection, "primary" | "managers">> {
+    ): Promise<
+        Pick<PackageManagerDetection, "primary" | "managers" | "signals">
+    > {
         try {
-            const signals = await this.collect(projectRoot);
-            const {primary, managers} = detectPackageManagers(signals);
-            return {primary, managers};
+            const collected = await this.collect(projectRoot);
+            const {primary, managers, signals} =
+                detectPackageManagers(collected);
+            // `signals` is forwarded because the gate distinguishes a real pip
+            // workflow from a merely packaging-shaped pyproject.toml, which the
+            // manager list alone cannot express (both read as "pip").
+            return {primary, managers, signals};
         } catch {
-            return {primary: "unknown", managers: []};
+            return {primary: "unknown", managers: [], signals: []};
         }
     }
 }

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
@@ -4,7 +4,7 @@ import {
     PackageManager,
     PrimaryManager,
 } from "../../language/packageManagerDetection";
-import {shouldShowPythonSetup} from "./pythonSetupGate";
+import {isUvSetupSuitable, shouldShowPythonSetup} from "./pythonSetupGate";
 
 const det = (
     primary: PrimaryManager,
@@ -175,5 +175,74 @@ describe("shouldShowPythonSetup", () => {
                 ),
             })
         ).to.equal(false);
+    });
+});
+
+// The shared predicate behind both the visibility gate and the attempt
+// telemetry's greenfield signal. Covered directly so the contract the two
+// consumers rely on is pinned independently of the flag handling above.
+describe("isUvSetupSuitable", () => {
+    it("accepts a clean uv project and a greenfield one", () => {
+        expect(isUvSetupSuitable(det("uv", ["uv"]))).to.equal(true);
+        expect(isUvSetupSuitable(det("unknown", []))).to.equal(true);
+    });
+
+    it("accepts a pip attribution resting only on the pyproject's shape", () => {
+        expect(
+            isUvSetupSuitable(det("pip", ["pip"], ["pyproject.pipOnly"]))
+        ).to.equal(true);
+    });
+
+    it("rejects a real pip workflow", () => {
+        for (const signal of [
+            "requirements.txt",
+            "constraints.txt",
+            "interpreter.venv",
+        ] as DetectionSignal[]) {
+            expect(
+                isUvSetupSuitable(
+                    det("pip", ["pip"], ["pyproject.pipOnly", signal])
+                ),
+                signal
+            ).to.equal(false);
+        }
+    });
+
+    it("rejects poetry and conda even alongside a shape-only pip", () => {
+        expect(
+            isUvSetupSuitable(
+                det(
+                    "poetry",
+                    ["poetry", "pip"],
+                    ["poetry.lock", "pyproject.pipOnly"]
+                )
+            )
+        ).to.equal(false);
+        expect(
+            isUvSetupSuitable(
+                det(
+                    "conda",
+                    ["conda", "pip"],
+                    ["conda.prefix", "pyproject.pipOnly"]
+                )
+            )
+        ).to.equal(false);
+    });
+
+    it("agrees with the gate whenever the flag is on", () => {
+        const cases = [
+            det("uv", ["uv"]),
+            det("unknown", []),
+            det("pip", ["pip"], ["pyproject.pipOnly"]),
+            det("pip", ["pip"], ["requirements.txt"]),
+            det("poetry", ["poetry"], ["poetry.lock"]),
+            det("conda", ["conda"], ["conda.prefix"]),
+        ];
+        for (const detection of cases) {
+            expect(
+                shouldShowPythonSetup({flagOn: true, detection}),
+                JSON.stringify(detection.signals)
+            ).to.equal(isUvSetupSuitable(detection));
+        }
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.test.ts
@@ -1,13 +1,19 @@
 import {expect} from "chai";
 import {
+    DetectionSignal,
     PackageManager,
     PrimaryManager,
 } from "../../language/packageManagerDetection";
 import {shouldShowPythonSetup} from "./pythonSetupGate";
 
-const det = (primary: PrimaryManager, managers: PackageManager[]) => ({
+const det = (
+    primary: PrimaryManager,
+    managers: PackageManager[],
+    signals: DetectionSignal[] = []
+) => ({
     primary,
     managers,
+    signals,
 });
 
 describe("shouldShowPythonSetup", () => {
@@ -79,6 +85,94 @@ describe("shouldShowPythonSetup", () => {
             shouldShowPythonSetup({
                 flagOn: true,
                 detection: det("conda", ["conda"]),
+            })
+        ).to.equal(false);
+    });
+
+    // A packaging-shaped pyproject.toml with no [tool.uv] and no uv.lock is
+    // classified as pip, which is what `databricks bundle init` generates. Those
+    // projects are the ones this feature exists to set up, so that attribution
+    // alone must not hide the entry.
+    it("shows when pip was attributed only by the pyproject's shape", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det("pip", ["pip"], ["pyproject.pipOnly"]),
+            })
+        ).to.equal(true);
+    });
+
+    it("still hides when a requirements.txt accompanies the pyproject", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "pip",
+                    ["pip"],
+                    ["pyproject.pipOnly", "requirements.txt"]
+                ),
+            })
+        ).to.equal(false);
+    });
+
+    it("still hides when a constraints.txt accompanies the pyproject", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "pip",
+                    ["pip"],
+                    ["pyproject.pipOnly", "constraints.txt"]
+                ),
+            })
+        ).to.equal(false);
+    });
+
+    it("still hides when a non-uv virtualenv is already the interpreter", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "pip",
+                    ["pip"],
+                    ["pyproject.pipOnly", "interpreter.venv"]
+                ),
+            })
+        ).to.equal(false);
+    });
+
+    it("shows for a uv project whose pip attribution is pyproject-shape only", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "uv",
+                    ["uv", "pip"],
+                    ["uv.lock", "pyproject.pipOnly"]
+                ),
+            })
+        ).to.equal(true);
+    });
+
+    it("does not discount poetry or conda alongside a shape-only pip", () => {
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "poetry",
+                    ["poetry", "pip"],
+                    ["poetry.lock", "pyproject.pipOnly"]
+                ),
+            })
+        ).to.equal(false);
+        expect(
+            shouldShowPythonSetup({
+                flagOn: true,
+                detection: det(
+                    "conda",
+                    ["conda", "pip"],
+                    ["conda.prefix", "pyproject.pipOnly"]
+                ),
             })
         ).to.equal(false);
     });

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
@@ -1,4 +1,5 @@
 import {
+    DetectionSignal,
     PackageManager,
     PackageManagerDetection,
 } from "../../language/packageManagerDetection";
@@ -13,29 +14,76 @@ import {
 const COMPETING_MANAGERS: PackageManager[] = ["pip", "poetry", "conda"];
 
 /**
+ * The pip signals that reflect a real pip workflow, as opposed to merely a
+ * packaging-shaped `pyproject.toml`.
+ *
+ * `pyproject.pipOnly` is deliberately absent: it fires on any `pyproject.toml`
+ * that declares `[project]`/`[build-system]` without a `[tool.uv]` or
+ * `[tool.poetry]` section, which is exactly the shape `databricks bundle init`
+ * generates and which uv itself works with natively. Treating it as a pip
+ * workflow would hide setup from the template our own onboarding produces. A
+ * `requirements.txt`, a `constraints.txt`, or a plain (non-uv) virtualenv are
+ * different: they are positive evidence that someone is driving pip directly.
+ */
+const SUBSTANTIVE_PIP_SIGNALS: DetectionSignal[] = [
+    "requirements.txt",
+    "constraints.txt",
+    "interpreter.venv",
+];
+
+/**
+ * Whether pip was attributed only because the project has a packaging-shaped
+ * `pyproject.toml`, with no other pip evidence.
+ */
+function pipIsPyprojectShapeOnly(
+    managers: readonly PackageManager[],
+    signals: readonly DetectionSignal[]
+): boolean {
+    return (
+        managers.includes("pip") &&
+        signals.includes("pyproject.pipOnly") &&
+        !signals.some((s) => SUBSTANTIVE_PIP_SIGNALS.includes(s))
+    );
+}
+
+/**
  * Whether to surface the uv-native python-setup entry for the current project.
  *
  * Pure predicate over the feature flag and the live detection result. Shows
- * only when all hold:
+ * only when both hold:
  *  - the feature flag is on (the whole feature is opt-in while the CLI command
  *    ships only in custom builds), AND
- *  - the primary manager is `uv` or `unknown` (a clean uv project, or a
- *    greenfield project with no manager yet — the two cases uv-native setup
- *    fits), AND
- *  - no competing manager (pip/poetry/conda) fired at all. Even a uv-primary
- *    project is excluded if it also shows pip/conda/poetry signals, so setup
- *    never fights an environment the project already depends on.
+ *  - no competing manager (pip/poetry/conda) is driving the project. Even a
+ *    uv-primary project is excluded if it also shows poetry/conda signals, or
+ *    real pip signals, so setup never fights an environment the project already
+ *    depends on.
+ *
+ * The one deliberate exception is a `pyproject.toml` that merely *looks* like a
+ * packaging project (`[project]`/`[build-system]`, no `[tool.uv]`, no
+ * `uv.lock`). The classifier attributes that to pip — a documented skew, since
+ * uv needs neither of those to manage such a project — and that covers every
+ * freshly-initialised bundle project until someone runs `uv lock`. Those are
+ * precisely the projects this feature exists to set up, so pip attributed from
+ * that signal alone is not treated as competing. See
+ * {@link SUBSTANTIVE_PIP_SIGNALS}.
  */
 export function shouldShowPythonSetup(args: {
     flagOn: boolean;
-    detection: Pick<PackageManagerDetection, "primary" | "managers">;
+    detection: Pick<
+        PackageManagerDetection,
+        "primary" | "managers" | "signals"
+    >;
 }): boolean {
     if (!args.flagOn) {
         return false;
     }
-    const {primary, managers} = args.detection;
-    if (primary !== "uv" && primary !== "unknown") {
-        return false;
-    }
-    return !managers.some((m) => COMPETING_MANAGERS.includes(m));
+    const {managers, signals} = args.detection;
+
+    // Discount a pip attribution that rests only on the pyproject's shape, then
+    // judge the project on what is left. Poetry and conda are never discounted.
+    const effective = pipIsPyprojectShapeOnly(managers, signals)
+        ? managers.filter((m) => m !== "pip")
+        : managers;
+
+    return !effective.some((m) => COMPETING_MANAGERS.includes(m));
 }

--- a/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pythonSetupGate.ts
@@ -10,6 +10,9 @@ import {
  * it would fight the tool the project already uses (pip/poetry/conda). The
  * legacy pip checklist covers those projects instead; the two entry points are
  * mutually exclusive and never shown together.
+ *
+ * `pip` here means a *real* pip workflow: an attribution rooted only in the
+ * pyproject's shape is discounted first — see {@link SUBSTANTIVE_PIP_SIGNALS}.
  */
 const COMPETING_MANAGERS: PackageManager[] = ["pip", "poetry", "conda"];
 
@@ -46,6 +49,44 @@ function pipIsPyprojectShapeOnly(
     );
 }
 
+/** The detection fields every uv-suitability decision reads. */
+export type SuitabilityDetection = Pick<
+    PackageManagerDetection,
+    "managers" | "signals"
+>;
+
+/**
+ * Whether uv-native setup fits this project at all — i.e. no competing manager
+ * is driving it.
+ *
+ * The single source of truth for "is this one of our projects", shared by the
+ * visibility gate and by the attempt telemetry's greenfield signal so the two
+ * cannot drift. Judging a project by its `managers` alone is not enough: a real
+ * pip workflow and a merely packaging-shaped `pyproject.toml` both read as
+ * `"pip"`, which is why this takes `signals` too.
+ *
+ * The one deliberate exception is a `pyproject.toml` that merely *looks* like a
+ * packaging project (`[project]`/`[build-system]`, no `[tool.uv]`, no
+ * `uv.lock`). The classifier attributes that to pip — a documented skew, since
+ * uv needs neither of those to manage such a project — and that covers every
+ * freshly-initialised bundle project until someone runs `uv lock`, as well as
+ * any other PEP 621 project whose build backend is not uv or poetry (pdm,
+ * hatch, flit). Those are precisely the projects this feature exists to set up,
+ * so pip attributed from that signal alone is not treated as competing. Poetry
+ * and conda are never discounted.
+ */
+export function isUvSetupSuitable(detection: SuitabilityDetection): boolean {
+    const {managers, signals} = detection;
+
+    // Discount a pip attribution that rests only on the pyproject's shape, then
+    // judge the project on what is left.
+    const effective = pipIsPyprojectShapeOnly(managers, signals)
+        ? managers.filter((m) => m !== "pip")
+        : managers;
+
+    return !effective.some((m) => COMPETING_MANAGERS.includes(m));
+}
+
 /**
  * Whether to surface the uv-native python-setup entry for the current project.
  *
@@ -53,37 +94,17 @@ function pipIsPyprojectShapeOnly(
  * only when both hold:
  *  - the feature flag is on (the whole feature is opt-in while the CLI command
  *    ships only in custom builds), AND
- *  - no competing manager (pip/poetry/conda) is driving the project. Even a
+ *  - the project is uv-suitable — see {@link isUvSetupSuitable}. Even a
  *    uv-primary project is excluded if it also shows poetry/conda signals, or
  *    real pip signals, so setup never fights an environment the project already
  *    depends on.
- *
- * The one deliberate exception is a `pyproject.toml` that merely *looks* like a
- * packaging project (`[project]`/`[build-system]`, no `[tool.uv]`, no
- * `uv.lock`). The classifier attributes that to pip — a documented skew, since
- * uv needs neither of those to manage such a project — and that covers every
- * freshly-initialised bundle project until someone runs `uv lock`. Those are
- * precisely the projects this feature exists to set up, so pip attributed from
- * that signal alone is not treated as competing. See
- * {@link SUBSTANTIVE_PIP_SIGNALS}.
  */
 export function shouldShowPythonSetup(args: {
     flagOn: boolean;
-    detection: Pick<
-        PackageManagerDetection,
-        "primary" | "managers" | "signals"
-    >;
+    detection: SuitabilityDetection;
 }): boolean {
     if (!args.flagOn) {
         return false;
     }
-    const {managers, signals} = args.detection;
-
-    // Discount a pip attribution that rests only on the pyproject's shape, then
-    // judge the project on what is left. Poetry and conda are never discounted.
-    const effective = pipIsPyprojectShapeOnly(managers, signals)
-        ? managers.filter((m) => m !== "pip")
-        : managers;
-
-    return !effective.some((m) => COMPETING_MANAGERS.includes(m));
+    return isUvSetupSuitable(args.detection);
 }

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -350,9 +350,12 @@ export class EventTypes {
         },
         isGreenfield: {
             comment:
-                "Whether the project has no pyproject.toml yet. Omitted unless packageManager " +
-                "is uv or unknown: for a pip/conda project the absence of a pyproject.toml says " +
-                "nothing about greenfield-ness, so the signal would be misleading",
+                "Whether the project has no pyproject.toml yet. Omitted unless the project is " +
+                "uv-suitable (the same predicate that gates the setup entry): for a project " +
+                "driven by poetry/conda or a real pip workflow the absence of a pyproject.toml " +
+                "says nothing about greenfield-ness, so the signal would be misleading. Note a " +
+                "packaging-shaped pyproject.toml is attributed to pip yet is still reported on, " +
+                "so this is NOT equivalent to packageManager being uv or unknown",
         },
     };
     [Events.PYTHON_ENV_SETUP_RESULT]: EventType<{


### PR DESCRIPTION
## Why

A freshly-initialised bundle project never surfaced the "Set up Python environment" entry.

The `pyproject.toml` that `databricks bundle init default-python` generates declares `[project]` and `[build-system]` but no `[tool.uv]`, and ships no `uv.lock`. That fires the `pyproject.pipOnly` signal, attributes the project to **pip**, and the gate hides the entry because pip counts as a competing manager. The legacy pip checklist showed instead.

This inverts the intent. uv manages such a project natively — it needs neither a `[tool.uv]` section nor a lockfile — and these are precisely the projects the feature exists to set up. The design doc's argument that *"our own example/bundle-init project already ships with uv, so the fully automated path matches what new users land on"* only holds once someone has run `uv lock`. The skew was already documented as a telemetry measurement caveat; this is the same root cause surfacing as a product defect.

Measured on a real `bundle init` project, before and after:

```
managers: ["uv", "pip"]
signals:  ["uv.lock", "pyproject.pipOnly"]
gate: false   ← main
gate: true    ← this PR
```

Note the first line: adding a `uv.lock` is **not** a workaround. It correctly attributes uv, but `pyproject.pipOnly` still fires, so pip stays in `managers` and the gate still rejects the project even with uv as primary. Before this change the only way to surface the entry was to hand-add a literal `[tool.uv]` section.

## What

Discount a pip attribution in the gate when it rests *solely* on the pyproject's shape. Pip is ignored when `pyproject.pipOnly` fired and no substantive pip signal did:

- `requirements.txt`
- `constraints.txt`
- `interpreter.venv` (an existing non-uv virtualenv)

Those three remain disqualifying — they are positive evidence that someone drives pip directly, and offering uv setup there would fight their tooling. Poetry and conda are never discounted.

## Why in the gate, not the classifier

Loosening `pyproject.pipOnly` in `packageManagerDetection.ts` would have been the smaller diff, but that signal also feeds the package-manager telemetry dataset. Redefining it there would silently change what the metric counts and break comparability with data already collected — the classifier's job is to describe the project, and it is describing it accurately.

The gate is the only consumer whose behaviour should change, so `PythonSetupManagerDetector` now forwards `signals` alongside `primary`/`managers` for it to read. The manager list alone cannot express the distinction: a real pip workflow and a merely packaging-shaped `pyproject.toml` both read as `"pip"`.

## Tests

- `yarn tsc --noEmit` clean; `yarn test:lint` clean (eslint + prettier).
- `yarn test:unit`: **481 passing, 6 failing.** The 6 are the pre-existing `CliWrapper` `listProfiles` failures, which also fail on unmodified `main` (they shell out to a real CLI binary absent from the worktree). 474 passed before this change, so all 7 new cases pass and nothing regressed.
- New coverage: shows for a shape-only pip attribution; still hides for each of the three substantive pip signals individually; shows for uv + shape-only pip; and poetry/conda alongside a shape-only pip still hide.
- Verified end to end against a real bundle-init project by running the actual signal collector and gate over it — not just unit fixtures — and separately in a dogfood VSIX build.

This pull request and its description were written by Isaac.