### PR TITLE
fix(python-setup): resolve a missing serverless version instead of aborting

### DIFF
--- a/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
+++ b/packages/databricks-vscode/src/configuration/ConnectionCommands.ts
@@ -29,9 +29,7 @@ import {
     resolveServerlessVersion,
 } from "../python-setup/utils/serverlessVersionResolver";
 import {pickServerlessVersion} from "../python-setup/utils/serverlessVersionPicker";
-import {collectBundleServerlessVersions} from "../python-setup/utils/bundleServerlessVersions";
-import {collectProjectNotebookVersions} from "../python-setup/utils/projectNotebookVersions";
-import {VersionObservation} from "../python-setup/utils/serverlessVersionScoring";
+import {collectServerlessVersionObservations} from "../python-setup/utils/serverlessVersionObservations";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 
 function formatQuickPickClusterSize(sizeInMB: number): string {
@@ -264,53 +262,27 @@ export class ConnectionCommands implements Disposable {
      * Returns the confirmed bare version, or undefined if dismissed. Delegates
      * to {@link resolveServerlessVersion} so the collect->score->pick pipeline
      * lives in one place; this call site only supplies where the evidence comes
-     * from (the bundle today) and how the user confirms it.
+     * from and how the user confirms it.
      */
     private async pickServerlessVersion(): Promise<string | undefined> {
         return resolveServerlessVersion({
-            collectObservations: () => this.collectServerlessObservations(),
+            collectObservations: () =>
+                collectServerlessVersionObservations({
+                    getValidateConfig: () =>
+                        this.configModel.get("validateConfig"),
+                    // activeProjectUri throws when no project is active; the
+                    // collector's contract is string | undefined.
+                    projectRoot: () => {
+                        try {
+                            return this.workspaceFolderManager.activeProjectUri
+                                .fsPath;
+                        } catch {
+                            return undefined;
+                        }
+                    },
+                }),
             pick: pickServerlessVersion,
         });
-    }
-
-    /**
-     * Gather serverless-version evidence from the project's local sources
-     * (bundle config + notebooks). Each source is collected independently and
-     * guarded, so one failing source never blocks the other or compute
-     * selection; the scorer merges and de-dupes across sources.
-     *
-     * The scorer also defines a `workspaceDefault` source, which is not
-     * collected here: it would come from the workspace's default base
-     * environment, and the SDK we depend on exposes no base-environment API yet.
-     * Until it does, that weight simply never contributes and the ranking falls
-     * back to the local sources.
-     */
-    private async collectServerlessObservations(): Promise<
-        VersionObservation[]
-    > {
-        const [bundle, notebooks] = await Promise.all([
-            (async () => {
-                try {
-                    const validateConfig =
-                        await this.configModel.get("validateConfig");
-                    return collectBundleServerlessVersions(validateConfig);
-                } catch {
-                    return [] as VersionObservation[];
-                }
-            })(),
-            (async () => {
-                try {
-                    const projectRoot =
-                        this.workspaceFolderManager.activeProjectUri.fsPath;
-                    return await collectProjectNotebookVersions(projectRoot);
-                } catch {
-                    // No active project, or notebook scan failed -- contribute
-                    // nothing rather than blocking compute selection.
-                    return [] as VersionObservation[];
-                }
-            })(),
-        ]);
-        return [...bundle, ...notebooks];
     }
 
     /**

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -53,7 +53,10 @@ import {PythonSetupCliClient} from "./python-setup/gateways/PythonSetupCliClient
 import {PythonSetupEnvironmentSetup} from "./python-setup/controllers/PythonSetupEnvironmentSetup";
 import {makePythonSetupDeps} from "./python-setup/controllers/pythonSetupDeps";
 import {resolveCliPath} from "./python-setup/utils/setupLocalArgs";
-import {isPythonSetupEnabled} from "./python-setup/utils/serverlessVersionResolver";
+import {
+    isPythonSetupEnabled,
+    makeServerlessVersionPrompt,
+} from "./python-setup/utils/serverlessVersionResolver";
 import {collectPackageManagerSignals} from "./language/packageManagerSignals";
 import {EnvironmentDependenciesVerifier} from "./language/EnvironmentDependenciesVerifier";
 import {MsPythonExtensionWrapper} from "./language/MsPythonExtensionWrapper";
@@ -947,6 +950,26 @@ export async function activate(
                     : undefined,
                 serverlessVersion: connectionManager.serverlessVersion,
             }),
+            promptServerlessVersion: makeServerlessVersionPrompt({
+                getValidateConfig: () => configModel.get("validateConfig"),
+                // activeProjectUri throws when no project is active; the
+                // collector's contract is string | undefined.
+                projectRoot: () => {
+                    try {
+                        return workspaceFolderManager.activeProjectUri.fsPath;
+                    } catch {
+                        return undefined;
+                    }
+                },
+            }),
+            // Reuses the compute picker's own persistence path: with serverless
+            // already enabled this only records the version -- it does not
+            // re-attach compute, fire a compute-change event, or re-report
+            // COMPUTE_SELECTED. It is decorated @onError, so a failed config
+            // write surfaces a popup to the user instead of rejecting into the
+            // setup flow.
+            persistServerlessVersion: (version) =>
+                connectionManager.enableServerless(version),
             setActiveInterpreter: async (interpreterPath, root) => {
                 await pythonExtensionWrapper.api.environments.updateActiveEnvironmentPath(
                     interpreterPath,

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -114,7 +114,10 @@ function makeDeps(
         projectRoot: () => "/proj",
         // Default seams model a connected serverless session that opted in.
         isVisible: async () => true,
-        resolveCompute: async () => ({kind: "serverless", version: "5"}),
+        resolveCompute: async () => ({
+            status: "ok",
+            compute: {kind: "serverless", version: "5"},
+        }),
         adoptInterpreter: async () => {},
         saveState: () => {},
         notify: async () => {},
@@ -261,7 +264,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli,
-                resolveCompute: async () => undefined,
+                resolveCompute: async () => ({status: "none"}),
                 notify: async (m) => {
                     notified.push(m);
                 },
@@ -600,8 +603,8 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
             makeDeps({
                 ...telemetry,
                 resolveCompute: async () => ({
-                    kind: "cluster",
-                    clusterId: "0710-abc",
+                    status: "ok",
+                    compute: {kind: "cluster", clusterId: "0710-abc"},
                 }),
             })
         );
@@ -794,7 +797,10 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
     it("reports no_compute (without an attempt) when the CTA is a dead end", async () => {
         const telemetry = makeTelemetryRecorder();
         const setup = new PythonSetupEnvironmentSetup(
-            makeDeps({...telemetry, resolveCompute: async () => undefined})
+            makeDeps({
+                ...telemetry,
+                resolveCompute: async () => ({status: "none"}),
+            })
         );
 
         await setup.setup();
@@ -806,11 +812,44 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         expect(telemetry.results).to.deep.equal([{outcome: "no_compute"}]);
     });
 
+    it("stops silently when the user dismisses the version prompt", async () => {
+        const cli = makeCli();
+        const telemetry = makeTelemetryRecorder();
+        const notified: string[] = [];
+        const shownErrors: string[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                ...telemetry,
+                cli,
+                resolveCompute: async () => ({status: "cancelled"}),
+                notify: async (m) => {
+                    notified.push(m);
+                },
+                showError: async (m) => {
+                    shownErrors.push(m);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        // A dismissal is a user action, not a failure and not a dead end: no
+        // run, no toast of either kind, and nothing recorded — reporting
+        // no_compute here would conflate deliberate bail-outs with a CTA that
+        // had nothing to do.
+        expect(cli.calls).to.have.length(0);
+        expect(notified).to.have.length(0);
+        expect(shownErrors).to.have.length(0);
+        expect(telemetry.attempts).to.have.length(0);
+        expect(telemetry.results).to.have.length(0);
+        expect(setup.ready).to.equal(false);
+    });
+
     it("still guides the user when the no_compute emit throws", async () => {
         const notified: string[] = [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
-                resolveCompute: async () => undefined,
+                resolveCompute: async () => ({status: "none"}),
                 recordNoCompute: () => {
                     throw new Error("telemetry blew up");
                 },

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -36,6 +36,17 @@ export interface CliRunner {
 
 export type SetupCompute = SetupLocalInvocation["compute"];
 
+/**
+ * What the compute seam resolved to. `cancelled` means the user was asked for a
+ * missing piece (a serverless version) and dismissed the prompt -- a user
+ * action, not a dead end, so it must stay silent and must not be counted as a
+ * no-compute click.
+ */
+export type ResolvedCompute =
+    | {status: "ok"; compute: SetupCompute}
+    | {status: "none"}
+    | {status: "cancelled"};
+
 /** Persisted after a successful setup, for later drift detection. */
 export interface PythonSetupPersistedState {
     envKey: string;
@@ -86,13 +97,15 @@ export interface PythonSetupSetupDeps {
     isVisible: () => Promise<boolean>;
 
     /**
-     * The compute target to provision for, or `undefined` to abort silently
-     * (nothing selected). The extension resolves this from the attached
-     * compute: a cluster maps directly; a serverless session uses the version
-     * the compute picker persisted (`serverlessVersion`), so a serverless
-     * session with no chosen version yields `undefined`.
+     * The compute target to provision for. `none` means nothing is attached
+     * (the CTA is a dead end -- guide the user); `cancelled` means the user
+     * dismissed a prompt for a missing detail and the flow should stop quietly.
+     * The extension resolves this from the attached compute: a cluster maps
+     * directly, a serverless session uses the version the compute picker
+     * persisted (`serverlessVersion`), and a serverless session with no chosen
+     * version prompts for one.
      */
-    resolveCompute: () => Promise<SetupCompute | undefined>;
+    resolveCompute: () => Promise<ResolvedCompute>;
 
     /**
      * Point the MS Python extension at the provisioned venv interpreter for
@@ -260,14 +273,20 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             return;
         }
 
-        const compute = await resolveCompute();
-        if (compute === undefined) {
+        const resolved = await resolveCompute();
+        if (resolved.status === "cancelled") {
+            // The user was asked for the missing serverless version and
+            // dismissed the prompt. That is a deliberate bail-out, not a dead
+            // end: stay silent (as with a cancelled run) and record nothing, so
+            // the no-compute metric keeps meaning "the CTA had nothing to do".
+            return;
+        }
+        if (resolved.status === "none") {
             // The entry is visible whenever the project fits (flag + uv shape),
             // independent of compute — so a user can click the CTA with no
-            // cluster attached or a serverless session without a chosen version.
-            // Tell them what to do instead of silently no-op'ing the button.
-            // Plain notify (not showError): no CLI ran, so there is no log to
-            // reveal.
+            // compute attached at all. Tell them what to do instead of silently
+            // no-op'ing the button. Plain notify (not showError): no CLI ran, so
+            // there is no log to reveal.
             try {
                 this.deps.recordNoCompute();
             } catch {
@@ -276,6 +295,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             await this.deps.notify(NO_COMPUTE_TARGET_MESSAGE);
             return;
         }
+        const compute = resolved.compute;
 
         const invocation: SetupLocalInvocation = {
             mode: "default",

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -152,34 +152,165 @@ describe("resolveComputeFrom", () => {
     });
 });
 
-describe("makePythonSetupDeps saveState", () => {
-    function makeWiring(
-        overrides: Partial<PythonSetupWiringDeps> = {}
-    ): PythonSetupWiringDeps {
-        return {
-            cli: {run: async () => ({}) as any},
-            projectRoot: () => "/proj",
-            isEnabled: () => true,
-            detect: async () => ({
-                primary: "uv" as const,
-                managers: ["uv" as const],
-                signals: [],
-            }),
-            attachedCompute: () => ({
-                serverless: false,
-                cluster: undefined,
-                serverlessVersion: undefined,
-            }),
-            setActiveInterpreter: async () => {},
-            persistSetupState: () => {},
-            log: {append: () => {}, show: () => {}},
-            // A reporter-less client: recordEvent short-circuits, so the setup
-            // events are inert here (they have their own tests).
-            telemetry: new Telemetry(undefined),
-            ...overrides,
-        };
-    }
+function makeWiring(
+    overrides: Partial<PythonSetupWiringDeps> = {}
+): PythonSetupWiringDeps {
+    return {
+        cli: {run: async () => ({}) as any},
+        projectRoot: () => "/proj",
+        isEnabled: () => true,
+        detect: async () => ({
+            primary: "uv" as const,
+            managers: ["uv" as const],
+            signals: [],
+        }),
+        attachedCompute: () => ({
+            serverless: false,
+            cluster: undefined,
+            serverlessVersion: undefined,
+        }),
+        promptServerlessVersion: async () => "4",
+        persistServerlessVersion: async () => {},
+        setActiveInterpreter: async () => {},
+        persistSetupState: () => {},
+        log: {append: () => {}, show: () => {}},
+        // A reporter-less client: recordEvent short-circuits, so the setup
+        // events are inert here (they have their own tests).
+        telemetry: new Telemetry(undefined),
+        ...overrides,
+    };
+}
 
+describe("makePythonSetupDeps resolveCompute", () => {
+    /** A serverless session with no version recorded -- the prompt's reason to exist. */
+    const versionlessServerless = () => ({
+        serverless: true,
+        cluster: undefined,
+        serverlessVersion: undefined,
+    });
+
+    it("prompts for a missing serverless version and persists the answer", async () => {
+        const persisted: string[] = [];
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                attachedCompute: versionlessServerless,
+                promptServerlessVersion: async () => "4",
+                persistServerlessVersion: async (v) => {
+                    persisted.push(v);
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({
+            status: "ok",
+            compute: {kind: "serverless", version: "4"},
+        });
+        // Persisted so the next run does not ask again.
+        expect(persisted).to.deep.equal(["4"]);
+    });
+
+    it("reports cancelled and persists nothing when the prompt is dismissed", async () => {
+        const persisted: string[] = [];
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                attachedCompute: versionlessServerless,
+                promptServerlessVersion: async () => undefined,
+                persistServerlessVersion: async (v) => {
+                    persisted.push(v);
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({
+            status: "cancelled",
+        });
+        expect(persisted).to.have.length(0);
+    });
+
+    it("never prompts when a cluster is attached", async () => {
+        let prompted = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                attachedCompute: () => ({
+                    serverless: false,
+                    cluster: {id: "c1"},
+                    serverlessVersion: undefined,
+                }),
+                promptServerlessVersion: async () => {
+                    prompted++;
+                    return "4";
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({
+            status: "ok",
+            compute: {kind: "cluster", clusterId: "c1"},
+        });
+        expect(prompted).to.equal(0);
+    });
+
+    it("never prompts when nothing is attached", async () => {
+        // Nothing selected is a real dead end, not a missing detail: the flow
+        // must guide the user, not open a version picker.
+        let prompted = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                promptServerlessVersion: async () => {
+                    prompted++;
+                    return "4";
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({status: "none"});
+        expect(prompted).to.equal(0);
+    });
+
+    it("never prompts when serverless already has a version", async () => {
+        let prompted = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                attachedCompute: () => ({
+                    serverless: true,
+                    cluster: undefined,
+                    serverlessVersion: "5",
+                }),
+                promptServerlessVersion: async () => {
+                    prompted++;
+                    return "4";
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({
+            status: "ok",
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(prompted).to.equal(0);
+    });
+
+    it("still runs when persisting the version fails", async () => {
+        // Persistence only buys "don't ask again"; losing it must not cost the
+        // user the run they asked for.
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                attachedCompute: versionlessServerless,
+                promptServerlessVersion: async () => "4",
+                persistServerlessVersion: async () => {
+                    throw new Error("config write failed");
+                },
+            })
+        );
+
+        expect(await deps.resolveCompute()).to.deep.equal({
+            status: "ok",
+            compute: {kind: "serverless", version: "4"},
+        });
+    });
+});
+
+describe("makePythonSetupDeps saveState", () => {
     it("stamps a timestamp and forwards the persisted state", () => {
         const persisted: PythonSetupState[] = [];
         const deps = makePythonSetupDeps(
@@ -260,33 +391,6 @@ describe("makePythonSetupVisibility error handling", () => {
 });
 
 describe("makePythonSetupDeps withProgress", () => {
-    function makeWiring(
-        overrides: Partial<PythonSetupWiringDeps> = {}
-    ): PythonSetupWiringDeps {
-        return {
-            cli: {run: async () => ({}) as any},
-            projectRoot: () => "/proj",
-            isEnabled: () => true,
-            detect: async () => ({
-                primary: "uv" as const,
-                managers: ["uv" as const],
-                signals: [],
-            }),
-            attachedCompute: () => ({
-                serverless: false,
-                cluster: undefined,
-                serverlessVersion: undefined,
-            }),
-            setActiveInterpreter: async () => {},
-            persistSetupState: () => {},
-            log: {append: () => {}, show: () => {}},
-            // A reporter-less client: recordEvent short-circuits, so the setup
-            // events are inert here (they have their own tests).
-            telemetry: new Telemetry(undefined),
-            ...overrides,
-        };
-    }
-
     it("forwards streamed log chunks to the injected channel", async () => {
         const appended: string[] = [];
         const deps = makePythonSetupDeps(

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -65,7 +65,10 @@ describe("resolveComputeFrom", () => {
                 cluster: {id: "0101-clusterid"},
                 serverlessVersion: undefined,
             })
-        ).to.deep.equal({kind: "cluster", clusterId: "0101-clusterid"});
+        ).to.deep.equal({
+            status: "ok",
+            compute: {kind: "cluster", clusterId: "0101-clusterid"},
+        });
     });
 
     it("returns a serverless target with the persisted version", () => {
@@ -75,29 +78,33 @@ describe("resolveComputeFrom", () => {
                 cluster: undefined,
                 serverlessVersion: "5",
             })
-        ).to.deep.equal({kind: "serverless", version: "5"});
+        ).to.deep.equal({
+            status: "ok",
+            compute: {kind: "serverless", version: "5"},
+        });
     });
 
-    it("returns undefined for serverless without a chosen version", () => {
-        // A version-less serverless selection cannot be provisioned yet -- the
-        // compute picker sub-step (or a fallback) supplies the version.
+    it("asks for a version when serverless is attached without one", () => {
+        // The distinguishing state: compute IS selected, only the version is
+        // missing -- so the caller must resolve one rather than claim nothing
+        // is attached.
         expect(
             resolveComputeFrom({
                 serverless: true,
                 cluster: undefined,
                 serverlessVersion: undefined,
             })
-        ).to.equal(undefined);
+        ).to.deep.equal({status: "needsServerlessVersion"});
     });
 
-    it("returns undefined when no compute is selected", () => {
+    it("returns none when no compute is selected", () => {
         expect(
             resolveComputeFrom({
                 serverless: false,
                 cluster: undefined,
                 serverlessVersion: undefined,
             })
-        ).to.equal(undefined);
+        ).to.deep.equal({status: "none"});
     });
 
     it("prefers a cluster over a stale serverless version", () => {
@@ -108,7 +115,10 @@ describe("resolveComputeFrom", () => {
                 cluster: {id: "c1"},
                 serverlessVersion: "5",
             })
-        ).to.deep.equal({kind: "cluster", clusterId: "c1"});
+        ).to.deep.equal({
+            status: "ok",
+            compute: {kind: "cluster", clusterId: "c1"},
+        });
     });
 
     it("prefers a cluster even when serverless is also set", () => {
@@ -120,7 +130,25 @@ describe("resolveComputeFrom", () => {
                 cluster: {id: "c1"},
                 serverlessVersion: "5",
             })
-        ).to.deep.equal({kind: "cluster", clusterId: "c1"});
+        ).to.deep.equal({
+            status: "ok",
+            compute: {kind: "cluster", clusterId: "c1"},
+        });
+    });
+
+    it("never asks for a version when a cluster is attached without one", () => {
+        // Guards the cluster path against the version prompt leaking into it:
+        // a cluster's DBR fully determines the environment.
+        expect(
+            resolveComputeFrom({
+                serverless: true,
+                cluster: {id: "c1"},
+                serverlessVersion: undefined,
+            })
+        ).to.deep.equal({
+            status: "ok",
+            compute: {kind: "cluster", clusterId: "c1"},
+        });
     });
 });
 

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -31,25 +31,49 @@ export interface AttachedCompute {
 }
 
 /**
+ * The outcome of classifying the attached compute. `needsServerlessVersion` is
+ * deliberately distinct from `none`: serverless IS selected in that state, only
+ * the version is missing, so the caller resolves one rather than telling the
+ * user to select compute they already selected.
+ */
+export type ComputeResolution =
+    | {status: "ok"; compute: SetupCompute}
+    | {status: "needsServerlessVersion"}
+    | {status: "none"};
+
+/**
  * Map the attached compute to a setup-local compute target. Pure so the
  * cluster/serverless/none branching is unit-testable.
  *
  * A cluster attachment wins outright (its DBR fully determines the
- * environment). A serverless session resolves to its persisted version -- the
- * one the compute picker recorded (see the serverlessVersion field); without a
- * chosen version there is nothing to provision yet, so this returns undefined
- * and the orchestrator aborts silently rather than guessing.
+ * environment), so it is checked first and a missing serverless version never
+ * matters on that path. A serverless session resolves to its persisted version
+ * when one was recorded; without it this reports `needsServerlessVersion` so the
+ * caller can resolve one, because a version-less serverless selection is
+ * reachable in normal use -- a `serverlessComputeId: auto` config enables
+ * serverless without ever opening the picker, a selection made while the feature
+ * was disabled records no version, and a persisted version outside the supported
+ * range is dropped to undefined on load.
  */
 export function resolveComputeFrom(
     compute: AttachedCompute
-): SetupCompute | undefined {
+): ComputeResolution {
     if (compute.cluster) {
-        return {kind: "cluster", clusterId: compute.cluster.id};
+        return {
+            status: "ok",
+            compute: {kind: "cluster", clusterId: compute.cluster.id},
+        };
     }
-    if (compute.serverless && compute.serverlessVersion !== undefined) {
-        return {kind: "serverless", version: compute.serverlessVersion};
+    if (compute.serverless) {
+        if (compute.serverlessVersion === undefined) {
+            return {status: "needsServerlessVersion"};
+        }
+        return {
+            status: "ok",
+            compute: {kind: "serverless", version: compute.serverlessVersion},
+        };
     }
-    return undefined;
+    return {status: "none"};
 }
 
 /**
@@ -129,8 +153,15 @@ export function makePythonSetupDeps(
         cli: wiring.cli,
         projectRoot: wiring.projectRoot,
         isVisible,
-        resolveCompute: async () =>
-            resolveComputeFrom(wiring.attachedCompute()),
+        resolveCompute: async () => {
+            const resolution = resolveComputeFrom(wiring.attachedCompute());
+            // The prompt for a missing serverless version is wired in a later
+            // change; until then this state is handled like nothing-attached.
+            if (resolution.status === "needsServerlessVersion") {
+                return {status: "none"};
+            }
+            return resolution;
+        },
         adoptInterpreter: async (venvPath: string, projectRoot: string) => {
             await wiring.setActiveInterpreter(
                 venvInterpreterPath(venvPath),

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -122,6 +122,17 @@ export interface PythonSetupWiringDeps {
     isEnabled: () => boolean;
     detect: (projectRoot: string) => Promise<Detection>;
     attachedCompute: () => AttachedCompute;
+    /**
+     * Ask the user which serverless version to provision, for a serverless
+     * session that has none recorded. Returns the bare version, or undefined
+     * when the user dismisses the prompt.
+     */
+    promptServerlessVersion: () => Promise<string | undefined>;
+    /**
+     * Persist a confirmed serverless version alongside the current serverless
+     * selection, so the next run does not ask again.
+     */
+    persistServerlessVersion: (version: string) => Promise<void>;
     /** Point the MS Python extension at an interpreter path (project-scoped). */
     setActiveInterpreter: (interpreterPath: string, root: Uri) => Promise<void>;
     /** Persist the post-setup state (workspace-scoped) for drift detection. */
@@ -155,12 +166,25 @@ export function makePythonSetupDeps(
         isVisible,
         resolveCompute: async () => {
             const resolution = resolveComputeFrom(wiring.attachedCompute());
-            // The prompt for a missing serverless version is wired in a later
-            // change; until then this state is handled like nothing-attached.
-            if (resolution.status === "needsServerlessVersion") {
-                return {status: "none"};
+            if (resolution.status !== "needsServerlessVersion") {
+                return resolution;
             }
-            return resolution;
+            // Serverless is selected and only the version is missing, so ask for
+            // that rather than telling the user to select compute they have
+            // already selected.
+            const version = await wiring.promptServerlessVersion();
+            if (version === undefined) {
+                return {status: "cancelled"};
+            }
+            try {
+                await wiring.persistServerlessVersion(version);
+            } catch {
+                // Persistence only buys "don't ask again": if the config write
+                // fails the user has already told us the version, so run with it
+                // rather than discarding a confirmed answer. (The production
+                // wiring surfaces the failure itself.)
+            }
+            return {status: "ok", compute: {kind: "serverless", version}};
         },
         adoptInterpreter: async (venvPath: string, projectRoot: string) => {
             await wiring.setActiveInterpreter(

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.test.ts
@@ -1,0 +1,68 @@
+import {expect} from "chai";
+import {collectServerlessVersionObservations} from "./serverlessVersionObservations";
+
+describe("collectServerlessVersionObservations", () => {
+    it("collects bundle observations from the validate config", async () => {
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => ({
+                resources: {
+                    jobs: {
+                        /* eslint-disable-next-line @typescript-eslint/naming-convention */
+                        j: {environments: [{spec: {environment_version: "4"}}]},
+                    },
+                },
+            }),
+            // No project root, so the notebook source contributes nothing.
+            projectRoot: () => undefined,
+        });
+
+        expect(observations).to.deep.equal([
+            {version: "4", source: "bundleYaml"},
+        ]);
+    });
+
+    it("still returns the other source's evidence when the bundle read throws", async () => {
+        // Each source is guarded independently: a failing bundle read must not
+        // discard notebook evidence (that would bias the ranking toward the
+        // bare fallback).
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => {
+                throw new Error("bundle not loaded");
+            },
+            projectRoot: () => undefined,
+        });
+
+        expect(observations).to.deep.equal([]);
+    });
+
+    it("contributes nothing when no project is open", async () => {
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => undefined,
+            projectRoot: () => undefined,
+        });
+
+        expect(observations).to.deep.equal([]);
+    });
+
+    it("keeps bundle evidence when the notebook scan throws", async () => {
+        // The mirror of the guard above: a project root that blows up the
+        // notebook scan must not discard what the bundle declared.
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => ({
+                resources: {
+                    jobs: {
+                        /* eslint-disable-next-line @typescript-eslint/naming-convention */
+                        j: {environments: [{spec: {environment_version: "4"}}]},
+                    },
+                },
+            }),
+            projectRoot: () => {
+                throw new Error("no active project");
+            },
+        });
+
+        expect(observations).to.deep.equal([
+            {version: "4", source: "bundleYaml"},
+        ]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.ts
@@ -1,0 +1,56 @@
+import {VersionObservation} from "./serverlessVersionScoring";
+import {collectBundleServerlessVersions} from "./bundleServerlessVersions";
+import {collectProjectNotebookVersions} from "./projectNotebookVersions";
+
+/**
+ * Where the version evidence comes from. Injected so collection stays testable
+ * without a bundle or a workspace, and so both call sites (compute selection and
+ * the setup flow) supply their own accessors.
+ */
+export interface ServerlessVersionObservationDeps {
+    /** The parsed bundle validate config, if a bundle is loaded. */
+    getValidateConfig: () => Promise<unknown>;
+    /** The active project root, or undefined when no project is open. */
+    projectRoot: () => string | undefined;
+}
+
+/**
+ * Gather serverless-version evidence from the project's local sources (bundle
+ * config + notebooks). Each source is collected independently and guarded, so
+ * one failing source never blocks the other or the flow that asked for it; the
+ * scorer merges and de-dupes across sources.
+ *
+ * The scorer also defines a `workspaceDefault` source, which is not collected
+ * here: it would come from the workspace's default base environment, and the SDK
+ * we depend on exposes no base-environment API yet. Until it does, that weight
+ * simply never contributes and the ranking falls back to the local sources.
+ */
+export async function collectServerlessVersionObservations(
+    deps: ServerlessVersionObservationDeps
+): Promise<VersionObservation[]> {
+    const [bundle, notebooks] = await Promise.all([
+        (async () => {
+            try {
+                return collectBundleServerlessVersions(
+                    await deps.getValidateConfig()
+                );
+            } catch {
+                return [] as VersionObservation[];
+            }
+        })(),
+        (async () => {
+            try {
+                const root = deps.projectRoot();
+                if (root === undefined) {
+                    return [] as VersionObservation[];
+                }
+                return await collectProjectNotebookVersions(root);
+            } catch {
+                // No active project, or the notebook scan failed -- contribute
+                // nothing rather than blocking the flow that asked.
+                return [] as VersionObservation[];
+            }
+        })(),
+    ]);
+    return [...bundle, ...notebooks];
+}

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -1,5 +1,6 @@
 import {expect} from "chai";
 import {
+    makeServerlessVersionPrompt,
     resolveServerlessVersion,
     ServerlessVersionResolverDeps,
 } from "./serverlessVersionResolver";
@@ -92,5 +93,42 @@ describe("resolveServerlessVersion", () => {
         const version = await resolveServerlessVersion(deps);
 
         expect(version).to.equal(undefined);
+    });
+});
+
+describe("makeServerlessVersionPrompt", () => {
+    it("offers the bundle-declared version ahead of the bare fallback", async () => {
+        // End-to-end through the real collector and scorer: bundle evidence
+        // (weight 100) must outrank the always-present fallback (weight 1), so
+        // the version the project declares is the recommendation.
+        const ranked: string[][] = [];
+        const prompt = makeServerlessVersionPrompt({
+            getValidateConfig: async () => ({
+                resources: {
+                    jobs: {
+                        /* eslint-disable-next-line @typescript-eslint/naming-convention */
+                        j: {environments: [{spec: {environment_version: "4"}}]},
+                    },
+                },
+            }),
+            projectRoot: () => undefined,
+            pick: async (candidates) => {
+                ranked.push(candidates.map((c) => c.version));
+                return candidates[0].version;
+            },
+        });
+
+        expect(await prompt()).to.equal("4");
+        expect(ranked).to.deep.equal([["4", "5"]]);
+    });
+
+    it("returns undefined when the user dismisses the picker", async () => {
+        const prompt = makeServerlessVersionPrompt({
+            getValidateConfig: async () => undefined,
+            projectRoot: () => undefined,
+            pick: async () => undefined,
+        });
+
+        expect(await prompt()).to.equal(undefined);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
@@ -4,6 +4,11 @@ import {
     scoreServerlessVersions,
     VersionObservation,
 } from "./serverlessVersionScoring";
+import {
+    collectServerlessVersionObservations,
+    ServerlessVersionObservationDeps,
+} from "./serverlessVersionObservations";
+import {pickServerlessVersion} from "./serverlessVersionPicker";
 
 /**
  * Whether the user has opted into the uv-native Python environment setup.
@@ -61,4 +66,28 @@ export async function resolveServerlessVersion(
     const observations = await deps.collectObservations();
     const ranked = scoreServerlessVersions(observations);
     return deps.pick(ranked);
+}
+
+/**
+ * Build the "which serverless version should we provision?" prompt: gather the
+ * project's evidence, score it, and present the ranked candidates. Returns the
+ * confirmed bare version, or undefined when the user dismisses the picker.
+ *
+ * Exists so the callers that need the whole pipeline as one thunk (the compute
+ * picker's serverless branch, and the setup flow resolving a version that was
+ * never recorded) share a single composition rather than re-wiring the three
+ * pieces each time. `pick` is injectable, defaulting to the real QuickPick, so
+ * the composition is testable without a VS Code host.
+ */
+export function makeServerlessVersionPrompt(
+    deps: ServerlessVersionObservationDeps & {
+        pick?: ServerlessVersionResolverDeps["pick"];
+    }
+): () => Promise<string | undefined> {
+    return () =>
+        resolveServerlessVersion({
+            collectObservations: () =>
+                collectServerlessVersionObservations(deps),
+            pick: deps.pick ?? pickServerlessVersion,
+        });
 }


### PR DESCRIPTION
## Why

Pressing the uv-native "set up Python environment" entry with serverless attached
but no serverless version persisted showed:

> Select a cluster or serverless compute before setting up the environment.

…and aborted — asking the user to select compute they had already selected, with
no hint that the missing piece was a version. The feature was unreachable for
those projects.

That state is not just a legacy leftover; four live paths produce it:

1. A `serverlessComputeId: auto` config enables serverless via `updateServerless`
   without ever opening the version picker.
2. With the feature flag off, `selectServerless()` enables serverless with no
   version — enabling the flag later leaves the project version-less.
3. A persisted version failing `isSupportedVersion` (e.g. a hand-edited `"7"`) is
   silently dropped to `undefined` on load, then dead-ends on the same message.
4. A pre-existing or hand-edited `vscode.overrides.json` with `serverless: true`
   and no `serverlessVersion` key — the original repro.

## What

Ask for the version on the spot, using the scorer and picker that already exist,
persist it with the serverless selection so the question is asked once, then
continue the run.

- `resolveComputeFrom` stays pure but returns a tagged `ComputeResolution`, with
  `needsServerlessVersion` as its own state rather than another `undefined`.
- The `resolveCompute` seam returns a separate `ResolvedCompute` union whose
  `cancelled` case is distinct from `none`: dismissing the prompt stops the flow
  silently and records nothing, so the `no_compute` metric keeps meaning "the CTA
  had nothing to do" instead of absorbing deliberate bail-outs.
- Persistence reuses `connectionManager.enableServerless(version)`. That call
  only records the version *while serverless is still enabled* — then it does not
  re-attach compute, fire a compute-change event, or re-report
  `COMPUTE_SELECTED`. No `ConnectionManager` change was needed. Because the
  guarantee is conditional, `resolveCompute` re-reads the attachment after the
  prompt (below) rather than trusting the pre-prompt snapshot.
- The observation collector moved off `ConnectionCommands` into
  `serverlessVersionObservations.ts`, so compute selection and the setup flow
  share one collect → score → pick pipeline.

Prompting sits after the visibility gate and before the attempt is recorded, so
we never prompt where the feature isn't offered and user think-time stays out of
the setup-duration metric. A failed config write still lets the run proceed —
persistence only buys "don't ask again", so losing it shouldn't cost the user the
run they asked for.

The picker doesn't set `ignoreFocusOut`, so compute can change while it is open.
`resolveCompute` therefore re-classifies `attachedCompute()` once the prompt
returns and persists only while the state it asked about still holds; otherwise it
skips the write and returns the fresh resolution, so the run follows what is
attached now. Without that re-read the write is destructive rather than merely
stale: `attachCluster` calls `disableServerless()`, so `enableServerless` takes
its full branch and detaches the cluster the user just picked. The same re-read
stops a version that landed from elsewhere (a concurrent compute-picker run, a
config reload) from being overwritten by the answer to a stale question.

Path 3 above is fixed as a side effect: an out-of-range persisted version now
prompts instead of dead-ending.

## Backward compatibility

The whole feature is behind `databricks.experiments.optInto` containing
`environment.pythonSetup`, so there is no change for anyone without the opt-in.
The only persisted-state write is `serverlessVersion` — an already-shipped
overrideable key that `selectServerless` writes today — into
`.databricks/bundle/<target>/vscode.overrides.json`. No format change, no
migration. Both unions are internal to `python-setup/`.

## Verification

`yarn test:unit` — **492 passing**, up from 475 on the base commit. The 6
remaining failures (CLI embedding, profile loading) are pre-existing on `main`
and byte-identical to the baseline captured before these changes.
`yarn test:lint` clean.

17 new tests cover: prompt + persist; dismissal staying silent with zero
telemetry; the three paths that must never prompt (cluster attached, nothing
attached, serverless already versioned); a failed persist still running; the
collector's per-source guards in both directions; and the three
compute-changed-during-the-prompt cases (cluster attached, everything detached, a
version recorded elsewhere), each of which fails without the post-prompt re-read.

Not yet manually verified against a live workspace — that needs the opt-in plus a
project with `serverless: true` and no `serverlessVersion`.

This pull request and its description were written by Isaac.
