### PR TITLE
Fix show bundle logs in Cursor

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -484,7 +484,9 @@ export class CliWrapper {
                         await FileUtils.openDatabricksConfigFile();
                     }
                     if (choice === "Show Error Logs") {
-                        this.loggerManager.showOutputChannel("Databricks Logs");
+                        await this.loggerManager.showOutputChannel(
+                            "Databricks Logs"
+                        );
                     }
                 });
         }

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -637,9 +637,9 @@ export async function activate(
         bundleRemoteStateModel,
         configModel,
         connectionManager,
-        commands.registerCommand("databricks.internal.showOutput", () => {
-            loggerManager.showOutputChannel("Databricks Logs");
-        }),
+        commands.registerCommand("databricks.internal.showOutput", () =>
+            loggerManager.showOutputChannel("Databricks Logs")
+        ),
         connectionManager.onDidChangeState(async () => {
             telemetry.setMetadata(
                 Metadata.USER,

--- a/packages/databricks-vscode/src/logger/LoggerManager.test.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.test.ts
@@ -6,7 +6,11 @@ import {tmpdir} from "os";
 import path from "path";
 import {instance, mock, when} from "ts-mockito";
 import {ExtensionContext, Uri} from "vscode";
-import {LoggerManager, Loggers} from "./LoggerManager";
+import {LoggerManager, Loggers, RevealCommandApi} from "./LoggerManager";
+
+const EXTENSION_ID = "databricks.databricks";
+const CHANNEL = "Databricks Logs" as const;
+const SCOPED_REVEAL = `workbench.action.output.show.${EXTENSION_ID}.${CHANNEL}.workspaceId-abc123`;
 
 describe(__filename, function () {
     let tempDir: string;
@@ -17,15 +21,132 @@ describe(__filename, function () {
         tempDir = await mkdtemp(path.join(tmpdir(), "testdir-"));
     });
 
-    it("should reveal an output channel without throwing", async () => {
+    function createManager(commandApi?: Partial<RevealCommandApi>) {
         const mockContext = mock<ExtensionContext>();
         when(mockContext.logUri).thenReturn(Uri.file(tempDir));
-        when(mockContext.extension).thenReturn({
-            id: "databricks.databricks",
-        } as any);
+        when(mockContext.extension).thenReturn({id: EXTENSION_ID} as any);
+        return new LoggerManager(instance(mockContext), {
+            getCommands: async () => [],
+            executeCommand: async () => undefined,
+            ...commandApi,
+        });
+    }
 
-        const manager = new LoggerManager(instance(mockContext));
-        await manager.showOutputChannel("Databricks Logs");
+    it("should reveal an output channel without throwing", async () => {
+        const manager = createManager();
+        await manager.showOutputChannel(CHANNEL);
+    });
+
+    it("should reveal via the scoped command when the host registers one", async () => {
+        const executed: string[] = [];
+        const manager = createManager({
+            getCommands: async () => [SCOPED_REVEAL],
+            executeCommand: async (command) => {
+                executed.push(command);
+            },
+        });
+
+        await manager.showOutputChannel(CHANNEL);
+
+        assert.deepStrictEqual(executed, [SCOPED_REVEAL]);
+    });
+
+    it("should cache the resolved command and not re-enumerate", async () => {
+        let getCommandsCalls = 0;
+        const executed: string[] = [];
+        const manager = createManager({
+            getCommands: async () => {
+                getCommandsCalls++;
+                return [SCOPED_REVEAL];
+            },
+            executeCommand: async (command) => {
+                executed.push(command);
+            },
+        });
+
+        await manager.showOutputChannel(CHANNEL);
+        await manager.showOutputChannel(CHANNEL);
+
+        assert.strictEqual(getCommandsCalls, 1);
+        assert.deepStrictEqual(executed, [SCOPED_REVEAL, SCOPED_REVEAL]);
+    });
+
+    it("should cache the 'use show()' sentinel when the ids agree", async () => {
+        let getCommandsCalls = 0;
+        let executeCalls = 0;
+        const manager = createManager({
+            getCommands: async () => {
+                getCommandsCalls++;
+                // Exact id registered -> plain show() is correct.
+                return [
+                    `workbench.action.output.show.${EXTENSION_ID}.${CHANNEL}`,
+                ];
+            },
+            executeCommand: async () => {
+                executeCalls++;
+            },
+        });
+
+        // First reveal creates the channel (the just-created retry path, which
+        // never caches). Production pre-creates channels at activation, so the
+        // interesting case is the subsequent reveals below.
+        await manager.showOutputChannel(CHANNEL);
+        getCommandsCalls = 0;
+
+        await manager.showOutputChannel(CHANNEL);
+        await manager.showOutputChannel(CHANNEL);
+
+        // First resolves and caches the sentinel; second reuses it.
+        assert.strictEqual(getCommandsCalls, 1);
+        assert.strictEqual(executeCalls, 0);
+    });
+
+    it("should evict the cache and re-resolve after a failed executeCommand", async () => {
+        let getCommandsCalls = 0;
+        let shouldFail = true;
+        const executed: string[] = [];
+        const manager = createManager({
+            getCommands: async () => {
+                getCommandsCalls++;
+                return [SCOPED_REVEAL];
+            },
+            executeCommand: async (command) => {
+                if (shouldFail) {
+                    throw new Error("stale command");
+                }
+                executed.push(command);
+            },
+        });
+
+        // First call fails and falls back to show(), evicting the cache entry.
+        await manager.showOutputChannel(CHANNEL);
+        assert.strictEqual(getCommandsCalls, 1);
+
+        // Next call must re-resolve rather than reuse the evicted entry.
+        shouldFail = false;
+        await manager.showOutputChannel(CHANNEL);
+        assert.strictEqual(getCommandsCalls, 2);
+        assert.deepStrictEqual(executed, [SCOPED_REVEAL]);
+    });
+
+    it("should retry resolving the reveal command for a just-created channel", async () => {
+        let getCommandsCalls = 0;
+        const executed: string[] = [];
+        const manager = createManager({
+            getCommands: async () => {
+                getCommandsCalls++;
+                // Registered only on the retry, mimicking async workbench registration.
+                return getCommandsCalls > 1 ? [SCOPED_REVEAL] : [];
+            },
+            executeCommand: async (command) => {
+                executed.push(command);
+            },
+        });
+
+        await manager.showOutputChannel(CHANNEL);
+
+        assert.strictEqual(getCommandsCalls, 2);
+        assert.deepStrictEqual(executed, [SCOPED_REVEAL]);
     });
 
     it("should create log file and log data", async () => {

--- a/packages/databricks-vscode/src/logger/LoggerManager.test.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.test.ts
@@ -17,6 +17,17 @@ describe(__filename, function () {
         tempDir = await mkdtemp(path.join(tmpdir(), "testdir-"));
     });
 
+    it("should reveal an output channel without throwing", async () => {
+        const mockContext = mock<ExtensionContext>();
+        when(mockContext.logUri).thenReturn(Uri.file(tempDir));
+        when(mockContext.extension).thenReturn({
+            id: "databricks.databricks",
+        } as any);
+
+        const manager = new LoggerManager(instance(mockContext));
+        await manager.showOutputChannel("Databricks Logs");
+    });
+
     it("should create log file and log data", async () => {
         const mockContext = mock<ExtensionContext>();
         when(mockContext.logUri).thenReturn(Uri.file(tempDir));

--- a/packages/databricks-vscode/src/logger/LoggerManager.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.ts
@@ -1,5 +1,11 @@
 import {logging} from "@databricks/sdk-experimental";
-import {env, ExtensionContext, window, LogOutputChannel} from "vscode";
+import {
+    commands,
+    env,
+    ExtensionContext,
+    window,
+    LogOutputChannel,
+} from "vscode";
 import {loggers, format, transports} from "winston";
 
 import {getJsonFormat} from "./truncatedJsonFormat";
@@ -9,12 +15,23 @@ import {
     LOG_OUTPUT_CHANNEL_LEVELS,
     LogOutputChannelStream,
 } from "./OutputConsoleStream";
+import {findRevealCommand} from "./outputChannelReveal";
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const {NamedLogger, ExposedLoggers} = logging;
 
+export type LogChannelName = "Databricks Logs" | "Databricks Bundle Logs";
+
+/**
+ * How long to wait before re-looking for a channel's reveal command when the
+ * channel was only just created. `createOutputChannel` registers with the
+ * workbench asynchronously, so the command may not exist yet on the first try.
+ */
+const REVEAL_COMMAND_RETRY_DELAY_MS = 200;
+
 export class LoggerManager {
-    private outputChannels: Map<string, LogOutputChannel> = new Map();
+    private outputChannels: Map<LogChannelName, LogOutputChannel> = new Map();
+    private readonly revealCommands: Map<LogChannelName, string> = new Map();
 
     constructor(readonly context: ExtensionContext) {}
 
@@ -32,9 +49,7 @@ export class LoggerManager {
         return logFile;
     }
 
-    private getLogOutputChannel(
-        name: "Databricks Logs" | "Databricks Bundle Logs"
-    ) {
+    private getLogOutputChannel(name: LogChannelName) {
         if (!this.outputChannels.has(name)) {
             const outputChannel = window.createOutputChannel(name, {log: true});
             outputChannel.clear();
@@ -157,8 +172,57 @@ export class LoggerManager {
         env.openExternal(this.context.logUri);
     }
 
-    showOutputChannel(name: "Databricks Logs" | "Databricks Bundle Logs") {
-        this.getLogOutputChannel(name).show();
+    /**
+     * Reveals a log output channel. Never rejects: any failure to resolve the
+     * host's reveal command falls back to `LogOutputChannel.show()`, which is
+     * correct everywhere the channel ids agree.
+     */
+    async showOutputChannel(name: LogChannelName): Promise<void> {
+        const justCreated = !this.outputChannels.has(name);
+        const channel = this.getLogOutputChannel(name);
+        try {
+            const command = await this.resolveRevealCommand(name, justCreated);
+            if (command !== undefined) {
+                await commands.executeCommand(command);
+                return;
+            }
+        } catch (e) {
+            // A cached command id can go stale, so drop it and let the next
+            // call re-resolve instead of failing for the rest of the session.
+            this.revealCommands.delete(name);
+            NamedLogger.getOrCreate(Loggers.Extension).debug(
+                `Could not reveal the "${name}" output channel by command, falling back to show()`,
+                e
+            );
+        }
+        channel.show();
+    }
+
+    private async resolveRevealCommand(
+        name: LogChannelName,
+        justCreated: boolean
+    ): Promise<string | undefined> {
+        const cached = this.revealCommands.get(name);
+        if (cached !== undefined) {
+            return cached;
+        }
+
+        const extensionId = this.context.extension.id;
+        let command = await findRevealCommand(extensionId, name);
+        if (command === undefined && justCreated) {
+            await new Promise((resolve) =>
+                setTimeout(resolve, REVEAL_COMMAND_RETRY_DELAY_MS)
+            );
+            command = await findRevealCommand(extensionId, name);
+        }
+
+        if (command !== undefined) {
+            this.revealCommands.set(name, command);
+            NamedLogger.getOrCreate(Loggers.Extension).debug(
+                `Revealing the "${name}" output channel via ${command}, as the host registered it under a scoped id`
+            );
+        }
+        return command;
     }
 }
 

--- a/packages/databricks-vscode/src/logger/LoggerManager.ts
+++ b/packages/databricks-vscode/src/logger/LoggerManager.ts
@@ -29,11 +29,35 @@ export type LogChannelName = "Databricks Logs" | "Databricks Bundle Logs";
  */
 const REVEAL_COMMAND_RETRY_DELAY_MS = 200;
 
+/**
+ * The VS Code command APIs the reveal logic depends on, injectable so tests can
+ * drive the orchestration deterministically. Defaults to the real `commands`.
+ */
+export interface RevealCommandApi {
+    getCommands: () => Thenable<string[]>;
+    executeCommand: (command: string) => Thenable<unknown>;
+}
+
+const defaultRevealCommandApi: RevealCommandApi = {
+    getCommands: () => commands.getCommands(true),
+    executeCommand: (command) => commands.executeCommand(command),
+};
+
 export class LoggerManager {
     private outputChannels: Map<LogChannelName, LogOutputChannel> = new Map();
-    private readonly revealCommands: Map<LogChannelName, string> = new Map();
+    /**
+     * Resolved reveal command per channel. `null` is a "no command needed, use
+     * `.show()`" sentinel that we cache so repeated reveals don't re-enumerate
+     * every registered command; `undefined` (absent key) means "not resolved
+     * yet".
+     */
+    private readonly revealCommands: Map<LogChannelName, string | null> =
+        new Map();
 
-    constructor(readonly context: ExtensionContext) {}
+    constructor(
+        readonly context: ExtensionContext,
+        private readonly commandApi: RevealCommandApi = defaultRevealCommandApi
+    ) {}
 
     async getLogFile(prefix: string) {
         await mkdir(this.context.logUri.fsPath, {recursive: true});
@@ -173,17 +197,17 @@ export class LoggerManager {
     }
 
     /**
-     * Reveals a log output channel. Never rejects: any failure to resolve the
-     * host's reveal command falls back to `LogOutputChannel.show()`, which is
-     * correct everywhere the channel ids agree.
+     * Reveals a log output channel. Any failure to resolve or run the host's
+     * reveal command is swallowed and falls back to `LogOutputChannel.show()`,
+     * which is correct everywhere the channel ids agree.
      */
     async showOutputChannel(name: LogChannelName): Promise<void> {
         const justCreated = !this.outputChannels.has(name);
         const channel = this.getLogOutputChannel(name);
         try {
             const command = await this.resolveRevealCommand(name, justCreated);
-            if (command !== undefined) {
-                await commands.executeCommand(command);
+            if (command !== null) {
+                await this.commandApi.executeCommand(command);
                 return;
             }
         } catch (e) {
@@ -198,22 +222,36 @@ export class LoggerManager {
         channel.show();
     }
 
+    /**
+     * Resolves the reveal command for a channel, or `null` when plain `.show()`
+     * is correct (the ids agree). Both outcomes are cached; on the `justCreated`
+     * path an unresolved command is left uncached so a later call retries, since
+     * the workbench may not have registered it yet.
+     */
     private async resolveRevealCommand(
         name: LogChannelName,
         justCreated: boolean
-    ): Promise<string | undefined> {
+    ): Promise<string | null> {
         const cached = this.revealCommands.get(name);
         if (cached !== undefined) {
             return cached;
         }
 
         const extensionId = this.context.extension.id;
-        let command = await findRevealCommand(extensionId, name);
+        let command = await findRevealCommand(
+            extensionId,
+            name,
+            this.commandApi.getCommands
+        );
         if (command === undefined && justCreated) {
             await new Promise((resolve) =>
                 setTimeout(resolve, REVEAL_COMMAND_RETRY_DELAY_MS)
             );
-            command = await findRevealCommand(extensionId, name);
+            command = await findRevealCommand(
+                extensionId,
+                name,
+                this.commandApi.getCommands
+            );
         }
 
         if (command !== undefined) {
@@ -221,8 +259,16 @@ export class LoggerManager {
             NamedLogger.getOrCreate(Loggers.Extension).debug(
                 `Revealing the "${name}" output channel via ${command}, as the host registered it under a scoped id`
             );
+            return command;
         }
-        return command;
+
+        // No scoped command found. Cache the "use .show()" sentinel unless the
+        // channel was only just created — then the command may simply not be
+        // registered yet, so leave it unresolved for the next call to retry.
+        if (!justCreated) {
+            this.revealCommands.set(name, null);
+        }
+        return null;
     }
 }
 

--- a/packages/databricks-vscode/src/logger/outputChannelReveal.test.ts
+++ b/packages/databricks-vscode/src/logger/outputChannelReveal.test.ts
@@ -1,0 +1,145 @@
+import assert from "assert";
+import {
+    findRevealCommand,
+    getLogChannelId,
+    pickRevealCommand,
+} from "./outputChannelReveal";
+
+const EXTENSION_ID = "databricks.databricks";
+const CHANNEL_NAME = "Databricks Bundle Logs";
+const CHANNEL_ID = `${EXTENSION_ID}.${CHANNEL_NAME}`;
+const REVEAL = `workbench.action.output.show.${CHANNEL_ID}`;
+const SCOPED_REVEAL = `${REVEAL}.workspaceId-abc123`;
+
+describe(__filename, function () {
+    describe("getLogChannelId", function () {
+        it("should leave the current channel names untouched", function () {
+            assert.strictEqual(
+                getLogChannelId(EXTENSION_ID, "Databricks Bundle Logs"),
+                "databricks.databricks.Databricks Bundle Logs"
+            );
+            assert.strictEqual(
+                getLogChannelId(EXTENSION_ID, "Databricks Logs"),
+                "databricks.databricks.Databricks Logs"
+            );
+        });
+
+        it("should strip the characters the host strips", function () {
+            assert.strictEqual(
+                getLogChannelId(EXTENSION_ID, 'a\\b/c:d*e?f"g<h>i|j'),
+                "databricks.databricks.abcdefghij"
+            );
+        });
+    });
+
+    describe("pickRevealCommand", function () {
+        it("should return undefined when the exact id is registered", function () {
+            // VS Code: the ids agree, so `.show()` works and must not be shadowed.
+            assert.strictEqual(
+                pickRevealCommand([REVEAL], CHANNEL_ID),
+                undefined
+            );
+        });
+
+        it("should return the scoped command when only it is registered", function () {
+            // Cursor: `.show()` sends the unscoped id and silently no-ops.
+            assert.strictEqual(
+                pickRevealCommand([SCOPED_REVEAL], CHANNEL_ID),
+                SCOPED_REVEAL
+            );
+        });
+
+        it("should prefer the exact id regardless of ordering", function () {
+            assert.strictEqual(
+                pickRevealCommand([REVEAL, SCOPED_REVEAL], CHANNEL_ID),
+                undefined
+            );
+            assert.strictEqual(
+                pickRevealCommand([SCOPED_REVEAL, REVEAL], CHANNEL_ID),
+                undefined
+            );
+        });
+
+        it("should return undefined when nothing matches", function () {
+            assert.strictEqual(pickRevealCommand([], CHANNEL_ID), undefined);
+            assert.strictEqual(
+                pickRevealCommand(
+                    [
+                        "databricks.bundle.showLogs",
+                        "workbench.action.files.save",
+                    ],
+                    CHANNEL_ID
+                ),
+                undefined
+            );
+        });
+
+        it("should not match a longer channel name that starts with ours", function () {
+            const otherChannel = `${REVEAL} Extra.workspaceId-abc123`;
+            assert.strictEqual(
+                pickRevealCommand([otherChannel], CHANNEL_ID),
+                undefined
+            );
+        });
+
+        it("should not match a suffix with more than one dot-segment", function () {
+            assert.strictEqual(
+                pickRevealCommand(
+                    [`${REVEAL}.workspaceId-abc.extra`],
+                    CHANNEL_ID
+                ),
+                undefined
+            );
+        });
+
+        it("should disambiguate several candidates via the workspace scope", function () {
+            assert.strictEqual(
+                pickRevealCommand(
+                    [`${REVEAL}.remote`, SCOPED_REVEAL],
+                    CHANNEL_ID
+                ),
+                SCOPED_REVEAL
+            );
+        });
+
+        it("should give up when the workspace scope is ambiguous", function () {
+            assert.strictEqual(
+                pickRevealCommand(
+                    [SCOPED_REVEAL, `${REVEAL}.workspaceId-def456`],
+                    CHANNEL_ID
+                ),
+                undefined
+            );
+        });
+
+        it("should match case insensitively and return the id verbatim", function () {
+            const differentlyCased = `workbench.action.output.show.Databricks.Databricks.${CHANNEL_NAME}.workspaceId-abc123`;
+            assert.strictEqual(
+                pickRevealCommand([differentlyCased], CHANNEL_ID),
+                differentlyCased
+            );
+        });
+    });
+
+    describe("findRevealCommand", function () {
+        it("should resolve against the injected command list", async function () {
+            assert.strictEqual(
+                await findRevealCommand(
+                    EXTENSION_ID,
+                    CHANNEL_NAME,
+                    async () => [SCOPED_REVEAL]
+                ),
+                SCOPED_REVEAL
+            );
+        });
+
+        it("should propagate errors so the caller can fall back", async function () {
+            await assert.rejects(
+                findRevealCommand(EXTENSION_ID, CHANNEL_NAME, () =>
+                    Promise.reject(new Error("no commands"))
+                ),
+                /no commands/
+            );
+        });
+    });
+});

--- a/packages/databricks-vscode/src/logger/outputChannelReveal.ts
+++ b/packages/databricks-vscode/src/logger/outputChannelReveal.ts
@@ -1,0 +1,76 @@
+import {commands} from "vscode";
+
+/**
+ * Recovers the command that reveals a `LogOutputChannel` on hosts that register
+ * the channel under a different id than the extension host believes it has.
+ *
+ * See ./README.md for why this is needed and why the check is shaped as a
+ * capability probe rather than a fork-name check.
+ */
+
+/** Mirrors the character class the extension host strips from channel names. */
+const ILLEGAL_CHANNEL_ID_CHARS = /[\\/:*?"<>|]/g;
+
+const REVEAL_COMMAND_PREFIX = "workbench.action.output.show.";
+
+/**
+ * The id the extension host derives locally for a log output channel. It never
+ * round-trips through the workbench, which is what allows it to disagree with
+ * the id the channel is actually registered under.
+ */
+export function getLogChannelId(extensionId: string, name: string): string {
+    return `${extensionId}.${name.replace(ILLEGAL_CHANNEL_ID_CHARS, "")}`;
+}
+
+/**
+ * Picks the reveal command for `channelId` out of `allCommands`, but only when
+ * the host registered the channel under a *different* id than `channelId`.
+ *
+ * Returns undefined when the ids agree (plain `.show()` already works) or when
+ * no single candidate is conclusive — callers fall back to `.show()`.
+ */
+export function pickRevealCommand(
+    allCommands: readonly string[],
+    channelId: string
+): string | undefined {
+    const prefix = `${REVEAL_COMMAND_PREFIX}${channelId}`.toLowerCase();
+    const candidates: string[] = [];
+
+    for (const command of allCommands) {
+        const lowerCased = command.toLowerCase();
+        if (lowerCased === prefix) {
+            // The ids agree, so `.show()` reveals the channel. Never shadow it.
+            return undefined;
+        }
+        if (!lowerCased.startsWith(prefix)) {
+            continue;
+        }
+        // A host-added scope is a single extra dot-segment (".workspaceId-<id>").
+        // Requiring the leading dot is what keeps a *longer channel name* whose
+        // id merely starts with ours out of the candidate set.
+        if (/^\.[^.]+$/.test(command.slice(prefix.length))) {
+            candidates.push(command);
+        }
+    }
+
+    if (candidates.length === 1) {
+        return candidates[0];
+    }
+    // Ambiguous: prefer the known workspace-scope shape, and otherwise give up
+    // rather than reveal some unrelated channel of ours.
+    const workspaceScoped = candidates.filter((command) =>
+        command.slice(prefix.length).startsWith(".workspaceId-")
+    );
+    return workspaceScoped.length === 1 ? workspaceScoped[0] : undefined;
+}
+
+export async function findRevealCommand(
+    extensionId: string,
+    name: string,
+    getCommands: () => Thenable<string[]> = () => commands.getCommands(true)
+): Promise<string | undefined> {
+    return pickRevealCommand(
+        await getCommands(),
+        getLogChannelId(extensionId, name)
+    );
+}

--- a/packages/databricks-vscode/src/logger/outputChannelReveal.ts
+++ b/packages/databricks-vscode/src/logger/outputChannelReveal.ts
@@ -4,8 +4,13 @@ import {commands} from "vscode";
  * Recovers the command that reveals a `LogOutputChannel` on hosts that register
  * the channel under a different id than the extension host believes it has.
  *
- * See ./README.md for why this is needed and why the check is shaped as a
- * capability probe rather than a fork-name check.
+ * The extension host derives a channel's id locally (`<extensionId>.<sanitized
+ * name>`) and never round-trips it through the workbench, so some hosts register
+ * under a different id (e.g. appending a `.workspaceId-<id>` scope segment). When
+ * they disagree, `LogOutputChannel.show()` targets an unregistered id and does
+ * nothing. This probes the registered command list to find the real reveal
+ * command. It is a capability probe rather than a host/fork-name check, so it
+ * degrades to plain `.show()` on hosts where the ids already agree.
  */
 
 /** Mirrors the character class the extension host strips from channel names. */
@@ -59,7 +64,7 @@ export function pickRevealCommand(
     // Ambiguous: prefer the known workspace-scope shape, and otherwise give up
     // rather than reveal some unrelated channel of ours.
     const workspaceScoped = candidates.filter((command) =>
-        command.slice(prefix.length).startsWith(".workspaceId-")
+        command.slice(prefix.length).toLowerCase().startsWith(".workspaceid-")
     );
     return workspaceScoped.length === 1 ? workspaceScoped[0] : undefined;
 }


### PR DESCRIPTION
## Changes

Problem

LoggerManager.showOutputChannel() called LogOutputChannel.show(), which silently did nothing on hosts that register a log channel under a different id than the extension host derives for it. The extension host computes the channel id locally (<extensionId>.<sanitized name>) and never round-trips it through the workbench, so the two can disagree — some hosts append a workspace scope segment (.workspaceId-<id>). When they disagree, .show() targets an id that isn't registered and the channel never appears.

User-visible effect: Databricks: Show Bundle Logs (databricks.bundle.showLogs), the databricks.internal.showOutput command behind the AI-tools "Show Logs" affordance, and the "Show Error Logs" button in CliWrapper's error notification all appeared to do nothing.

Fix

New src/logger/outputChannelReveal.ts recovers the real reveal command by probing the registered command list for workbench.action.output.show.<channelId>:

- getLogChannelId() derives the id the way the extension host does, stripping the same illegal characters.
- pickRevealCommand() returns a scoped command only when the host registered the channel under a different id — if the exact id is present, it returns undefined so plain .show() stays in charge. Candidates must differ by exactly one dot-segment, which keeps a longer channel name whose id merely prefixes ours out of the set. On ambiguity it prefers the .workspaceId- shape and otherwise gives up rather than reveal an unrelated channel.

This is a capability probe rather than a host/fork-name check, so it degrades to existing behavior on hosts where ids already agree.

LoggerManager changes:

- showOutputChannel() is now async and resolves the reveal command before falling back to channel.show(). It never rejects — any failure is logged at debug level and falls through to .show().
- Resolved command ids are cached per channel; a failed executeCommand evicts the cache entry so a stale id doesn't break reveals for the rest of the session.
- When a channel was just created, one 200 ms retry covers createOutputChannel registering with the workbench asynchronously.
- The ad-hoc "Databricks Logs" | "Databricks Bundle Logs" union is extracted to an exported LogChannelName type and now types the outputChannels map.

CliWrapper awaits the newly-async call.

## Tests

outputChannelReveal.test.ts
LoggerManager.test.ts