### PR TITLE
fix(python-setup): show red icon when setup is not done

### DIFF
--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {ThemeIcon} from "vscode";
+import {ThemeColor, ThemeIcon} from "vscode";
 import {buildPythonSetupEntry} from "./pythonSetupEntry";
 
 describe("buildPythonSetupEntry", () => {
@@ -10,6 +10,11 @@ describe("buildPythonSetupEntry", () => {
 
         expect(item.command?.command).to.equal(COMMAND);
         expect((item.iconPath as ThemeIcon).id).to.equal("rocket");
+        // Not-done reads as an error (red), consistent with the sibling
+        // checklist entries, rather than the green debug-start color.
+        expect((item.iconPath as ThemeIcon).color).to.deep.equal(
+            new ThemeColor("errorForeground")
+        );
         // The label invites the user to run setup.
         expect(String(item.label)).to.match(/set up/i);
     });

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
@@ -43,10 +43,7 @@ export function buildPythonSetupEntry(
             }`,
             iconPath: state.ready
                 ? new ThemeIcon("check")
-                : new ThemeIcon(
-                      "rocket",
-                      new ThemeColor("debugIcon.startForeground")
-                  ),
+                : new ThemeIcon("rocket", new ThemeColor("errorForeground")),
             command: {
                 title: "Set up Python environment",
                 command: commandId,


### PR DESCRIPTION
## Why

The uv-native **Set up Python environment** entry rendered its call-to-action icon in green (`debugIcon.startForeground`) while its `contextValue` was `databricks.environment.pythonSetup.error`. The green icon read as "ready" before setup had ever run — contradicting both the contextValue and the sibling checklist entries.

This is defect #2 from the M4 bug bash (DECO-27917): *"Entry Appears Ready Before Setup Runs — Call-to-action renders green before provisioning occurs; internal inconsistency: contextValue shows `...pythonSetup.error` while icon is green."*

## What

- `pythonSetupEntry.ts`: color the not-ready rocket icon with `errorForeground` (red) instead of `debugIcon.startForeground` (green). This matches the convention already used by the other Python Environment and cluster entries, where required-but-not-done steps are red and only ready/available states are green. The ready state (green `check`) is unchanged.
- `pythonSetupEntry.test.ts`: assert the not-ready icon color is `errorForeground` so it can't silently regress to green.

## Verification

- Unit suite green: **507 passing, 0 failing**.
- ESLint + Prettier clean on both files.

This pull request and its description were written by Isaac.