### PR TITLE
fix(cli): warn when the bundled CLI is stale in a dev checkout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,53 +7,18 @@ links — in code, comments, commit messages, PR titles, or PR descriptions. The
 direction is one-way: link the PR from the internal ticket, never the ticket from the
 PR. A handful of `DECO-*` mentions predate this rule and are not precedent.
 
-## Running the extension from source
+## Re-fetch the CLI after pulling
 
-Full setup and test instructions live in [CONTRIBUTING.md](CONTRIBUTING.md). The
-points below are the ones that cost time when they're missed.
-
-**Re-fetch the CLI after pulling.** The extension shells out to a Databricks CLI
-bundled at `packages/databricks-vscode/bin/databricks`, pinned by `cli.version` in
-`packages/databricks-vscode/package.json`. `bin/` is gitignored, so a `git pull`
-that bumps `cli.version` leaves the old binary in place:
+Setup, build, and test instructions live in [CONTRIBUTING.md](CONTRIBUTING.md). The
+step easiest to miss: the extension shells out to a Databricks CLI bundled at
+`packages/databricks-vscode/bin/databricks`, and `bin/` is gitignored, so a `git pull`
+that bumps `cli.version` leaves the old binary in place. Re-fetch it:
 
 ```sh
 yarn workspace databricks run package:cli:fetch
 ```
 
-A stale CLI rejects subcommands the extension expects and aborts activation, which
-looks like a configuration view stuck on "Initializing..." rather than an error.
-The extension warns about this on startup in a dev checkout.
-
-**Launching.** Press `F5` in VS Code (`Run and Watch Extension`) — it builds and sets
-`EXTENSION_DEVELOPMENT` for you. To launch from a terminal instead:
-
-```sh
-cd packages/databricks-vscode
-EXTENSION_DEVELOPMENT=true code --disable-extension databricks.databricks \
-    --extensionDevelopmentPath="$PWD" --new-window <a-bundle-project>
-```
-
-`--disable-extension databricks.databricks` avoids an ID collision with an installed
-marketplace build. Note that `code` may fold `--new-window` into an existing window
-instead of opening the folder you asked for; check the window's title bar says
-`[Extension Development Host]` and that it's on the folder you intended.
-
-**Activation is lazy.** `activationEvents` has no `*`, so the extension only starts
-for a folder containing a `databricks.yml` (or an open `.py` file) — an empty folder
-activates nothing. Point it at a project whose target sets `workspace.host`.
-
-**Don't pass `--extensions-dir`** unless you also populate it. The extension declares
-`extensionDependencies` (`ms-python.python`, `ms-python.debugpy`, `ms-toolsai.jupyter`,
-`redhat.vscode-yaml`); VS Code won't activate an extension whose dependencies are
-missing, and it reports nothing when it declines.
-
-**Reading the logs.** Extension logs land in the `Databricks Logs` output channel, on
-disk under
-`~/Library/Application Support/Code/logs/<session>/<window>/exthost/databricks.databricks/`
-(`sdk-and-extension-logs.json`, `databricks-cli-logs.json`). `exthost.log` in the
-parent folder records whether the extension activated at all — check that before
-debugging activation itself.
+CONTRIBUTING.md explains what a stale binary looks like when you skip this.
 
 ## Code conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,9 @@ that bumps `cli.version` leaves the old binary in place. Re-fetch it:
 yarn workspace databricks run package:cli:fetch
 ```
 
-CONTRIBUTING.md explains what a stale binary looks like when you skip this.
+A stale binary rejects subcommands the extension expects and aborts activation, so
+the configuration view sits on "Initializing..." instead of reporting an error. In a
+development checkout the extension warns about the mismatch on startup.
 
 ## Code conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,54 @@ links — in code, comments, commit messages, PR titles, or PR descriptions. The
 direction is one-way: link the PR from the internal ticket, never the ticket from the
 PR. A handful of `DECO-*` mentions predate this rule and are not precedent.
 
+## Running the extension from source
+
+Full setup and test instructions live in [CONTRIBUTING.md](CONTRIBUTING.md). The
+points below are the ones that cost time when they're missed.
+
+**Re-fetch the CLI after pulling.** The extension shells out to a Databricks CLI
+bundled at `packages/databricks-vscode/bin/databricks`, pinned by `cli.version` in
+`packages/databricks-vscode/package.json`. `bin/` is gitignored, so a `git pull`
+that bumps `cli.version` leaves the old binary in place:
+
+```sh
+yarn workspace databricks run package:cli:fetch
+```
+
+A stale CLI rejects subcommands the extension expects and aborts activation, which
+looks like a configuration view stuck on "Initializing..." rather than an error.
+The extension warns about this on startup in a dev checkout.
+
+**Launching.** Press `F5` in VS Code (`Run and Watch Extension`) — it builds and sets
+`EXTENSION_DEVELOPMENT` for you. To launch from a terminal instead:
+
+```sh
+cd packages/databricks-vscode
+EXTENSION_DEVELOPMENT=true code --disable-extension databricks.databricks \
+    --extensionDevelopmentPath="$PWD" --new-window <a-bundle-project>
+```
+
+`--disable-extension databricks.databricks` avoids an ID collision with an installed
+marketplace build. Note that `code` may fold `--new-window` into an existing window
+instead of opening the folder you asked for; check the window's title bar says
+`[Extension Development Host]` and that it's on the folder you intended.
+
+**Activation is lazy.** `activationEvents` has no `*`, so the extension only starts
+for a folder containing a `databricks.yml` (or an open `.py` file) — an empty folder
+activates nothing. Point it at a project whose target sets `workspace.host`.
+
+**Don't pass `--extensions-dir`** unless you also populate it. The extension declares
+`extensionDependencies` (`ms-python.python`, `ms-python.debugpy`, `ms-toolsai.jupyter`,
+`redhat.vscode-yaml`); VS Code won't activate an extension whose dependencies are
+missing, and it reports nothing when it declines.
+
+**Reading the logs.** Extension logs land in the `Databricks Logs` output channel, on
+disk under
+`~/Library/Application Support/Code/logs/<session>/<window>/exthost/databricks.databricks/`
+(`sdk-and-extension-logs.json`, `databricks-cli-logs.json`). `exthost.log` in the
+parent folder records whether the extension activated at all — check that before
+debugging activation itself.
+
 ## Code conventions
 
 Read [CODE_CONVENTIONS.md](CODE_CONVENTIONS.md) before you:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,7 @@ yarn workspace databricks run package:cli:fetch
 ```
 
 Re-run this whenever `cli.version` in `packages/databricks-vscode/package.json`
