### PR TITLE
fix(shellUtils): build terminal commands for the shell that runs them (#1822)

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
+++ b/packages/databricks-vscode/src/bundle/BundleInitWizard.ts
@@ -15,7 +15,6 @@ import {getSubProjects} from "./BundleFileSet";
 import {tmpdir} from "os";
 import {ShellUtils} from "../utils";
 import {Events, Telemetry} from "../telemetry";
-import {escapePathArgument} from "../utils/shellUtils";
 import {promptToSelectActiveProjectFolder} from "./activeBundleUtils";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
 import {AiToolsManager} from "../aitools/AiToolsManager";
@@ -138,6 +137,27 @@ export class BundleInitWizard {
         parentFolder: Uri,
         authProvider: AuthProvider
     ) {
+        // The command line has to be written in the dialect of the shell that
+        // will parse it. We don't pin `shellPath` to force a known shell:
+        // supplying an executable makes VS Code drop the resolved profile's
+        // args, which is what makes macOS shells login shells.
+        const kind = ShellUtils.currentShellKind();
+
+        // cmd expands %VAR% (and !VAR! under delayed expansion) even inside
+        // double quotes, and offers no way to escape it. Rather than scaffold
+        // the project into a directory the user didn't choose, refuse.
+        if (
+            kind === "cmd" &&
+            ShellUtils.hasCmdUnsafeChars(parentFolder.fsPath)
+        ) {
+            window.showErrorMessage(
+                `Can't create a project in "${parentFolder.fsPath}": the Command Prompt shell ` +
+                    `expands "%" and "!" in paths. Choose a folder without those characters, or ` +
+                    `set "terminal.integrated.defaultProfile.windows" to PowerShell.`
+            );
+            return;
+        }
+
         const terminalDidClosePromise = new Promise<void>((resolve) => {
             const closeEvent = window.onDidCloseTerminal((t) => {
                 if (t === terminal) {
@@ -180,12 +200,26 @@ export class BundleInitWizard {
             "bundle",
             "init",
             "--output-dir",
-            escapePathArgument(parentFolder.fsPath),
+            ShellUtils.escapePathArgument(parentFolder.fsPath, kind),
         ].join(" ");
-        const initialPrompt = `clear; echo "Executing: databricks ${args}\nFollow the steps below to create your new Databricks project.\n"`;
-        const finalPrompt = `echo "\nPress any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`;
         terminal.sendText(
-            `${initialPrompt}; ${this.cli.escapedCliPath} ${args}; ${finalPrompt}`
+            [
+                ShellUtils.clearCmd(kind),
+                ShellUtils.echoLine(`Executing: databricks ${args}`, kind),
+                ShellUtils.echoLine(
+                    "Follow the steps below to create your new Databricks project.",
+                    kind
+                ),
+                ShellUtils.echoLine("", kind),
+                `${this.cli.escapedCliPathFor(kind)} ${args}`,
+                ShellUtils.echoLine("", kind),
+                ShellUtils.echoLine(
+                    "Press any key to close the terminal and continue ...",
+                    kind
+                ),
+                ShellUtils.readCmd(kind),
+                "exit",
+            ].join(ShellUtils.commandSeparator(kind))
         );
         return terminalDidClosePromise;
     }

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -26,7 +26,11 @@ import {quote} from "shell-quote";
 import {BundleVariableModel} from "../bundle/models/BundleVariableModel";
 import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
 import path from "path";
-import {isPowershell} from "../utils/shellUtils";
+import {
+    currentShellKind,
+    escapeExecutableForTerminal,
+    ShellKind,
+} from "../utils/shellUtils";
 
 const withLogContext = logging.withLogContext;
 function getEscapedCommandAndAgrs(
@@ -446,10 +450,26 @@ export class CliWrapper {
         };
     }
 
+    /**
+     * The CLI path, quoted for a shell we send it to as a command.
+     *
+     * Takes the shell kind explicitly so the escaping matches the shell that
+     * will parse the command line, rather than assuming the default profile's.
+     */
+    escapedCliPathFor(kind: ShellKind): string {
+        return escapeExecutableForTerminal(this.cliPath, kind);
+    }
+
+    /**
+     * The CLI path quoted for the *default* shell.
+     *
+     * Only correct when sending to a terminal created without `shellPath`,
+     * which is what makes the default profile the shell that parses the line.
+     * Don't use it with a reused terminal (`window.activeTerminal`): that can be
+     * running any profile, so prefer `escapedCliPathFor` with a known kind.
+     */
     get escapedCliPath(): string {
-        return isPowershell()
-            ? `& "${this.cliPath.replace('"', '\\"')}"`
-            : `'${this.cliPath.replaceAll("'", "\\'")}'`;
+        return this.escapedCliPathFor(currentShellKind());
     }
 
     /**

--- a/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
+++ b/packages/databricks-vscode/src/configuration/auth/AzureCliCheck.ts
@@ -367,14 +367,36 @@ export class AzureCliCheck implements Disposable {
             this.disposables.push(terminal);
             terminal.show();
 
-            const useDeviceCode = this.isCodeSpaces ? "--use-device-code" : "";
+            // The command line has to be written in the dialect of the shell
+            // that will parse it: `;` and `echo` are not cmd.exe syntax. The
+            // terminal is created without `shellPath`, so it runs the resolved
+            // default profile, which is what `currentShellKind` reports.
+            const kind = ShellUtils.currentShellKind();
+
+            const args = [
+                "login",
+                "--allow-no-subscriptions",
+                ...(this.isCodeSpaces ? ["--use-device-code"] : []),
+                // The tenant comes from a token's `iss` claim, so quote it
+                // rather than interpolating it into the command line bare.
+                ...(tenant
+                    ? ["-t", ShellUtils.escapePathArgument(tenant, kind)]
+                    : []),
+            ].join(" ");
 
             terminal.sendText(
-                `${
-                    this.azBinPath
-                } login --allow-no-subscriptions ${useDeviceCode} ${
-                    tenant ? "-t " + tenant : ""
-                }; echo "Press any key to close the terminal and continue ..."; ${ShellUtils.readCmd()}; exit`
+                [
+                    `${ShellUtils.escapeExecutableForTerminal(
+                        this.azBinPath,
+                        kind
+                    )} ${args}`,
+                    ShellUtils.echoLine(
+                        "Press any key to close the terminal and continue ...",
+                        kind
+                    ),
+                    ShellUtils.readCmd(kind),
+                    "exit",
+                ].join(ShellUtils.commandSeparator(kind))
             );
 
             cancellationToken?.onCancellationRequested(() =>

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -7,8 +7,8 @@ import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
 import path from "path";
 import {FeatureManager, FeatureState} from "../feature-manager/FeatureManager";
 import {
-    escapeExecutableForTerminal,
-    escapePathArgument,
+    escapeExecutableForUnknownShell,
+    escapePathArgumentForUnknownShell,
 } from "../utils/shellUtils";
 import {CustomWhenContext} from "../vscode-objs/CustomWhenContext";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
@@ -244,10 +244,15 @@ export class RunCommands {
             path.join("resources", "python", "dbconnect-bootstrap.py")
         );
         terminal.show();
+        // This reuses whatever terminal is focused, so we can't know which shell
+        // will parse the line — hence the unknown-shell quoting rather than the
+        // per-dialect helpers used where we create the terminal ourselves.
         terminal.sendText(
-            `${escapeExecutableForTerminal(executable)} ${escapePathArgument(
+            `${escapeExecutableForUnknownShell(
+                executable
+            )} ${escapePathArgumentForUnknownShell(
                 bootstrapPath
-            )} ${escapePathArgument(targetResource.fsPath)}`
+            )} ${escapePathArgumentForUnknownShell(targetResource.fsPath)}`
         );
 
         this.telemetry.recordEvent(Events.DBCONNECT_RUN, {

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -16,6 +16,25 @@ import {
     ShellKind,
 } from "./shellUtils";
 
+/**
+ * Locate `fish` on `PATH`, or return `[]` when it isn't installed.
+ *
+ * fish is neither in the CI images nor preinstalled on macOS, so the round-trips
+ * that use it must degrade to a skip rather than fail. Probing `PATH` (instead of
+ * hardcoding a path) covers Homebrew's differing Intel and Apple Silicon
+ * prefixes as well as Linux packages.
+ */
+function fishPath(): string[] {
+    const probe = spawnSync(process.platform === "win32" ? "where" : "which", [
+        "fish",
+    ]);
+    if (probe.status !== 0) {
+        return [];
+    }
+    const found = probe.stdout.toString().split("\n")[0].trim();
+    return found === "" ? [] : [found];
+}
+
 describe("shellUtils", () => {
     describe("detectShellKind", () => {
         const cases: [string, NodeJS.Platform, ShellKind][] = [
@@ -83,8 +102,11 @@ describe("shellUtils", () => {
         it("waits for a key press", () => {
             expect(readCmd("cmd")).to.equal("pause");
             expect(readCmd("powershell")).to.equal("Read-Host");
-            // Bare `read` is a usage error in dash; `read _` works everywhere.
-            expect(readCmd("posix")).to.equal("read _");
+            // An ordinary variable name is the only spelling every POSIX-ish
+            // shell accepts: bare `read` is a usage error in dash, `read _` is
+            // one in fish (`_` is read-only), and `-r` is not a fish flag. See
+            // the round-trips below, which run this in each shell.
+            expect(readCmd("posix")).to.equal("read discard");
         });
 
         it("separates commands", () => {
@@ -312,7 +334,7 @@ describe("shellUtils", () => {
                 "clear; printf '%s\\n' 'Executing: databricks bundle init --output-dir '\\''/home/me/proj'\\'''; " +
                     "printf '%s\\n' 'Follow the steps below to create your new Databricks project.'; printf '%s\\n' ''; " +
                     "'/opt/databricks' bundle init --output-dir '/home/me/proj'; " +
-                    "printf '%s\\n' ''; printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+                    "printf '%s\\n' ''; printf '%s\\n' 'Press any key to close the terminal and continue ...'; read discard; exit"
             );
         });
     });
@@ -363,14 +385,14 @@ describe("shellUtils", () => {
         it("is valid posix", () => {
             expect(azLoginCommand("az", tenant, false, "posix")).to.equal(
                 `'az' login --allow-no-subscriptions -t '${tenant}'; ` +
-                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read discard; exit"
             );
         });
 
         it("omits the tenant flag when there is no tenant", () => {
             expect(azLoginCommand("az", "", false, "posix")).to.equal(
                 "'az' login --allow-no-subscriptions; " +
-                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read discard; exit"
             );
         });
 
@@ -404,9 +426,17 @@ describe("shellUtils", () => {
     // agrees. Run the generated POSIX fragments through real shells and check
     // the output byte for byte.
     describe("posix round-trip through real shells", () => {
-        const shells = ["/bin/sh", "/bin/bash", "/bin/zsh", "/bin/dash"].filter(
-            (s) => existsSync(s)
-        );
+        // fish is included because it is *not* strictly POSIX: it rejects
+        // `read _` (`_` is read-only) and treats `\` inside single quotes as an
+        // escape. It ships in neither CI image nor macOS, so it is probed for on
+        // `PATH` rather than at a fixed location.
+        const shells = [
+            "/bin/sh",
+            "/bin/bash",
+            "/bin/zsh",
+            "/bin/dash",
+            ...fishPath(),
+        ].filter((s) => existsSync(s));
 
         const awkward = [
             "plain",
@@ -452,15 +482,30 @@ describe("shellUtils", () => {
             it(`readCmd is not a usage error in ${shell}`, () => {
                 // With stdin at EOF, `read` legitimately fails (exit 1). What
                 // must not happen is a *usage* error: bare `read` in dash is
-                // "read: arg count", exit 2, printed to stderr. That fails the
-                // hold-open step, so the following `exit` closes the terminal
-                // and discards the CLI error we were keeping on screen.
+                // "read: arg count", exit 2, and `read _` in fish is
+                // "cannot overwrite read-only variable", also exit 2. That fails
+                // the hold-open step, so the following `exit` closes the
+                // terminal and discards the CLI error we were keeping on screen.
                 const result = spawnSync(shell, ["-c", readCmd("posix")], {
                     encoding: "utf8",
                     stdio: ["ignore", "pipe", "pipe"],
                 });
                 expect(result.stderr).to.equal("");
                 expect(result.status).to.not.equal(2);
+            });
+
+            it(`readCmd consumes a line silently in ${shell}`, () => {
+                // The pause must swallow the keypress, not print it. Bare `read`
+                // in fish exits 0 with empty stderr — so the usage-error check
+                // above passes — yet echoes the line back, corrupting the
+                // terminal with a stray copy of whatever the user typed.
+                const result = spawnSync(shell, ["-c", readCmd("posix")], {
+                    encoding: "utf8",
+                    input: "keypress\n",
+                });
+                expect(result.stdout).to.equal("");
+                expect(result.stderr).to.equal("");
+                expect(result.status).to.equal(0);
             });
         });
     });

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -88,7 +88,9 @@ describe("shellUtils", () => {
         });
 
         it("separates commands", () => {
-            expect(commandSeparator("cmd")).to.equal(" & ");
+            // No leading space: cmd's `echo` prints the rest of the line raw,
+            // so `echo one & ...` would print "one" with a trailing space.
+            expect(commandSeparator("cmd")).to.equal("& ");
             expect(commandSeparator("powershell")).to.equal("; ");
             expect(commandSeparator("posix")).to.equal("; ");
         });
@@ -200,6 +202,40 @@ describe("shellUtils", () => {
             );
         });
 
+        it("escapes cmd's operators outside quotes with a caret", () => {
+            // Unescaped, cmd parses these as operators rather than text, so it
+            // tries to run the following word as a command.
+            expect(
+                echoLine("amp & pipe | gt > lt < paren ( )", "cmd")
+            ).to.equal("echo amp ^& pipe ^| gt ^> lt ^< paren ^( ^)");
+            // `^` is the escape character, so it escapes itself.
+            expect(echoLine("caret ^ here", "cmd")).to.equal(
+                "echo caret ^^ here"
+            );
+            // The other shells quote instead, so they need no caret.
+            expect(echoLine("amp & pipe |", "posix")).to.equal(
+                "printf '%s\\n' 'amp & pipe |'"
+            );
+        });
+
+        it("leaves cmd's operators alone inside quotes", () => {
+            // This is the shape the bundle-init banner actually has: an already
+            // double-quoted path. cmd treats operators inside quotes as text, and
+            // a `^` there would *print*, so the quoted run must pass through
+            // untouched while operators outside it are still escaped.
+            expect(
+                echoLine(
+                    'Executing: databricks bundle init --output-dir "C:\\a&b\\proj"',
+                    "cmd"
+                )
+            ).to.equal(
+                'echo Executing: databricks bundle init --output-dir "C:\\a&b\\proj"'
+            );
+            expect(echoLine('before & "in&side" after & x', "cmd")).to.equal(
+                'echo before ^& "in&side" after ^& x'
+            );
+        });
+
         it("prints a blank line", () => {
             expect(echoLine("", "cmd")).to.equal("echo.");
             expect(echoLine("", "posix")).to.equal("printf '%s\\n' ''");
@@ -247,10 +283,10 @@ describe("shellUtils", () => {
                     "cmd"
                 )
             ).to.equal(
-                'cls & echo Executing: databricks bundle init --output-dir "C:\\Users\\me\\proj" & ' +
-                    "echo Follow the steps below to create your new Databricks project. & echo. & " +
-                    '"C:\\ext\\bin\\databricks.exe" bundle init --output-dir "C:\\Users\\me\\proj" & ' +
-                    "echo. & echo Press any key to close the terminal and continue ... & pause & exit"
+                'cls& echo Executing: databricks bundle init --output-dir "C:\\Users\\me\\proj"& ' +
+                    "echo Follow the steps below to create your new Databricks project.& echo.& " +
+                    '"C:\\ext\\bin\\databricks.exe" bundle init --output-dir "C:\\Users\\me\\proj"& ' +
+                    "echo.& echo Press any key to close the terminal and continue ...& pause& exit"
             );
         });
 
@@ -312,8 +348,8 @@ describe("shellUtils", () => {
 
         it("is valid cmd", () => {
             expect(azLoginCommand("az", tenant, false, "cmd")).to.equal(
-                `"az" login --allow-no-subscriptions -t "${tenant}" & ` +
-                    "echo Press any key to close the terminal and continue ... & pause & exit"
+                `"az" login --allow-no-subscriptions -t "${tenant}"& ` +
+                    "echo Press any key to close the terminal and continue ...& pause& exit"
             );
         });
 
@@ -460,17 +496,6 @@ describe("shellUtils", () => {
             "amp & pipe | redirect > caret ^",
             "paren (grouped) and `backtick`",
         ];
-
-        /** The ASCII escape character that starts an ANSI sequence. */
-        const ESC = String.fromCharCode(27);
-
-        /** Strip ANSI escape sequences, e.g. the ones `Clear-Host` emits. */
-        function stripAnsi(text: string): string {
-            return text
-                .split(ESC)
-                .join("")
-                .replace(/\[[0-9;]*[A-Za-z]/g, "");
-        }
 
         /**
          * Drop stderr output that says nothing about whether our command line
@@ -657,14 +682,35 @@ describe("shellUtils", () => {
                 ).to.deep.equal(["ran"]);
             });
 
-            psIt("clearCmd clears and does not swallow what follows", () => {
-                // Clear-Host writes the clear sequences to stdout rather than
-                // driving a TTY, so assert on them: their presence is the proof
-                // it actually cleared, and "ok" after them is the proof the
-                // separator didn't swallow the next command.
-                const [line] = runPs([clearCmd("powershell"), "Write-Host ok"]);
-                expect(line).to.contain(ESC);
-                expect(stripAnsi(line)).to.equal("ok");
+            psIt("clearCmd resolves as a PowerShell command", () => {
+                // Ask PowerShell to resolve the verb rather than run it. Running
+                // it proves little: `clear` is also a valid command on Linux
+                // pwsh, so a POSIX verb leaking into the PowerShell branch would
+                // still exit 0 here, and whether Clear-Host emits its escape
+                // sequences depends on the detected terminal capabilities (they
+                // appear with $TERM set, and not on a TTY-less CI runner).
+                // Assert on the resolved name only. The command *type* varies
+                // (Clear-Host is a Function in pwsh 7 but a Cmdlet in Windows
+                // PowerShell 5), whereas a POSIX `clear` leaking into this
+                // branch resolves to an Application named `clear` on Linux and
+                // fails to resolve at all on Windows.
+                expect(
+                    runPs([
+                        `(Get-Command ${clearCmd(
+                            "powershell"
+                        )}).Name.ToString()`,
+                    ])
+                ).to.deep.equal([clearCmd("powershell")]);
+            });
+
+            psIt("the separator does not swallow what follows", () => {
+                // Deliberately not `Clear-Host` here: with no console attached
+                // it throws "The handle is invalid" on Windows, which is about
+                // the runner's environment rather than our command line. Its
+                // resolution is covered by the test above.
+                expect(
+                    runPs(["Write-Host first", "Write-Host ok"])
+                ).to.deep.equal(["first", "ok"]);
             });
         });
     });

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -281,6 +281,89 @@ describe("shellUtils", () => {
         });
     });
 
+    describe("the az login command line", () => {
+        // Mirrors what AzureCliCheck assembles. Same hardcoded-POSIX defect as
+        // the bundle init line: `;` and `echo` are not cmd syntax, so `az login`
+        // was broken on cmd.exe too.
+        function azLoginCommand(
+            azBinPath: string,
+            tenant: string,
+            useDeviceCode: boolean,
+            kind: ShellKind
+        ): string {
+            const args = [
+                "login",
+                "--allow-no-subscriptions",
+                ...(useDeviceCode ? ["--use-device-code"] : []),
+                ...(tenant ? ["-t", escapePathArgument(tenant, kind)] : []),
+            ].join(" ");
+            return [
+                `${escapeExecutableForTerminal(azBinPath, kind)} ${args}`,
+                echoLine(
+                    "Press any key to close the terminal and continue ...",
+                    kind
+                ),
+                readCmd(kind),
+                "exit",
+            ].join(commandSeparator(kind));
+        }
+
+        const tenant = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+
+        it("is valid cmd", () => {
+            expect(azLoginCommand("az", tenant, false, "cmd")).to.equal(
+                `"az" login --allow-no-subscriptions -t "${tenant}" & ` +
+                    "echo Press any key to close the terminal and continue ... & pause & exit"
+            );
+        });
+
+        it("is valid powershell", () => {
+            expect(azLoginCommand("az", tenant, false, "powershell")).to.equal(
+                `& 'az' login --allow-no-subscriptions -t '${tenant}'; ` +
+                    "Write-Host 'Press any key to close the terminal and continue ...'; Read-Host; exit"
+            );
+        });
+
+        it("is valid posix", () => {
+            expect(azLoginCommand("az", tenant, false, "posix")).to.equal(
+                `'az' login --allow-no-subscriptions -t '${tenant}'; ` +
+                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+            );
+        });
+
+        it("omits the tenant flag when there is no tenant", () => {
+            expect(azLoginCommand("az", "", false, "posix")).to.equal(
+                "'az' login --allow-no-subscriptions; " +
+                    "printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+            );
+        });
+
+        it("adds --use-device-code in codespaces", () => {
+            expect(azLoginCommand("az", "", true, "posix")).to.contain(
+                "login --allow-no-subscriptions --use-device-code;"
+            );
+        });
+
+        it("quotes an absolute az path with spaces", () => {
+            expect(
+                azLoginCommand(
+                    "C:\\Program Files\\Azure CLI\\az.cmd",
+                    "",
+                    false,
+                    "cmd"
+                )
+            ).to.contain('"C:\\Program Files\\Azure CLI\\az.cmd" login');
+        });
+
+        it("quotes the tenant, which comes from a token claim", () => {
+            // Not attacker-controlled in practice, but it is external data
+            // reaching a command line, so it must not be able to inject.
+            expect(
+                azLoginCommand("az", "a'b$(id)c", false, "posix")
+            ).to.contain("-t 'a'\\''b$(id)c'");
+        });
+    });
+
     // String equality only proves we built what we intended, not that a shell
     // agrees. Run the generated POSIX fragments through real shells and check
     // the output byte for byte.

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -461,7 +461,42 @@ describe("shellUtils", () => {
             "paren (grouped) and `backtick`",
         ];
 
-        describe("cmd", () => {
+        /** The ASCII escape character that starts an ANSI sequence. */
+        const ESC = String.fromCharCode(27);
+
+        /** Strip ANSI escape sequences, e.g. the ones `Clear-Host` emits. */
+        function stripAnsi(text: string): string {
+            return text
+                .split(ESC)
+                .join("")
+                .replace(/\[[0-9;]*[A-Za-z]/g, "");
+        }
+
+        /**
+         * Drop stderr output that says nothing about whether our command line
+         * was correct.
+         *
+         * `Clear-Host` on Linux shells out to `clear`, which needs `$TERM`;
+         * under CI there is no TTY, so it warns. The command still parses and
+         * still exits 0 — asserting raw-empty stderr would fail on the
+         * environment rather than on the code under test.
+         */
+        function stripBenignStderr(stderr: string): string {
+            return stderr
+                .split(/\r?\n/)
+                .filter(
+                    (line) =>
+                        line.trim() !== "" &&
+                        !/TERM environment variable not set/i.test(line)
+                )
+                .join("\n");
+        }
+
+        describe("cmd", function () {
+            // Each case spawns cmd.exe and writes a temp file, so the 2s default
+            // is too tight on a loaded Windows runner.
+            this.timeout(60_000);
+
             const cmdIt = onWindows ? it : it.skip;
 
             // Run a generated line through cmd via a temp .cmd file rather than
@@ -481,7 +516,7 @@ describe("shellUtils", () => {
                         stdio: ["pipe", "pipe", "pipe"],
                         input: "",
                     });
-                    expect(result.stderr).to.equal("");
+                    expect(stripBenignStderr(result.stderr)).to.equal("");
                     expect(result.status).to.equal(0);
                     return result.stdout;
                 } finally {
@@ -538,11 +573,16 @@ describe("shellUtils", () => {
             });
         });
 
-        describe("powershell", () => {
+        describe("powershell", function () {
+            // A PowerShell cold start is ~0.5-1s, an order of magnitude slower
+            // than the POSIX shells above, so the 2s default is not enough even
+            // for a couple of spawns on a loaded CI runner.
+            this.timeout(60_000);
+
             // Prefer pwsh (6+, cross-platform) wherever it's on PATH, and fall
             // back to the built-in Windows PowerShell. Probing rather than
             // checking the platform means a machine with pwsh installed runs
-            // these for real instead of skipping.
+            // these for real instead of skipping — the Linux CI runner has it.
             const psExe = ((): string | undefined => {
                 for (const candidate of ["pwsh", "powershell.exe"]) {
                     const probe = spawnSync(
@@ -560,71 +600,71 @@ describe("shellUtils", () => {
             })();
             const psIt = psExe ? it : it.skip;
 
+            /**
+             * Run one PowerShell script and return its stdout lines.
+             *
+             * Batching every case into a single invocation keeps these tests
+             * off the per-spawn startup cost, and joining with our own
+             * `commandSeparator` means the separator is exercised too.
+             */
+            function runPs(commands: string[]): string[] {
+                const result = spawnSync(
+                    psExe!,
+                    [
+                        "-NoProfile",
+                        "-Command",
+                        commands.join(commandSeparator("powershell")),
+                    ],
+                    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                );
+                expect(stripBenignStderr(result.stderr)).to.equal("");
+                expect(result.status).to.equal(0);
+                return result.stdout.replace(/\r?\n$/, "").split(/\r?\n/);
+            }
+
             psIt("echoLine prints each message verbatim", () => {
-                awkwardMessages.forEach((message) => {
-                    const out = execFileSync(
-                        psExe!,
-                        [
-                            "-NoProfile",
-                            "-Command",
-                            echoLine(message, "powershell"),
-                        ],
-                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
-                    );
-                    expect(out.replace(/\r?\n$/, "")).to.equal(message);
-                });
+                expect(
+                    runPs(awkwardMessages.map((m) => echoLine(m, "powershell")))
+                ).to.deep.equal(awkwardMessages);
             });
 
             psIt("escapePathArgument does not interpolate", () => {
-                awkwardWinPaths.forEach((p) => {
-                    // Single quotes are literal in PowerShell; with double
-                    // quotes `$VAR` would vanish and `$(cmd)` would execute.
-                    const out = execFileSync(
-                        psExe!,
-                        [
-                            "-NoProfile",
-                            "-Command",
-                            `Write-Host -NoNewline ${escapePathArgument(
-                                p,
-                                "powershell"
-                            )}`,
-                        ],
-                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
-                    );
-                    expect(out).to.equal(p);
-                });
+                // Single quotes are literal in PowerShell; with double quotes
+                // `$VAR` would vanish and `$(cmd)` would execute.
+                expect(
+                    runPs(
+                        awkwardWinPaths.map(
+                            (p) =>
+                                `Write-Host ${escapePathArgument(
+                                    p,
+                                    "powershell"
+                                )}`
+                        )
+                    )
+                ).to.deep.equal(awkwardWinPaths);
             });
 
             psIt("escapeExecutableForTerminal invokes the executable", () => {
                 // The `&` call operator is what makes a quoted path run rather
                 // than just echo back as a string.
-                const out = execFileSync(
-                    psExe!,
-                    [
-                        "-NoProfile",
-                        "-Command",
+                expect(
+                    runPs([
                         `${escapeExecutableForTerminal(
                             process.execPath,
                             "powershell"
                         )} -e "process.stdout.write('ran')"`,
-                    ],
-                    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
-                );
-                expect(out).to.equal("ran");
+                    ])
+                ).to.deep.equal(["ran"]);
             });
 
-            psIt("clearCmd and the separator parse", () => {
-                const line = [clearCmd("powershell"), "Write-Host ok"].join(
-                    commandSeparator("powershell")
-                );
-                const result = spawnSync(
-                    psExe!,
-                    ["-NoProfile", "-Command", line],
-                    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
-                );
-                expect(result.stderr).to.equal("");
-                expect(result.status).to.equal(0);
-                expect(result.stdout).to.contain("ok");
+            psIt("clearCmd clears and does not swallow what follows", () => {
+                // Clear-Host writes the clear sequences to stdout rather than
+                // driving a TTY, so assert on them: their presence is the proof
+                // it actually cleared, and "ok" after them is the proof the
+                // separator didn't swallow the next command.
+                const [line] = runPs([clearCmd("powershell"), "Write-Host ok"]);
+                expect(line).to.contain(ESC);
+                expect(stripAnsi(line)).to.equal("ok");
             });
         });
     });

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -1,0 +1,548 @@
+import {expect} from "chai";
+import {execFileSync, spawnSync} from "node:child_process";
+import {existsSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import path from "node:path";
+import {
+    clearCmd,
+    commandSeparator,
+    detectShellKind,
+    echoLine,
+    escapeExecutableForTerminal,
+    escapePathArgument,
+    escapePathArgumentForUnknownShell,
+    hasCmdUnsafeChars,
+    readCmd,
+    ShellKind,
+} from "./shellUtils";
+
+describe("shellUtils", () => {
+    describe("detectShellKind", () => {
+        const cases: [string, NodeJS.Platform, ShellKind][] = [
+            ["C:\\Windows\\System32\\cmd.exe", "win32", "cmd"],
+            ["cmd.exe", "win32", "cmd"],
+            [
+                "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "win32",
+                "powershell",
+            ],
+            // pwsh (PowerShell 6+) is the default on modern Windows and was
+            // classified as posix before this fix, so it got POSIX `read`.
+            [
+                "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+                "win32",
+                "powershell",
+            ],
+            ["pwsh", "darwin", "powershell"],
+            ["pwsh-preview", "win32", "powershell"],
+            ["C:\\Program Files\\Git\\bin\\bash.exe", "win32", "posix"],
+            ["C:\\Windows\\System32\\wsl.exe", "win32", "posix"],
+            ["/bin/bash", "linux", "posix"],
+            ["/bin/zsh", "darwin", "posix"],
+            ["/usr/bin/fish", "linux", "posix"],
+            ["/bin/dash", "linux", "posix"],
+            ["/bin/sh", "linux", "posix"],
+        ];
+
+        cases.forEach(([shell, platform, expected]) => {
+            it(`classifies ${shell} on ${platform} as ${expected}`, () => {
+                expect(detectShellKind(shell, platform)).to.equal(expected);
+            });
+        });
+
+        it("matches on the basename, not a substring of the path", () => {
+            // "cmd" appears in the directory, but this is bash.
+            expect(
+                detectShellKind(
+                    "C:\\cmder\\vendor\\git-for-windows\\bin\\bash.exe",
+                    "win32"
+                )
+            ).to.equal("posix");
+        });
+
+        it("does not treat a windows shell name as windows-only", () => {
+            expect(detectShellKind("/usr/local/bin/cmd", "linux")).to.equal(
+                "cmd"
+            );
+        });
+
+        it("falls back to the platform default for an empty shell", () => {
+            expect(detectShellKind("", "win32")).to.equal("powershell");
+            expect(detectShellKind("", "darwin")).to.equal("posix");
+            expect(detectShellKind("", "linux")).to.equal("posix");
+        });
+    });
+
+    describe("per-shell verbs", () => {
+        it("clears the screen", () => {
+            expect(clearCmd("cmd")).to.equal("cls");
+            expect(clearCmd("powershell")).to.equal("Clear-Host");
+            expect(clearCmd("posix")).to.equal("clear");
+        });
+
+        it("waits for a key press", () => {
+            expect(readCmd("cmd")).to.equal("pause");
+            expect(readCmd("powershell")).to.equal("Read-Host");
+            // Bare `read` is a usage error in dash; `read _` works everywhere.
+            expect(readCmd("posix")).to.equal("read _");
+        });
+
+        it("separates commands", () => {
+            expect(commandSeparator("cmd")).to.equal(" & ");
+            expect(commandSeparator("powershell")).to.equal("; ");
+            expect(commandSeparator("posix")).to.equal("; ");
+        });
+    });
+
+    describe("escapePathArgument", () => {
+        it("quotes plain paths", () => {
+            expect(escapePathArgument("C:\\a b\\c", "cmd")).to.equal(
+                '"C:\\a b\\c"'
+            );
+            expect(escapePathArgument("C:\\a b\\c", "powershell")).to.equal(
+                "'C:\\a b\\c'"
+            );
+            expect(escapePathArgument("/a b/c", "posix")).to.equal("'/a b/c'");
+        });
+
+        it("uses single quotes so powershell does not interpolate", () => {
+            // With double quotes PowerShell would run `whoami` here.
+            expect(
+                escapePathArgument("C:\\a$(whoami)b", "powershell")
+            ).to.equal("'C:\\a$(whoami)b'");
+            // ...and would expand $RECYCLE to nothing.
+            expect(
+                escapePathArgument("C:\\Users\\me\\$RECYCLE.BIN", "powershell")
+            ).to.equal("'C:\\Users\\me\\$RECYCLE.BIN'");
+        });
+
+        it("escapes every embedded quote, not just the first", () => {
+            expect(escapePathArgument("/a'b'c", "posix")).to.equal(
+                "'/a'\\''b'\\''c'"
+            );
+            expect(escapePathArgument("C:\\a'b'c", "powershell")).to.equal(
+                "'C:\\a''b''c'"
+            );
+            expect(escapePathArgument('C:\\a"b"c', "cmd")).to.equal(
+                '"C:\\a""b""c"'
+            );
+        });
+
+        it("leaves shell metacharacters literal", () => {
+            expect(escapePathArgument("/a$VAR`x$(y)&z|w>v", "posix")).to.equal(
+                "'/a$VAR`x$(y)&z|w>v'"
+            );
+        });
+    });
+
+    describe("escapeExecutableForTerminal", () => {
+        it("prefixes powershell with the call operator", () => {
+            expect(
+                escapeExecutableForTerminal(
+                    "C:\\a b\\databricks.exe",
+                    "powershell"
+                )
+            ).to.equal("& 'C:\\a b\\databricks.exe'");
+        });
+
+        it("just quotes elsewhere", () => {
+            expect(
+                escapeExecutableForTerminal("C:\\a b\\databricks.exe", "cmd")
+            ).to.equal('"C:\\a b\\databricks.exe"');
+            expect(
+                escapeExecutableForTerminal("/opt/a b/databricks", "posix")
+            ).to.equal("'/opt/a b/databricks'");
+        });
+    });
+
+    describe("escapePathArgumentForUnknownShell", () => {
+        // For reused terminals we can't know the dialect, so we keep main's
+        // double quotes: they parse in cmd, PowerShell and POSIX alike. Single
+        // quotes would break a cmd tab, which cmd reads as literal characters.
+        it("uses double quotes so the line parses in any shell", () => {
+            expect(
+                escapePathArgumentForUnknownShell("C:\\Python\\python.exe")
+            ).to.equal('"C:\\Python\\python.exe"');
+            expect(
+                escapePathArgumentForUnknownShell("/usr/bin/my python")
+            ).to.equal('"/usr/bin/my python"');
+        });
+
+        it("escapes embedded double quotes", () => {
+            expect(escapePathArgumentForUnknownShell('/a"b')).to.equal(
+                '"/a\\"b"'
+            );
+        });
+    });
+
+    describe("hasCmdUnsafeChars", () => {
+        it("flags characters cmd expands inside quotes", () => {
+            expect(hasCmdUnsafeChars("C:\\p%TEMP%q")).to.equal(true);
+            expect(hasCmdUnsafeChars("C:\\p!VAR!q")).to.equal(true);
+        });
+
+        it("passes ordinary paths", () => {
+            expect(hasCmdUnsafeChars("C:\\Users\\me\\project")).to.equal(false);
+            expect(hasCmdUnsafeChars("C:\\a b\\c-d_e.f")).to.equal(false);
+        });
+    });
+
+    describe("echoLine", () => {
+        it("prints a line per shell", () => {
+            expect(echoLine("hello world", "cmd")).to.equal("echo hello world");
+            expect(echoLine("hello world", "powershell")).to.equal(
+                "Write-Host 'hello world'"
+            );
+            // printf, not echo: zsh/dash `echo` interprets backslash escapes
+            // even inside single quotes.
+            expect(echoLine("hello world", "posix")).to.equal(
+                "printf '%s\\n' 'hello world'"
+            );
+        });
+
+        it("prints a blank line", () => {
+            expect(echoLine("", "cmd")).to.equal("echo.");
+            expect(echoLine("", "posix")).to.equal("printf '%s\\n' ''");
+        });
+    });
+
+    describe("the bundle init command line", () => {
+        // Mirrors what BundleInitWizard assembles, so the shipped string for
+        // each shell is reviewable here.
+        function bundleInitCommand(
+            cliPath: string,
+            outputDir: string,
+            kind: ShellKind
+        ): string {
+            const args = [
+                "bundle",
+                "init",
+                "--output-dir",
+                escapePathArgument(outputDir, kind),
+            ].join(" ");
+            return [
+                clearCmd(kind),
+                echoLine(`Executing: databricks ${args}`, kind),
+                echoLine(
+                    "Follow the steps below to create your new Databricks project.",
+                    kind
+                ),
+                echoLine("", kind),
+                `${escapeExecutableForTerminal(cliPath, kind)} ${args}`,
+                echoLine("", kind),
+                echoLine(
+                    "Press any key to close the terminal and continue ...",
+                    kind
+                ),
+                readCmd(kind),
+                "exit",
+            ].join(commandSeparator(kind));
+        }
+
+        it("is valid cmd (the #1822 case)", () => {
+            expect(
+                bundleInitCommand(
+                    "C:\\ext\\bin\\databricks.exe",
+                    "C:\\Users\\me\\proj",
+                    "cmd"
+                )
+            ).to.equal(
+                'cls & echo Executing: databricks bundle init --output-dir "C:\\Users\\me\\proj" & ' +
+                    "echo Follow the steps below to create your new Databricks project. & echo. & " +
+                    '"C:\\ext\\bin\\databricks.exe" bundle init --output-dir "C:\\Users\\me\\proj" & ' +
+                    "echo. & echo Press any key to close the terminal and continue ... & pause & exit"
+            );
+        });
+
+        it("is valid powershell", () => {
+            expect(
+                bundleInitCommand(
+                    "C:\\ext\\bin\\databricks.exe",
+                    "C:\\Users\\me\\proj",
+                    "powershell"
+                )
+            ).to.equal(
+                "Clear-Host; Write-Host 'Executing: databricks bundle init --output-dir ''C:\\Users\\me\\proj'''; " +
+                    "Write-Host 'Follow the steps below to create your new Databricks project.'; Write-Host ''; " +
+                    "& 'C:\\ext\\bin\\databricks.exe' bundle init --output-dir 'C:\\Users\\me\\proj'; " +
+                    "Write-Host ''; Write-Host 'Press any key to close the terminal and continue ...'; Read-Host; exit"
+            );
+        });
+
+        it("is valid posix", () => {
+            expect(
+                bundleInitCommand("/opt/databricks", "/home/me/proj", "posix")
+            ).to.equal(
+                "clear; printf '%s\\n' 'Executing: databricks bundle init --output-dir '\\''/home/me/proj'\\'''; " +
+                    "printf '%s\\n' 'Follow the steps below to create your new Databricks project.'; printf '%s\\n' ''; " +
+                    "'/opt/databricks' bundle init --output-dir '/home/me/proj'; " +
+                    "printf '%s\\n' ''; printf '%s\\n' 'Press any key to close the terminal and continue ...'; read _; exit"
+            );
+        });
+    });
+
+    // String equality only proves we built what we intended, not that a shell
+    // agrees. Run the generated POSIX fragments through real shells and check
+    // the output byte for byte.
+    describe("posix round-trip through real shells", () => {
+        const shells = ["/bin/sh", "/bin/bash", "/bin/zsh", "/bin/dash"].filter(
+            (s) => existsSync(s)
+        );
+
+        const awkward = [
+            "plain",
+            "with spaces",
+            "it's quoted",
+            'double "quotes"',
+            "$VAR and ${BRACED}",
+            "$(whoami) and `id`",
+            "amp & pipe | redirect > semi ;",
+            "back\\slash and \\t tab-ish",
+            "percent %s %d",
+            "tilde ~ star * question ?",
+        ];
+
+        shells.forEach((shell) => {
+            it(`echoLine round-trips verbatim in ${shell}`, () => {
+                awkward.forEach((message) => {
+                    const out = execFileSync(
+                        shell,
+                        ["-c", echoLine(message, "posix")],
+                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                    );
+                    expect(out).to.equal(`${message}\n`);
+                });
+            });
+
+            it(`escapePathArgument round-trips verbatim in ${shell}`, () => {
+                awkward.forEach((arg) => {
+                    // `printf %s` on the escaped argument: if quoting is wrong
+                    // the shell splits, expands, or fails to parse.
+                    const out = execFileSync(
+                        shell,
+                        [
+                            "-c",
+                            `printf '%s' ${escapePathArgument(arg, "posix")}`,
+                        ],
+                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                    );
+                    expect(out).to.equal(arg);
+                });
+            });
+
+            it(`readCmd is not a usage error in ${shell}`, () => {
+                // With stdin at EOF, `read` legitimately fails (exit 1). What
+                // must not happen is a *usage* error: bare `read` in dash is
+                // "read: arg count", exit 2, printed to stderr. That fails the
+                // hold-open step, so the following `exit` closes the terminal
+                // and discards the CLI error we were keeping on screen.
+                const result = spawnSync(shell, ["-c", readCmd("posix")], {
+                    encoding: "utf8",
+                    stdio: ["ignore", "pipe", "pipe"],
+                });
+                expect(result.stderr).to.equal("");
+                expect(result.status).to.not.equal(2);
+            });
+        });
+    });
+
+    // The cmd/PowerShell half of the round-trip layer. These are the shells
+    // #1822 is actually about, so without them those branches are only covered
+    // by string equality — which cannot catch a verb that doesn't exist or
+    // quoting the shell disagrees with.
+    //
+    // cmd only exists on Windows (the CI matrix has a windows-server-latest
+    // runner). PowerShell is probed for rather than gated on the platform, so
+    // these also run wherever `pwsh` is installed, including Linux and macOS.
+    describe("cmd and powershell round-trip through real shells", () => {
+        const onWindows = process.platform === "win32";
+
+        // Paths cmd and PowerShell accept literally: no `%`/`!` (cmd expands
+        // those and we reject them upstream), no chars illegal in NTFS names.
+        const awkwardWinPaths = [
+            "C:\\plain\\proj",
+            "C:\\with spaces\\my proj",
+            "C:\\a'b\\quoted",
+            "C:\\a$VAR\\dollar",
+            "C:\\a(paren)b\\proj",
+            "C:\\a&b\\amp",
+            "C:\\a;b\\semi",
+        ];
+
+        const awkwardMessages = [
+            "plain",
+            "with spaces",
+            "it's quoted",
+            "$VAR and $(cmd)",
+            "amp & pipe | redirect > caret ^",
+            "paren (grouped) and `backtick`",
+        ];
+
+        describe("cmd", () => {
+            const cmdIt = onWindows ? it : it.skip;
+
+            // Run a generated line through cmd via a temp .cmd file rather than
+            // `cmd /c <line>`: passing it as an argv entry would let Node apply
+            // its own Windows quoting, which escapes an embedded `"` as `\"` —
+            // a sequence cmd does not understand, so the test would be
+            // measuring Node's escaping instead of ours.
+            function runCmd(line: string): string {
+                const file = path.join(
+                    mkdtempSync(path.join(tmpdir(), "shellutils-")),
+                    "run.cmd"
+                );
+                writeFileSync(file, `@echo off\r\n${line}\r\n`);
+                try {
+                    const result = spawnSync("cmd.exe", ["/d", "/c", file], {
+                        encoding: "utf8",
+                        stdio: ["pipe", "pipe", "pipe"],
+                        input: "",
+                    });
+                    expect(result.stderr).to.equal("");
+                    expect(result.status).to.equal(0);
+                    return result.stdout;
+                } finally {
+                    rmSync(path.dirname(file), {
+                        recursive: true,
+                        force: true,
+                    });
+                }
+            }
+
+            cmdIt("echoLine prints each message verbatim", () => {
+                awkwardMessages.forEach((message) => {
+                    expect(
+                        runCmd(echoLine(message, "cmd")).replace(/\r?\n$/, "")
+                    ).to.equal(message);
+                });
+            });
+
+            cmdIt("echoLine('') prints a blank line", () => {
+                // Plain `echo` would print "ECHO is off." instead.
+                expect(runCmd(echoLine("", "cmd"))).to.equal("\r\n");
+            });
+
+            cmdIt("escapePathArgument stays one literal argument", () => {
+                awkwardWinPaths.forEach((p) => {
+                    // Echo the quoted path back through cmd. If the quoting is
+                    // wrong, `&`/`;`/spaces split it or cmd reports a parse
+                    // error, which runCmd's status/stderr assertions catch.
+                    const out = runCmd(
+                        `echo ${escapePathArgument(p, "cmd")}`
+                    ).replace(/\r?\n$/, "");
+                    // cmd's `echo` keeps the quotes it was given.
+                    expect(out).to.equal(`"${p}"`);
+                });
+            });
+
+            cmdIt("the command separator chains commands", () => {
+                const line = ["echo one", "echo two"].join(
+                    commandSeparator("cmd")
+                );
+                expect(runCmd(line).replace(/\r\n/g, "\n")).to.equal(
+                    "one\ntwo\n"
+                );
+            });
+
+            cmdIt("clearCmd and readCmd are real cmd verbs", () => {
+                // `cls` and `pause` are the two verbs #1822 got wrong: the
+                // POSIX `clear`/`read` it sent don't exist here. runCmd
+                // asserts exit 0 and empty stderr, which is what a
+                // "not recognized as an internal or external command" would
+                // violate. `pause` gets EOF on stdin so it can't hang.
+                runCmd(clearCmd("cmd"));
+                runCmd(readCmd("cmd"));
+            });
+        });
+
+        describe("powershell", () => {
+            // Prefer pwsh (6+, cross-platform) wherever it's on PATH, and fall
+            // back to the built-in Windows PowerShell. Probing rather than
+            // checking the platform means a machine with pwsh installed runs
+            // these for real instead of skipping.
+            const psExe = ((): string | undefined => {
+                for (const candidate of ["pwsh", "powershell.exe"]) {
+                    const probe = spawnSync(
+                        candidate,
+                        ["-NoProfile", "-Command", "exit 0"],
+                        {
+                            stdio: "ignore",
+                        }
+                    );
+                    if (!probe.error && probe.status === 0) {
+                        return candidate;
+                    }
+                }
+                return undefined;
+            })();
+            const psIt = psExe ? it : it.skip;
+
+            psIt("echoLine prints each message verbatim", () => {
+                awkwardMessages.forEach((message) => {
+                    const out = execFileSync(
+                        psExe!,
+                        [
+                            "-NoProfile",
+                            "-Command",
+                            echoLine(message, "powershell"),
+                        ],
+                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                    );
+                    expect(out.replace(/\r?\n$/, "")).to.equal(message);
+                });
+            });
+
+            psIt("escapePathArgument does not interpolate", () => {
+                awkwardWinPaths.forEach((p) => {
+                    // Single quotes are literal in PowerShell; with double
+                    // quotes `$VAR` would vanish and `$(cmd)` would execute.
+                    const out = execFileSync(
+                        psExe!,
+                        [
+                            "-NoProfile",
+                            "-Command",
+                            `Write-Host -NoNewline ${escapePathArgument(
+                                p,
+                                "powershell"
+                            )}`,
+                        ],
+                        {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                    );
+                    expect(out).to.equal(p);
+                });
+            });
+
+            psIt("escapeExecutableForTerminal invokes the executable", () => {
+                // The `&` call operator is what makes a quoted path run rather
+                // than just echo back as a string.
+                const out = execFileSync(
+                    psExe!,
+                    [
+                        "-NoProfile",
+                        "-Command",
+                        `${escapeExecutableForTerminal(
+                            process.execPath,
+                            "powershell"
+                        )} -e "process.stdout.write('ran')"`,
+                    ],
+                    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                );
+                expect(out).to.equal("ran");
+            });
+
+            psIt("clearCmd and the separator parse", () => {
+                const line = [clearCmd("powershell"), "Write-Host ok"].join(
+                    commandSeparator("powershell")
+                );
+                const result = spawnSync(
+                    psExe!,
+                    ["-NoProfile", "-Command", line],
+                    {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]}
+                );
+                expect(result.stderr).to.equal("");
+                expect(result.status).to.equal(0);
+                expect(result.stdout).to.contain("ok");
+            });
+        });
+    });
+});

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -93,9 +93,14 @@ export function readCmd(kind: ShellKind = currentShellKind()): string {
     }
 }
 
-/** Separator for running commands in sequence. cmd has no `;`. */
+/**
+ * Separator for running commands in sequence. cmd has no `;`.
+ *
+ * No space before cmd's `&`: its `echo` prints the rest of the line raw, so
+ * `echo one & echo two` would print "one" with a trailing space.
+ */
 export function commandSeparator(kind: ShellKind = currentShellKind()): string {
-    return kind === "cmd" ? " & " : "; ";
+    return kind === "cmd" ? "& " : "; ";
 }
 
 /**
@@ -194,11 +199,35 @@ export function echoLine(
     switch (kind) {
         case "cmd":
             // `echo.` prints an empty line; plain `echo` would print the ECHO
-            // state instead. cmd can't quote `%`, so callers must pre-check.
-            return line === "" ? "echo." : `echo ${line}`;
+            // state instead.
+            //
+            // cmd's `echo` prints the rest of the line raw, so quoting it would
+            // show the quotes. Escape the shell operators individually with `^`
+            // instead — without this, a message containing `&`, `|` or `>` (our
+            // banner embeds the user's output directory) is parsed as an
+            // operator and cmd tries to run the following word as a command.
+            // `%` cannot be escaped at all; callers pre-check with
+            // {@link hasCmdUnsafeChars}.
+            return line === "" ? "echo." : `echo ${escapeCmdEchoText(line)}`;
         case "powershell":
             return `Write-Host ${escapePathArgument(line, kind)}`;
         case "posix":
             return `printf '%s\\n' ${escapePathArgument(line, kind)}`;
     }
+}
+
+/**
+ * Escape cmd's shell operators for use in `echo` text, so they print as
+ * themselves instead of being parsed.
+ *
+ * Only operators *outside* double quotes are escaped. Inside quotes cmd already
+ * treats them as text, and a `^` there would print literally — so escaping
+ * blindly would corrupt the quoted path our banner embeds. A single regex pass
+ * with an alternation keeps quoted runs intact: they match the first branch and
+ * are emitted unchanged.
+ */
+function escapeCmdEchoText(text: string): string {
+    return text.replace(/"[^"]*"?|[\^&|<>()]/g, (match) =>
+        match.startsWith('"') ? match : `^${match}`
+    );
 }

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -1,23 +1,204 @@
+import path from "node:path";
 import {env} from "vscode";
 
-export function isPowershell() {
-    return env.shell.toLowerCase().includes("powershell");
-}
+/**
+ * The shell dialects we generate command lines for. This is about *syntax*, not
+ * about the specific executable: WSL and Git Bash are both `"posix"` because
+ * they parse the same way.
+ */
+export type ShellKind = "cmd" | "powershell" | "posix";
 
-export function readCmd() {
-    if (isPowershell()) {
-        return "Read-Host";
+/**
+ * Classify a shell executable path into the dialect its command lines must be
+ * written in.
+ *
+ * Matching is on the **basename** (minus `.exe`), never a substring of the full
+ * path: `C:\cmder\vendor\git-for-windows\bin\bash.exe` is bash, even though
+ * "cmd" appears in its directory. `shell` and `platform` are parameters so this
+ * stays a pure function, testable on any host OS.
+ */
+export function detectShellKind(
+    shell: string,
+    platform: NodeJS.Platform = process.platform
+): ShellKind {
+    if (shell === "") {
+        // Shell-less environments. `env.shell` is always populated for this
+        // (desktop-only) extension, so this is only defence in depth.
+        return platform === "win32" ? "powershell" : "posix";
     }
-    return "read";
-}
 
-export function escapeExecutableForTerminal(exe: string): string {
-    if (isPowershell()) {
-        return `& "${exe}"`;
+    // `path.win32` splits on both separators, so this works regardless of the
+    // host we're running on — `path.basename` on macOS would treat an entire
+    // `C:\...\cmd.exe` as one segment.
+    const name = path.win32
+        .basename(shell)
+        .toLowerCase()
+        .replace(/\.exe$/, "");
+    switch (name) {
+        case "cmd":
+            return "cmd";
+        case "powershell":
+        case "pwsh":
+        case "pwsh-preview":
+            return "powershell";
+        default:
+            // bash, zsh, fish, sh, dash, wsl, git-bash, ...
+            return "posix";
     }
-    return `"${exe}"`;
 }
 
-export function escapePathArgument(arg: string): string {
+/**
+ * The dialect of the shell that new terminals will run.
+ *
+ * `env.shell` is the resolved default terminal profile's path, so as long as we
+ * create terminals without `shellPath` this names the shell that will actually
+ * parse our command line. We deliberately don't pin `shellPath` to it: passing
+ * an explicit executable makes VS Code drop the profile's `args`, which is what
+ * makes login shells login shells on macOS.
+ *
+ * This is the only place `env.shell` is read, which keeps the rest of this
+ * module unit testable.
+ */
+export function currentShellKind(): ShellKind {
+    return detectShellKind(env.shell);
+}
+
+/** Clear the screen. */
+export function clearCmd(kind: ShellKind = currentShellKind()): string {
+    switch (kind) {
+        case "cmd":
+            return "cls";
+        case "powershell":
+            return "Clear-Host";
+        case "posix":
+            return "clear";
+    }
+}
+
+/**
+ * Wait for the user to press a key, so a failed command stays readable instead
+ * of the terminal closing on the following `exit`.
+ *
+ * POSIX uses `read _`: bare `read` is a usage error in dash (`read: arg count`),
+ * which would fail the pause and let `exit` discard the error we're preserving.
+ */
+export function readCmd(kind: ShellKind = currentShellKind()): string {
+    switch (kind) {
+        case "cmd":
+            return "pause";
+        case "powershell":
+            return "Read-Host";
+        case "posix":
+            return "read _";
+    }
+}
+
+/** Separator for running commands in sequence. cmd has no `;`. */
+export function commandSeparator(kind: ShellKind = currentShellKind()): string {
+    return kind === "cmd" ? " & " : "; ";
+}
+
+/**
+ * Quote a path used as a command *argument*.
+ *
+ * PowerShell and POSIX use single quotes because double quotes interpolate:
+ * with `"..."` a directory named `C:\a$(whoami)b` would *execute* `whoami`, and
+ * `C:\Users\me\$RECYCLE.BIN` would expand to `C:\Users\me\.BIN`.
+ *
+ * cmd has no literal quoting at all, so it keeps double quotes — and `%VAR%`
+ * still expands inside them. Callers handing cmd a user-chosen path must reject
+ * it first; see {@link hasCmdUnsafeChars}.
+ */
+export function escapePathArgument(
+    arg: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    switch (kind) {
+        case "cmd":
+            return `"${arg.replaceAll('"', '""')}"`;
+        case "powershell":
+            // '' is the escape for a literal single quote in PowerShell.
+            return `'${arg.replaceAll("'", "''")}'`;
+        case "posix":
+            // End the quote, emit an escaped quote, reopen: it's -> 'it'\''s'
+            return `'${arg.replaceAll("'", "'\\''")}'`;
+    }
+}
+
+/**
+ * Quote a path being invoked as a command. PowerShell needs the `&` call
+ * operator, because a quoted string on its own is just a string expression.
+ */
+export function escapeExecutableForTerminal(
+    exe: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    const quoted = escapePathArgument(exe, kind);
+    return kind === "powershell" ? `& ${quoted}` : quoted;
+}
+
+/**
+ * Quote a path for a terminal whose shell we don't know.
+ *
+ * Only for reusing `window.activeTerminal`: it can be running any profile, so
+ * neither `env.shell` nor a pinned `shellPath` tells us the dialect, and the
+ * 1.86 API we build against has no `TerminalState.shell` to ask. Double quotes
+ * are the compromise that at least parses in cmd, PowerShell and POSIX alike —
+ * unlike single quotes, which cmd treats as literal characters.
+ *
+ * The trade-off is that double quotes interpolate: `$VAR` and `$(cmd)` are live
+ * in POSIX and PowerShell. Prefer {@link escapePathArgument} with a known kind.
+ * The real fix for such call sites is to skip the shell entirely and use a task
+ * with an argv array.
+ */
+export function escapePathArgumentForUnknownShell(arg: string): string {
     return `"${arg.replaceAll('"', '\\"')}"`;
+}
+
+/** {@link escapePathArgumentForUnknownShell} for a path invoked as a command. */
+export function escapeExecutableForUnknownShell(exe: string): string {
+    const quoted = escapePathArgumentForUnknownShell(exe);
+    return currentShellKind() === "powershell" ? `& ${quoted}` : quoted;
+}
+
+/**
+ * Whether a string would be corrupted by cmd's variable expansion. `%VAR%`
+ * expands even inside double quotes and there is no way to escape it on an
+ * interactive command line, so callers must refuse rather than silently pass a
+ * different value than the user chose.
+ *
+ * `!VAR!` is included because it expands the same way when delayed expansion is
+ * enabled (`cmd /V:ON`, or via the registry — not the default, but some managed
+ * Windows images turn it on).
+ */
+export function hasCmdUnsafeChars(arg: string): boolean {
+    return /[%!]/.test(arg);
+}
+
+/**
+ * Print one line verbatim.
+ *
+ * POSIX uses `printf '%s\n'` rather than `echo`: the `echo` builtin in zsh and
+ * dash interprets backslash escapes *even inside single quotes*, so a path
+ * containing `\t` would print a tab and `\c` would truncate the rest of the
+ * line. The message is a printf *argument*, not the format string, so a literal
+ * `%` in it is safe.
+ *
+ * Pass a single line — callers wanting a blank line should emit a separate
+ * command, since `\n` handling differs per shell.
+ */
+export function echoLine(
+    line: string,
+    kind: ShellKind = currentShellKind()
+): string {
+    switch (kind) {
+        case "cmd":
+            // `echo.` prints an empty line; plain `echo` would print the ECHO
+            // state instead. cmd can't quote `%`, so callers must pre-check.
+            return line === "" ? "echo." : `echo ${line}`;
+        case "powershell":
+            return `Write-Host ${escapePathArgument(line, kind)}`;
+        case "posix":
+            return `printf '%s\\n' ${escapePathArgument(line, kind)}`;
+    }
 }

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -79,8 +79,16 @@ export function clearCmd(kind: ShellKind = currentShellKind()): string {
  * Wait for the user to press a key, so a failed command stays readable instead
  * of the terminal closing on the following `exit`.
  *
- * POSIX uses `read _`: bare `read` is a usage error in dash (`read: arg count`),
- * which would fail the pause and let `exit` discard the error we're preserving.
+ * POSIX needs an explicit, ordinary variable name — every shorter spelling
+ * breaks somewhere:
+ * - bare `read` is a usage error in dash (`read: arg count`, exit 2), and fish
+ *   echoes the input back instead of consuming it silently.
+ * - `read _` is an error in fish, where `_` is a read-only variable
+ *   (`cannot overwrite read-only variable`).
+ * - `read -r name` is an error in fish, which has no `-r` flag.
+ *
+ * A failed pause is not cosmetic: the following `exit` closes the terminal and
+ * discards exactly the CLI error this step exists to keep readable.
  */
 export function readCmd(kind: ShellKind = currentShellKind()): string {
     switch (kind) {
@@ -89,7 +97,7 @@ export function readCmd(kind: ShellKind = currentShellKind()): string {
         case "powershell":
             return "Read-Host";
         case "posix":
-            return "read _";
+            return "read discard";
     }
 }
 

--- a/packages/databricks-vscode/src/utils/shellUtils.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.ts
@@ -121,6 +121,14 @@ export function commandSeparator(kind: ShellKind = currentShellKind()): string {
  * cmd has no literal quoting at all, so it keeps double quotes — and `%VAR%`
  * still expands inside them. Callers handing cmd a user-chosen path must reject
  * it first; see {@link hasCmdUnsafeChars}.
+ *
+ * Known gap: the `"posix"` branch is wrong for **fish**, which treats `\` as an
+ * escape inside single quotes where every other POSIX-ish shell does not. A
+ * directory named `two\\slashes` arrives as `two\slashes`, and a trailing `\`
+ * makes fish report unbalanced quotes. Both are legal directory names, so this
+ * is reachable, but fixing it properly needs fish to become its own
+ * {@link ShellKind} — it is only the quoting that differs, not `clear`/`;`/
+ * `printf`/`read`. Tracked separately rather than widened into the #1822 fix.
  */
 export function escapePathArgument(
     arg: string,


### PR DESCRIPTION
Fixes #1822.

## Why

On Windows with cmd.exe as the terminal shell, "Create a new Databricks project" was
broken. The wizard built one POSIX command line and sent it to whatever shell the
terminal was running, so cmd rejected it token by token and the CLI never started:

```
C:\...\Temp>clear; echo "Executing: databricks bundle init --output-dir "c:\...\databricks-test"
'clear' is not recognized as an internal or external command,
'Follow' is not recognized as an internal or external command,
'Press' is not recognized as an internal or external command,
```

`clear`, `;` as a separator, and `read` are all POSIX-only. cmd needs `cls`, ` & ` and
`pause`.

The reported wizard turned out not to be the only casualty. The same shared helpers are
used by **"Databricks SSH Tunnel"** and **`az login`**, and both were broken in cmd on
`main` for the same reason — details in their own sections below.

The root cause is structural, not a missing branch. `shellUtils` read `env.shell` inside
every helper and split only "PowerShell" vs "everything else", using a substring match on
the full path — so cmd.exe fell into the POSIX bucket. Because the branching sat behind a
module-level VS Code read, none of it could be reached from a unit test, so this class of
bug had no way to be caught. Fixing only the `clear`/`read` symptoms would have left the
next shell-specific bug just as invisible, which is why this is a refactor rather than a
two-line patch.

## What changed

**One classifier instead of scattered predicates.**
`detectShellKind(shell, platform) -> "cmd" | "powershell" | "posix"` is a pure function;
every helper takes that kind. `env.shell` is now read in exactly one place,
`currentShellKind()`, matching the existing `venvInterpreterPath` injection pattern in
this repo. Detection matches on the shell's **basename**, so
`C:\cmder\...\bash.exe` is no longer mistaken for cmd.

**Terminals still resolve their own shell.** I deliberately did *not* pin `shellPath`.
Passing an explicit executable makes VS Code build a synthetic profile from
`{path, args}` and never supply the resolved profile's defaults
([`terminalProfileResolverService.ts:113-124`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts)) —
and on macOS the fallback profile is what appends `--login`. So pinning
`shellPath: env.shell` would silently turn a login shell into a non-login one, stop
`~/.zprofile` being sourced, and change `PATH`. `env.shell` exposes only `profile.path`,
never `args`, so those args can't be recovered.

Per file:

| File | Change |
|---|---|
| `utils/shellUtils.ts` | `ShellKind` + `detectShellKind`; all helpers parameterised; per-shell quoting; `clearCmd`/`commandSeparator`/`echoLine`/`hasCmdUnsafeChars` added |
| `utils/shellUtils.test.ts` | New — 60 cases across three layers |
| `bundle/BundleInitWizard.ts` | Assembles the line via the helpers; refuses a cmd-unsafe output dir |
| `cli/CliWrapper.ts` | `escapedCliPathFor(kind)`; `escapedCliPath` delegates to it — which also fixes the SSH tunnel, see below |
| `configuration/auth/AzureCliCheck.ts` | Same defect in the `az login` line; also quotes the az path and the tenant |
| `run/RunCommands.ts` | Explicit unknown-shell quoting (behaviour unchanged — see below) |

### Bugs found once the logic became testable

Each is a real defect on `main`, not hypothetical:

- **`pwsh[.exe]` was unhandled** — PowerShell 6+/7, the default on modern Windows. It
  matched neither `"powershell"` nor cmd, so those users got POSIX `read`, which does not
  exist in PowerShell.
- **PowerShell paths were double-quoted, which interpolates.**
  `C:\Users\me\$RECYCLE.BIN` expanded to `C:\Users\me\.BIN`, and a directory named
  `C:\a$(whoami)b` would **execute** `whoami`. Both PowerShell and POSIX now use single
  quotes, which are literal.
- **`escapedCliPath` quoted the CLI wrongly for *both* Windows shells**, which broke the
  SSH tunnel as well as the init wizard — see the section below.
- **`escapedCliPath` used `.replace`, not `.replaceAll`** — every quote after the first
  was left unescaped.
- **`az login` interpolated both the az path and the tenant bare.** A custom `azBinPath`
  containing spaces (`C:\Program Files\Azure CLI\az.cmd`) split into several arguments,
  and the tenant — which comes from a token's `iss` claim, i.e. external data reaching a
  command line — was unquoted. Both are quoted now. (Quoting a bare command name still
  resolves via `PATH` in all three shells, so the default `az` is unaffected.)
- **POSIX used `echo`**, whose builtin form interprets backslash escapes in zsh and dash
  *even inside single quotes*: `\t` printed a tab, and `\c` truncated the rest of the
  line. Now `printf '%s\n'`, which is verbatim everywhere. (The message is a printf
  *argument*, not the format string, so a literal `%` is safe.)
- **The `read` pause needs a named variable; every shorter spelling breaks a shell.**
  Bare `read` is a usage error in dash (`read: arg count`, exit 2), and in **fish** it
  exits 0 but echoes the keypress back into the terminal. `read _` fixes dash but is an
  error in fish, where `_` is read-only. `read -r name` is an error in fish too — it has no
  `-r` flag. Now `read discard`, the only form `sh`, `bash`, `zsh`, `dash` and `fish` all
  accept. A failed pause isn't cosmetic: the following `exit` closes the terminal and
  discards exactly the CLI error the pause exists to keep on screen. (Matrix in the testing
  section below.)
- **cmd's `echo` printed shell operators as operators.** The message was interpolated
  unquoted, so a banner containing `&`, `|` or `>` was parsed rather than printed — and the
  banner embeds the user's output directory, so a folder named `a&b` made cmd try to run
  `b` as a command (`'pipe' is not recognized...`). Now caret-escaped. Quoting isn't an
  option: cmd's `echo` prints the rest of the line raw, so the quotes would show. The
  escaping skips text already inside double quotes, where cmd treats operators as literal
  and a caret would itself print — that's the shape the real banner has.
- **The cmd separator had a leading space**, so `echo one & ...` printed `one ` with a
  trailing space, for the same raw-text reason. Now `& ` rather than ` & `.
- **`%VAR%` cannot be escaped in cmd** — it expands even inside double quotes. Output dir
  `C:\p%TEMP%q\proj` would have scaffolded into a directory the user never chose, after
  which `getSubProjects` reports "no Databricks projects detected". `BundleInitWizard` now
  refuses up front with an actionable message. (`!VAR!` is included too, since it expands
  the same way under delayed expansion.)

### The SSH tunnel had the same bug, and is fixed by the same change

Not just the init wizard: **"Databricks SSH Tunnel" was broken in cmd on `main` too**, and
in `pwsh`. `SshCommands.launchSshTunnel` sends `${this.cli.escapedCliPath} …`
(`src/ssh/SshCommands.ts:435`), and `main`'s getter had no cmd branch at all:

```ts
get escapedCliPath(): string {
    return isPowershell()
        ? `& "${this.cliPath.replace('"', '\\"')}"`
        : `'${this.cliPath.replaceAll("'", "\\'")}'`;   // ← cmd landed here
}
```

The consequence differs per shell, and neither starts the tunnel:

- **cmd** got the single-quoted POSIX form. cmd has no single-quote semantics, so the
  quotes are part of the name and it looks for a program literally called
  `'C:\…\databricks.exe'` → `is not recognized as an internal or external command`.
- **`pwsh`** failed `isPowershell()`'s `"powershell"` substring match, so it *also* got
  single quotes — and without the `&` call operator a quoted string on its own line is
  just a string expression, so PowerShell prints the path rather than running it.

No change to `SshCommands.ts` was needed: `escapedCliPath` now delegates to
`escapedCliPathFor(currentShellKind())`, which routes cmd to double quotes and PowerShell
to `& '…'`. The call site was already correct — the terminal is created **without**
`shellPath` (`SshCommands.ts:428-433`), which is exactly the precondition the getter
documents, so the default profile really is the shell that parses the line. That's what
distinguishes it from `RunCommands` below.

The tunnel's *arguments* need no quoting: `getSshConnectCommand`
(`CliWrapper.ts:128-142`) emits only internally-generated tokens — `ssh connect`,
`--ide=vscode|cursor`, `--auto-approve`, `--auto-start-cluster`, a cluster ID, and an
accelerator from a hardcoded list — with no spaces or metacharacters. And it's a single
command, so none of the `clear`/`read`/separator/`echo` syntax that varies per shell is
involved. Worth noting for a follow-up: those args are interpolated unquoted, which is
fine for today's fixed set but would silently become a bug if a flag ever carried a
user-supplied value. There's also no `src/ssh/` test file, so this path is covered only
indirectly through `escapeExecutableForTerminal`'s round-trips.

### `RunCommands` is deliberately unchanged in behaviour

`runFileUsingDbconnect` sends to `window.activeTerminal ?? createTerminal()`. For a
*reused* terminal the shell is not `env.shell`, and `TerminalState.shell` doesn't exist in
the `@types/vscode@1.86.0` this extension targets, so no escaping choice is safe.
`main`'s `"…"` quoting happens to parse in **both** cmd and POSIX, so it survives a
mismatch by accident; switching its POSIX branch to single quotes would have *newly*
broken a focused cmd tab (cmd would look for a program literally named
`'C:\Python\python.exe'`). It now calls explicit `escapePathArgumentForUnknownShell` /
`escapeExecutableForUnknownShell` helpers that keep the double quotes and say why. The
real fix there is a `ProcessExecution`/task with an argv array, which needs no quoting —
left as a follow-up.

### Known gap: fish and backslashes

`escapePathArgument`'s POSIX branch is **not** correct for fish, which — unlike sh, bash,
zsh and dash — treats `\` as an escape *inside single quotes*. Two shapes go wrong:

| output dir | sh/bash/zsh/dash | fish |
|---|---|---|
| `/Users/me/two\\slashes` | verbatim | arrives as `two\slashes` |
| `/Users/me/trailing\` | verbatim | `Unexpected end of string, quotes are not balanced` |

This is reachable, not theoretical: a directory literally named `two\\slashes` is legal on
macOS and Linux, and I confirmed it can be created. The first shape scaffolds into a
directory the user didn't choose (the same failure mode as `%VAR%` in cmd); the second
fails to parse.

I've **left this out of this PR deliberately** — it needs a fourth `ShellKind` (fish is
currently classified `posix`, which is right for `clear`/`;`/`printf` and wrong only for
backslash quoting), and that's a wider change than the bug this PR is about. Everything
else the wizard emits was verified byte-identical in fish. Happy to file it as a separate
issue.

## How this was tested

**Manually on Windows**, across several `terminal.integrated.defaultProfile.windows`
settings — this is the bug report's scenario and it now works.

`yarn test:unit` — **669 passing, 0 failing** with PowerShell 7.6.2 and fish 4.8.1 present
(599 before this branch, so 70 are new). Verified green in all three shapes this affects:
with `pwsh` and `$TERM` set, with `pwsh` and `$TERM` unset (the CI shape, via
`env -u TERM`), and with no `pwsh` at all. `yarn test:lint` clean.

**fish is included in the POSIX round-trips**, probed for on `PATH` so the tests skip
rather than fail where it isn't installed — neither CI image has it, nor does macOS out of
the box. It earns its place by *not* being strictly POSIX, which is how the `read _` bug
above was found. The full `read` matrix, measured by running each candidate in each shell:

| candidate | sh | bash | zsh | dash | fish |
|---|---|---|---|---|---|
| `read` | ok | ok | ok | **X** `arg count` | **X** echoes the input back |
| `read _` | ok | ok | ok | ok | **X** read-only variable |
| `read -r name` | ok | ok | ok | ok | **X** no `-r` flag |
| `read discard` | ok | ok | ok | ok | ok |

Three layers, chosen so the weaknesses of each are covered by another:

1. **Table-driven classification.** `detectShellKind` across 13 shell/platform pairs plus
   regression cases: the cmder false positive, `cmd` on Linux, `pwsh` on macOS, and the
   empty-shell fallback per platform. Both inputs are parameters, so these are
   deterministic on any host OS — no `process.platform` patching and no mocking anywhere
   in the suite.
2. **Exact command strings.** The full bundle-init line is asserted verbatim for cmd,
   PowerShell and POSIX, so a reviewer can read the expected output for each shell
   directly in the test.
3. **Round-trip execution against real shells.** String equality only proves the code
   built what the author intended — not that the shell agrees. Reverting the PowerShell
   single-quoting fix makes the round-trip fail with `C:\a$VAR\dollar` arriving as
   `C:\a\dollar`, i.e. real PowerShell silently dropping the variable. The generated commands are
   executed through `/bin/sh`, `zsh`, `bash`, `dash` and `fish`, and through cmd and
   PowerShell, asserting output matches input byte for byte across awkward messages and
   paths: embedded quotes of both kinds, `$VAR`, `` `cmd` ``, `$(cmd)`, `&`/`|`/`>`,
   backslashes. This layer is what caught the `echo` and `read` bugs; the string assertions
   alone had passed.

**Verifying the tests actually bite.** Since a test that passes either way proves nothing,
I reverted each fix individually and recorded the failures:

| Fix reverted | Tests failing |
|---|---|
| PowerShell single-quoting | 6 |
| `printf` instead of `echo` | 6 — in `sh`/`zsh`/`dash` only; **`bash` passed**, matching the real defect |
| `read discard` → `read _` | 6 (incl. both `fish` round-trips) |
| `read discard` → bare `read` | 7 — `dash` and `fish`; the fish echo-back is caught **only** by the new silent-consume assertion |
| `%`/`!` guard | 1 |
| empty-shell fallback | 1 |

Every fix has at least one test that fails without it. Doing this also exposed two
weaknesses in my own tests, both times an assertion too weak to see a real failure:

- the `read` round-trip originally used `|| true`, which masked dash's exit-2 usage error.
  It now asserts empty stderr and `status !== 2`.
- that stderr-and-status check still wasn't enough: bare `read` in fish exits **0** with
  empty stderr while echoing the keypress back into the terminal, so it slipped through.
  A second round-trip now asserts the pause consumes its line *silently* (`stdout === ""`),
  which is the only assertion that catches it.

## Reviewer notes

- **The round-trip layer earned its keep, and the CI matrix is what proved it.** Neither
  cmd nor PowerShell can be exercised on a macOS dev machine, so both CI legs found real
  problems that a green local run had missed:
  - The **Linux** leg has `pwsh` installed (PowerShell is *probed for* rather than gated on
    platform), so it ran those four tests and caught two Mocha timeouts from per-case
    `pwsh` spawns plus two assertions that depended on `$TERM`.
  - The **Windows** leg then caught the two genuine `echo`/separator defects listed above.
  Both are fixed and **both legs are now green**: Windows 660 passing / 0 failing with all
  ten cmd and PowerShell round-trips executing (non-trivial durations, 0 pending), Linux 663
  passing / 0 failing. So every assertion for the two shells #1822 is about has now run
  against a real shell, not just against a string comparison.
- The cmd round-trips run the generated line from a temp `.cmd` file rather than
  `cmd /c <line>`. Passing it as an argv entry lets Node apply its own Windows quoting,
  which escapes an embedded `"` as `\"` — a sequence cmd doesn't understand — so the test
  would measure Node's escaping instead of ours.
- **Five commits, reviewable in order:** (1) the bundle-init fix plus the `shellUtils`
  refactor — which is also where the SSH tunnel fix lands, via `escapedCliPath`, (2)
  `az login`, which had the identical defect, (3) making the PowerShell round-trips pass on
  a real `pwsh`, (4) the two cmd `echo`/separator fixes the Windows leg found, (5) the
  `read discard` fix for fish.
- **Three user-facing commands were broken in cmd on `main`, not one:** the init wizard
  (reported), the SSH tunnel, and `az login`. All three are fixed here. The manual Windows
  testing covered the wizard — the bug report's scenario — so the tunnel and `az login`
  paths are verified by the round-trip tests rather than by hand, and are worth a manual
  look if you have a Windows box with cmd as the default profile.
- `echoLine` takes a **single line** and callers emit blank lines as separate commands.
  The old code embedded `\n` in a double-quoted `echo`, which isn't portable.
- Once `engines.vscode` moves past 1.86, `terminal.state.shell` becomes available and
  would make a good dev-only assertion: compare it against `detectShellKind(env.shell)`
  and log a warning on disagreement. That would also cover sub-shells and WSL distro
  wrappers, which basename matching can't see.
- **Follow-ups I'd file rather than grow this PR:** fish's backslash quoting (section
  above — needs a fourth `ShellKind`), `RunCommands` moving to a `ProcessExecution` with an
  argv array, and the SSH tunnel's unquoted args.

This pull request and its description were written by Isaac.

