### PR TITLE
test(e2e): win the sub-second cancel race in run_files

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/run_files.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/run_files.e2e.ts
@@ -14,6 +14,30 @@ import {
     writeRootBundleConfig,
 } from "./utils/dabsFixtures.ts";
 
+/**
+ * Empty the debug console. The whole spec shares one console, so output from an
+ * earlier run would otherwise satisfy a later wait.
+ */
+async function clearDebugConsole() {
+    try {
+        await browser.executeWorkbench(async (vscode) => {
+            // clearReplAction is a ViewAction: it resolves the REPL through
+            // getActiveViewWithId and silently does nothing when the console
+            // isn't the active view. Focus it first so the clear really happens.
+            await vscode.commands.executeCommand(
+                "workbench.panel.repl.view.focus"
+            );
+            await vscode.commands.executeCommand(
+                "workbench.debug.panel.action.clearReplAction"
+            );
+        });
+    } catch (e) {
+        // Hygiene, not an assertion — don't fail the run over it, but say so,
+        // because a stale console can make a later wait pass on old output.
+        console.log("Failed to clear the debug console:", e);
+    }
+}
+
 describe("Run files", async function () {
     let projectDir: string;
     this.timeout(6 * 60 * 1000);
@@ -48,76 +72,113 @@ describe("Run files", async function () {
 
     it("should cancel a run during deployment", async () => {
         const workbench = await driver.getWorkbench();
-        await executeCommandWhenAvailable("Databricks: Upload and Run File");
 
-        // Catching the in-flight "Uploading bundle assets" toast and clicking
-        // its Cancel action is a tight race on the slow Windows shard: the
-        // toast is transient and its action button can lag the toast body by a
-        // few frames. A throw from takeAction() inside a waitUntil condition
-        // rejects the whole wait — wdio does NOT retry a condition that throws
-        // — which is exactly the "element wasn't found" failure observed in CI.
-        // Guard both the message read and the click so a not-yet-rendered
-        // button just retries on the next poll, and only resolve once the click
-        // actually lands. Fail closed with a clear message if the cancellable
-        // toast never appears.
+        // The "Uploading bundle assets" toast is only cancellable while
+        // `bundle sync` is in flight, and for a project this small that window
+        // is well under a second on a Linux runner (0.93s in the nightly
+        // failure this guards against). The toast is torn down the moment the
+        // upload finishes, so the Cancel click can be issued and still lose:
+        // in CI it came back as a stale element reference ~60ms before the
+        // upload completed, after which the poll loop had nothing left to
+        // retry. Longer timeouts cannot fix that — the window is short because
+        // the upload is fast, not because the test is slow. So race the toast
+        // with as few round-trips as possible and, when the upload wins,
+        // start another run and race the next upload.
+        //
+        // Scoped to the toast container so a stray "Cancel" elsewhere in the
+        // workbench can't satisfy the wait.
+        const cancelAction =
+            '.notifications-toasts a[role="button"][title="Cancel"]';
+        const maxAttempts = 3;
+        let sawCancellableToast = false;
         let cancelled = false;
-        await browser.waitUntil(
-            async () => {
-                const notifications = await workbench.getNotifications();
-                console.log("Notifications:", notifications.length);
-                for (const notification of notifications) {
-                    let message: string;
-                    try {
-                        message = await notification.getMessage();
-                    } catch {
-                        // Notification vanished between listing and read — skip.
-                        continue;
-                    }
-                    console.log("Message:", message);
-                    if (message.includes("Uploading bundle assets")) {
-                        try {
-                            await notification.takeAction("Cancel");
-                            cancelled = true;
-                            return true;
-                        } catch {
-                            // The Cancel button hasn't rendered yet; retry.
-                            return false;
-                        }
-                    }
-                }
-                return false;
-            },
-            {
-                timeout: 60_000,
-                interval: 500,
-                timeoutMsg:
-                    "The cancellable 'Uploading bundle assets' notification never appeared",
+
+        for (let attempt = 1; attempt <= maxAttempts && !cancelled; attempt++) {
+            console.log(`Cancel attempt ${attempt} of ${maxAttempts}`);
+            // Losing the race lets a run finish, which prints "hello world" to
+            // the debug console — exactly what the next test waits for, and it
+            // shares this console. Clear it so neither that test nor the
+            // "Cancelled" check below can pass on a previous run's output.
+            await clearDebugConsole();
+            if (attempt > 1) {
+                // beforeEach already opened it for the first attempt.
+                await openFile("hello.py");
             }
-        );
+            await executeCommandWhenAvailable(
+                "Databricks: Upload and Run File"
+            );
+
+            // Find and click inside one browser.execute. Three things make
+            // this fit the window: it cannot go stale (lookup and click are
+            // one synchronous JS turn, so the toast can't be disposed between
+            // them, which is precisely how CI failed); it is a single
+            // round-trip, unlike the message read plus find plus click the old
+            // code paid; and it returns immediately when the button is absent,
+            // whereas element.click() blocks on wdio's 10s implicit wait and
+            // would make a tight poll interval meaningless.
+            //
+            // The last attempt falls back to wdio's element click — the real
+            // input event. If a synthetic DOM click ever stops reaching VS
+            // Code's handler, that keeps this a race we can lose rather than a
+            // test that always fails.
+            const useRealInputEvent = attempt === maxAttempts;
+            try {
+                await browser.waitUntil(
+                    async () => {
+                        if (useRealInputEvent) {
+                            const button = await browser.$(cancelAction);
+                            if (!(await button.isExisting())) {
+                                return false;
+                            }
+                            try {
+                                await button.click();
+                                return true;
+                            } catch {
+                                // Disposed mid-click; the upload won.
+                                return false;
+                            }
+                        }
+                        return browser.execute((selector) => {
+                            const found =
+                                document.querySelector<HTMLElement>(selector);
+                            found?.click();
+                            return Boolean(found);
+                        }, cancelAction);
+                    },
+                    {timeout: 30_000, interval: 100}
+                );
+                sawCancellableToast = true;
+            } catch {
+                // The cancellable toast never appeared. Check the debug console
+                // before racing another upload.
+            }
+
+            // Ground truth: killing the in-flight `bundle sync` surfaces a
+            // cancellation error in the debug console. Re-open the view on
+            // every attempt, since starting a run reveals the bundle logs
+            // output channel over it.
+            const debugOutput = await workbench
+                .getBottomBar()
+                .openDebugConsoleView();
+            try {
+                await browser.waitUntil(
+                    async () => {
+                        const text = await (await debugOutput.elem).getHTML();
+                        return Boolean(text && text.includes("Cancelled"));
+                    },
+                    {timeout: 20_000, interval: 1_000}
+                );
+                cancelled = true;
+            } catch {
+                // The upload won this race; retry with a fresh run.
+            }
+        }
+
         assert(
             cancelled,
-            "Failed to click Cancel on the deployment notification"
-        );
-
-        // Previously an unbounded `while (true)` poll: if "Cancelled" never
-        // showed (cancel didn't register, or the deploy already finished) it
-        // spun until the per-test mocha timeout surfaced as a bare
-        // `Error: Timeout` with no context. Bound the wait so a genuine miss
-        // fails fast with a diagnostic reason instead.
-        const debugOutput = await workbench
-            .getBottomBar()
-            .openDebugConsoleView();
-        await browser.waitUntil(
-            async () => {
-                const text = await (await debugOutput.elem).getHTML();
-                return Boolean(text && text.includes("Cancelled"));
-            },
-            {
-                timeout: 120_000,
-                interval: 2_000,
-                timeoutMsg:
-                    "Deployment run did not report 'Cancelled' in the debug console",
-            }
+            sawCancellableToast
+                ? `Cancel was clicked but the run never reported 'Cancelled', in all ${maxAttempts} runs`
+                : "The cancellable 'Uploading bundle assets' notification never appeared"
         );
     });
 


### PR DESCRIPTION
## Changes

The nightly `run_files > should cancel a run during deployment` spec fails
intermittently on Linux (most recently in `vscode-isolated-nightly` run
31358950776, and on ~1 night in 3).

The automated triage read this as "the notification never appeared", but the wdio
log in the job's `test-logs` artifact shows the opposite — the toast appeared, and
Cancel was found *and clicked*:

```
05:42:54.105  RESULT Uploading bundle assets            <- toast found
05:42:54.106  findElement(".//a[@role='button' and @title='Cancel']")
05:42:54.127  elementClick(element_158)                 <- Cancel found and clicked
05:42:54.373  request failed: stale element reference   <- toast disposed mid-click
```

`bundle sync` completed in **0.93s** (CLI log, pid 4988: `05:42:53.26` ->
`05:42:54.19`, exit 0), so VS Code tore the toast down between the `findElement`
and the `elementClick`. After that the poll loop had nothing left to retry and
spun out the remaining 59s on an empty notification list (`Notifications: 0`).
The recorded video confirms the run then completed normally
(`Done (took 10516ms)`).

The cancellable window is short because the upload is *fast*, not because the
test is slow — so longer timeouts and click retries (#2056) can't fix it. Instead:

- **Find and click in a single `browser.execute`**, so the lookup and the click
  are one synchronous JS turn that cannot go stale in between. This also drops
  two round-trips (the toast message read, then a separate find — the message
  read alone cost ~135ms of a sub-second window), and it returns immediately when
  the button is absent, whereas `element.click()` blocks on wdio's 10s implicit
  wait and would make a tight poll interval a no-op.
- **Retry the whole run, not just the click**: if the upload wins the race, start
  another run and race the next upload (3 attempts).
- **Clear the debug console between attempts.** A lost race completes a run and
  prints `hello world` — exactly what the next test in this spec waits for, on
  the same shared console.

Two guards, since a test that always fails would be worse than a flake:

- The final attempt falls back to wdio's element click (a real input event), so
  if a synthetic DOM click ever stops reaching VS Code's handler this stays a
  race we can lose rather than a hard failure.
- `clearReplAction` is a `ViewAction` resolved via `getActiveViewWithId`, so it
  silently no-ops unless the console is the active view — the helper focuses the
  panel first, and only logs (never throws) if clearing fails.

## Tests

Verified against the pinned VS Code 1.86.0 source that the DOM assumptions hold:

- The action button is an `<a>` with `role="button"` and `title="Cancel"`
  (`base/browser/ui/button/button.ts`) — same element the wdio-vscode-service
  locator targets, just scoped to `.notifications-toasts` and expressed in CSS.
- `.notifications-toasts` is the outermost toast container, with each
  `.notification-toast` nested inside
  (`browser/parts/notifications/notificationsToasts.ts`).
- The button binds a plain `click` listener, which `HTMLElement.click()`
  dispatches — so the synthetic click does reach the handler.
- `workbench.debug.panel.action.clearReplAction` exists in 1.86 and is a
  `ViewAction` (`contrib/debug/browser/repl.ts:973`), hence the focus-first
  ordering above.

`prettier --check` and `tsc -p src/test/e2e/tsconfig.json --noEmit` are clean for
this file. (Two pre-existing `tsc` errors in `utils/unityCatalogUtils.ts` are
untouched by this change.)

Not yet exercised by a real run — the e2e suite can't run in my dev environment,
so this needs a CI run on the `run_files` shard. Since the failure reproduces on
roughly one night in three, a single green run won't be conclusive; I'd suggest a
couple of `vscode-isolated-pr` runs, and ideally one confirming the retry path
itself works (the `Cancel attempt N of 3` logging makes that visible).

This pull request and its description were written by Isaac.