-changes — after every `git pull`, in practice. `bin/` is gitignored, so a pull
-that bumps the pinned version never updates the binary you already have, and a
-stale CLI rejects subcommands the extension expects. That failure is easy to
-misread: the rejected subcommand throws during activation, so the configuration
-view sits on "Initializing..." indefinitely instead of reporting an error. In a
-development checkout the extension compares the two versions on startup and
-warns when they differ, naming this command.
+changes — after every `git pull`, in practice.
 
 After that you're ready to build, run, and test the extension.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ Fetch the Databricks CLI that the extension bundles:
 yarn workspace databricks run package:cli:fetch
 ```
 
+Re-run this whenever `cli.version` in `packages/databricks-vscode/package.json`
+changes: `bin/` is gitignored, so a `git pull` never updates the binary, and a
+stale CLI rejects subcommands the extension expects — which surfaces as a
+configuration view stuck on "Initializing..." rather than as an error. The
+extension warns about a version mismatch on startup in a dev checkout.
+
 After that you're ready to build, run, and test the extension.
 
 ## Building and running

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,13 @@ yarn workspace databricks run package:cli:fetch
 ```
 
 Re-run this whenever `cli.version` in `packages/databricks-vscode/package.json`
-changes: `bin/` is gitignored, so a `git pull` never updates the binary, and a
-stale CLI rejects subcommands the extension expects — which surfaces as a
-configuration view stuck on "Initializing..." rather than as an error. The
-extension warns about a version mismatch on startup in a dev checkout.
+changes — after every `git pull`, in practice. `bin/` is gitignored, so a pull
+that bumps the pinned version never updates the binary you already have, and a
+stale CLI rejects subcommands the extension expects. That failure is easy to
+misread: the rejected subcommand throws during activation, so the configuration
+view sits on "Initializing..." indefinitely instead of reporting an error. In a
+development checkout the extension compares the two versions on startup and
+warns when they differ, naming this command.
 
 After that you're ready to build, run, and test the extension.
 

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -295,6 +295,10 @@ export async function activate(
 
     const cli = new CliWrapper(context, loggerManager, cliLogFilePath);
 
+    // Surfaces a stale bundled CLI in dev checkouts. Not awaited: it only warns,
+    // and activation shouldn't wait on spawning the CLI to find out.
+    void PackageJsonUtils.checkBundledCliVersion(cli.cliPath, packageMetadata);
+
     // Loggers
     context.subscriptions.push(
         telemetry.registerCommand(

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
-import {chmod, writeFile} from "fs/promises";
+import {writeFile} from "fs/promises";
+import path from "node:path";
 import * as tmp from "tmp";
 import {anything, instance, mock, when} from "ts-mockito";
 import {ExtensionContext} from "vscode";
@@ -16,16 +17,16 @@ import {
 } from "./packageJsonUtils";
 import {EXTENSION_DEVELOPMENT} from "./developmentUtils";
 
-/**
- * Writes an executable stub that answers `version --output json` like the CLI.
- * Skipped on Windows, where a shell-script stub isn't executable.
- */
-async function fakeCli(version: string) {
-    const {name: path} = tmp.fileSync();
-    await writeFile(path, `#!/bin/sh\necho '{"Version": "${version}"}'\n`);
-    await chmod(path, 0o755);
-    return path;
-}
+// The real bundled CLI, which CI fetches at the pinned version before running
+// the suite. Mirrors CliWrapper.cliPath — `databricks.exe` on Windows.
+const cliPath = path.join(
+    __dirname,
+    "../../bin/" +
+        (process.platform === "win32" ? "databricks.exe" : "databricks")
+);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pinnedCliVersion = require("../../package.json").cli.version;
 
 describe(__filename, () => {
     it("should correctly check compatibility", () => {
@@ -130,50 +131,46 @@ describe(__filename, () => {
             }
         });
 
-        if (process.platform !== "win32") {
-            it("should read the version the CLI reports", async () => {
-                const cliPath = await fakeCli("1.11.0");
-                assert.equal(await getBundledCliVersion(cliPath), "1.11.0");
-            });
+        it("should read the version the bundled CLI reports", async () => {
+            assert.equal(await getBundledCliVersion(cliPath), pinnedCliVersion);
+        });
 
-            it("should detect a stale CLI", async () => {
-                const cliPath = await fakeCli("0.297.2");
-                assert.ok(
-                    !(await checkBundledCliVersion(cliPath, {
-                        packageName: "databricks",
-                        version: "2.13.0",
-                        cliVersion: "1.11.0",
-                    }))
-                );
-            });
+        it("should accept a CLI matching the pinned version", async () => {
+            assert.ok(
+                await checkBundledCliVersion(cliPath, {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                    cliVersion: pinnedCliVersion,
+                })
+            );
+        });
 
-            it("should accept a matching CLI", async () => {
-                const cliPath = await fakeCli("1.11.0");
-                assert.ok(
-                    await checkBundledCliVersion(cliPath, {
-                        packageName: "databricks",
-                        version: "2.13.0",
-                        cliVersion: "1.11.0",
-                    })
-                );
-            });
+        it("should detect a stale CLI", async () => {
+            assert.ok(
+                !(await checkBundledCliVersion(cliPath, {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                    cliVersion: `${pinnedCliVersion}-not-the-bundled-version`,
+                }))
+            );
+        });
 
-            it("should not warn outside a dev checkout", async () => {
-                delete process.env[EXTENSION_DEVELOPMENT];
-                const cliPath = await fakeCli("0.297.2");
-                assert.ok(
-                    await checkBundledCliVersion(cliPath, {
-                        packageName: "databricks",
-                        version: "2.13.0",
-                        cliVersion: "1.11.0",
-                    })
-                );
-            });
-        }
+        it("should not warn outside a dev checkout", async () => {
+            delete process.env[EXTENSION_DEVELOPMENT];
+            assert.ok(
+                await checkBundledCliVersion(cliPath, {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                    cliVersion: `${pinnedCliVersion}-not-the-bundled-version`,
+                })
+            );
+        });
 
         it("should return undefined for a missing binary", async () => {
             assert.equal(
-                await getBundledCliVersion("/nonexistent/databricks"),
+                await getBundledCliVersion(
+                    path.join(__dirname, "nonexistent-databricks")
+                ),
                 undefined
             );
         });

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -1,9 +1,11 @@
 import assert from "assert";
-import {writeFile} from "fs/promises";
+import {chmod, writeFile} from "fs/promises";
 import * as tmp from "tmp";
 import {anything, instance, mock, when} from "ts-mockito";
 import {ExtensionContext} from "vscode";
 import {
+    checkBundledCliVersion,
+    getBundledCliVersion,
     getCorrectVsixInstallString,
     getMetadata,
     isCompatibleArchitecture,
@@ -12,6 +14,18 @@ import {
     nodeOsMap,
     vsixArchMap,
 } from "./packageJsonUtils";
+import {EXTENSION_DEVELOPMENT} from "./developmentUtils";
+
+/**
+ * Writes an executable stub that answers `version --output json` like the CLI.
+ * Skipped on Windows, where a shell-script stub isn't executable.
+ */
+async function fakeCli(version: string) {
+    const {name: path} = tmp.fileSync();
+    await writeFile(path, `#!/bin/sh\necho '{"Version": "${version}"}'\n`);
+    await chmod(path, 0o755);
+    return path;
+}
 
 describe(__filename, () => {
     it("should correctly check compatibility", () => {
@@ -54,6 +68,9 @@ describe(__filename, () => {
                 vsixArch: "vsixArch",
             },
             commitSha: "commitSha",
+            cli: {
+                version: "1.11.0",
+            },
         };
         await writeFile(path, JSON.stringify(metaData));
 
@@ -68,6 +85,7 @@ describe(__filename, () => {
             cliArch: "cliArch",
             vsixArch: "vsixArch",
             commitSha: "commitSha",
+            cliVersion: "1.11.0",
         });
     });
 
@@ -94,6 +112,79 @@ describe(__filename, () => {
                           "Current system architecture is not supported."
                       );
             });
+        });
+    });
+
+    describe("bundled CLI version", () => {
+        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
+
+        beforeEach(() => {
+            process.env[EXTENSION_DEVELOPMENT] = "true";
+        });
+
+        afterEach(() => {
+            if (originalDevFlag === undefined) {
+                delete process.env[EXTENSION_DEVELOPMENT];
+            } else {
+                process.env[EXTENSION_DEVELOPMENT] = originalDevFlag;
+            }
+        });
+
+        if (process.platform !== "win32") {
+            it("should read the version the CLI reports", async () => {
+                const cliPath = await fakeCli("1.11.0");
+                assert.equal(await getBundledCliVersion(cliPath), "1.11.0");
+            });
+
+            it("should detect a stale CLI", async () => {
+                const cliPath = await fakeCli("0.297.2");
+                assert.ok(
+                    !(await checkBundledCliVersion(cliPath, {
+                        packageName: "databricks",
+                        version: "2.13.0",
+                        cliVersion: "1.11.0",
+                    }))
+                );
+            });
+
+            it("should accept a matching CLI", async () => {
+                const cliPath = await fakeCli("1.11.0");
+                assert.ok(
+                    await checkBundledCliVersion(cliPath, {
+                        packageName: "databricks",
+                        version: "2.13.0",
+                        cliVersion: "1.11.0",
+                    })
+                );
+            });
+
+            it("should not warn outside a dev checkout", async () => {
+                delete process.env[EXTENSION_DEVELOPMENT];
+                const cliPath = await fakeCli("0.297.2");
+                assert.ok(
+                    await checkBundledCliVersion(cliPath, {
+                        packageName: "databricks",
+                        version: "2.13.0",
+                        cliVersion: "1.11.0",
+                    })
+                );
+            });
+        }
+
+        it("should return undefined for a missing binary", async () => {
+            assert.equal(
+                await getBundledCliVersion("/nonexistent/databricks"),
+                undefined
+            );
+        });
+
+        it("should not warn when the pinned version is unknown", async () => {
+            assert.ok(
+                await checkBundledCliVersion("/nonexistent/databricks", {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                })
+            );
         });
     });
 });

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -150,9 +150,9 @@ export function isCompatibleArchitecture(
 }
 
 /**
- * Warns when the bundled CLI is not the version `package.json` pins, because a
- * stale binary otherwise fails opaquely — see "Getting started" in
- * CONTRIBUTING.md.
+ * Warns when the bundled CLI is not the version `package.json` pins, because a stale
+ * binary otherwise aborts activation opaquely — see "Re-fetch the CLI after pulling"
+ * in AGENTS.md.
  *
  * Dev-only. A packaged extension fetches its CLI during the build, so the two
  * versions can't diverge there.

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -150,13 +150,9 @@ export function isCompatibleArchitecture(
 }
 
 /**
- * Warns when the bundled CLI is not the version `package.json` pins.
- *
- * `bin/` is gitignored, so the binary is fetched once by `package:cli:fetch` and
- * never updated by a `git pull`. A `cli.version` bump therefore leaves a stale
- * binary behind, and the resulting failure is opaque: the CLI rejects a
- * subcommand the extension expects, which aborts activation before the
- * configuration view leaves "Initializing...".
+ * Warns when the bundled CLI is not the version `package.json` pins, because a
+ * stale binary otherwise fails opaquely — see "Getting started" in
+ * CONTRIBUTING.md.
  *
  * Dev-only. A packaged extension fetches its CLI during the build, so the two
  * versions can't diverge there.

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -1,5 +1,12 @@
 import fs from "node:fs/promises";
+import {execFile as execFileCb} from "node:child_process";
+import {promisify} from "node:util";
 import {ExtensionContext, window} from "vscode";
+import {logging} from "@databricks/sdk-experimental";
+import {Loggers} from "../logger";
+import {isDevExtension} from "./developmentUtils";
+
+const execFile = promisify(execFileCb);
 
 type OsType = "windows" | "linux" | "macos";
 type ArchType = "x64" | "arm64" | "x86_32";
@@ -49,6 +56,7 @@ export interface PackageMetaData {
     cliArch?: string;
     vsixArch?: string;
     commitSha?: string;
+    cliVersion?: string;
 }
 
 function getNodeArchDetails(): ArchDetails {
@@ -79,7 +87,35 @@ export async function getMetadata(
         cliArch: jsonData["arch"]?.["cliArch"],
         vsixArch: jsonData["arch"]?.["vsixArch"],
         commitSha: jsonData["commitSha"],
+        cliVersion: jsonData["cli"]?.["version"],
     };
+}
+
+/**
+ * Reads the version of the CLI binary bundled at `cliPath`.
+ *
+ * Returns undefined when the binary is missing or its output can't be parsed —
+ * callers treat that as "unknown" rather than as a mismatch, since a missing
+ * binary already fails loudly elsewhere.
+ */
+export async function getBundledCliVersion(
+    cliPath: string
+): Promise<string | undefined> {
+    try {
+        const {stdout} = await execFile(cliPath, [
+            "version",
+            "--output",
+            "json",
+        ]);
+        const version = JSON.parse(stdout)["Version"];
+        return typeof version === "string" ? version : undefined;
+    } catch (e) {
+        logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
+            "Failed to read the bundled Databricks CLI version",
+            e
+        );
+        return undefined;
+    }
 }
 
 export function getCorrectVsixInstallString(
@@ -111,6 +147,40 @@ export function isCompatibleArchitecture(
         return false;
     }
     return true;
+}
+
+/**
+ * Warns when the bundled CLI is not the version `package.json` pins.
+ *
+ * `bin/` is gitignored, so the binary is fetched once by `package:cli:fetch` and
+ * never updated by a `git pull`. A `cli.version` bump therefore leaves a stale
+ * binary behind, and the resulting failure is opaque: the CLI rejects a
+ * subcommand the extension expects, which aborts activation before the
+ * configuration view leaves "Initializing...".
+ *
+ * Dev-only. A packaged extension fetches its CLI during the build, so the two
+ * versions can't diverge there.
+ */
+export async function checkBundledCliVersion(
+    cliPath: string,
+    metaData: PackageMetaData
+): Promise<boolean> {
+    if (!isDevExtension() || metaData.cliVersion === undefined) {
+        return true;
+    }
+
+    const actual = await getBundledCliVersion(cliPath);
+    if (actual === undefined || actual === metaData.cliVersion) {
+        return true;
+    }
+
+    const message =
+        `The bundled Databricks CLI is v${actual}, but this checkout pins ` +
+        `v${metaData.cliVersion}. Run "yarn workspace databricks run ` +
+        `package:cli:fetch" and reload the window.`;
+    logging.NamedLogger.getOrCreate(Loggers.Extension).warn(message);
+    window.showWarningMessage(message);
+    return false;
 }
 
 export async function checkArchCompat(context: ExtensionContext) {


### PR DESCRIPTION
## Changes

The extension shells out to a Databricks CLI bundled at
`packages/databricks-vscode/bin/databricks`, pinned by `cli.version` in
`packages/databricks-vscode/package.json`. `bin/` is gitignored, so the binary is
fetched once by `package:cli:fetch` and a later `git pull` that bumps
`cli.version` leaves the old one in place.

The resulting failure is opaque. A stale CLI rejects a subcommand the extension
expects — `unknown command "aitools"` for a checkout predating #2025 — which
throws inside `AiToolsManager.initialize` and aborts activation before
`databricks.context.initialized` is set. The configuration view then sits on
"Initializing..." indefinitely, with nothing pointing at the CLI as the cause.
This cost real debugging time on a 4-month-old checkout.

This PR compares the bundled binary's reported version against the pinned one at
startup and warns, naming the command to fix it:

> The bundled Databricks CLI is v0.297.2, but this checkout pins v1.11.0. Run
> "yarn workspace databricks run package:cli:fetch" and reload the window.

Design notes:

- **Dev-only** (`isDevExtension()`). A packaged extension fetches its CLI during
  the build, so the two versions can't diverge there.
- **Warn-only, not blocking.** A mismatched CLI is usually still usable; failing
  activation would be worse than the warning.
- **Not awaited** in `activate()`, so activation doesn't wait on spawning the CLI.
- Lives beside `checkArchCompat` in `packageJsonUtils.ts`, which is the same shape
  of startup guard.

Also documents the devloop in `AGENTS.md` (re-fetching the CLI after a pull, lazy
activation, the marketplace extension ID collision, and where the logs live), and
notes in `CONTRIBUTING.md` that the CLI fetch is not a one-time step.

## Tests

Added unit tests in `packageJsonUtils.test.ts` covering: reading the reported
version, a missing binary, a stale CLI, a matching CLI, a non-dev checkout, and an
unknown pinned version. The stub-CLI cases are skipped on Windows, where a shell
script isn't executable. Also updated the existing `getMetadata` test, which
asserts with `deepEqual` and so needed the new `cliVersion` field.

Verified manually that the warning fires for the real case that prompted this —
a v0.297.2 binary in a checkout pinning v1.11.0 — and that it stays silent once
`package:cli:fetch` has run.

⚠️ **Not yet run through the repo's test runner.** My local checkout has stale
`node_modules` (TypeScript 5.3.3 where the repo now pins ^6.0.3, and a mocha whose
bundled yargs breaks on Node 26), and npmjs is unreachable from this machine, so
`yarn workspace databricks run test:unit` could not execute. I verified the logic
by compiling the module and exercising it directly — all six cases pass — but the
suite should be run on fresh dependencies before merging.

This pull request and its description were written by Isaac.
