### PR TITLE
fix(python-setup): show vN versions and offer the full supported range

### DIFF
--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
@@ -19,16 +19,20 @@ describe("buildVersionPickItems", () => {
         expect(items[1].picked).to.equal(false);
     });
 
-    it("labels each item with the bare version and only stars the picked one", () => {
+    it("labels each item with the vN display form and only stars the picked one", () => {
         const items = buildVersionPickItems([
             {version: "5", score: 100, sources: ["bundleYaml"]},
             {version: "4", score: 50, sources: ["notebook"]},
         ]);
 
-        // The picked item is visually marked; others are the plain version.
-        expect(items[0].label).to.contain("5");
+        // Labels use the `vN` form (matching the CLI/docs/compute picker); the
+        // picked item is additionally starred, others are just `vN`.
+        expect(items[0].label).to.contain("v5");
         expect(items[0].label).to.not.equal(items[0].version);
-        expect(items[1].label).to.equal("4");
+        expect(items[1].label).to.equal("v4");
+        // The forwarded payload stays the bare integer, not the display form.
+        expect(items[0].version).to.equal("5");
+        expect(items[1].version).to.equal("4");
     });
 
     it("handles a fallback-only list", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
@@ -19,6 +19,15 @@ const SOURCE_LABELS: Record<VersionSource, string> = {
     /* eslint-enable @typescript-eslint/naming-convention */
 };
 
+/**
+ * Render a bare version for display in the `vN` form the CLI, compute picker and
+ * docs all use (e.g. "5" -> "v5"). Display-only: the item's `version` field
+ * stays the bare integer the `--serverless-version` flag expects.
+ */
+function displayVersion(version: string): string {
+    return `v${version}`;
+}
+
 function describeSources(sources: VersionSource[]): string {
     const labels = sources.map((s) => SOURCE_LABELS[s]);
     if (labels.length === 0) {
@@ -37,8 +46,9 @@ function describeSources(sources: VersionSource[]): string {
  * starred. (`picked` is also set for completeness, but note `showQuickPick`
  * only honours it in multi-select mode -- see {@link pickServerlessVersion} --
  * so in this single-select picker the star and ordering are what actually
- * signal the recommendation.) Every row carries its bare `version` for the
- * caller to forward to the CLI, and a `description` summarising where the
+ * signal the recommendation.) Each row's `label` is the `vN` display form (see
+ * {@link displayVersion}), while its `version` field stays the bare integer for
+ * the caller to forward to the CLI, plus a `description` summarising where the
  * version came from.
  */
 export function buildVersionPickItems(
@@ -46,8 +56,9 @@ export function buildVersionPickItems(
 ): VersionPickItem[] {
     return ranked.map((r, i) => {
         const picked = i === 0;
+        const label = displayVersion(r.version);
         return {
-            label: picked ? `$(star-full) ${r.version}` : r.version,
+            label: picked ? `$(star-full) ${label}` : label,
             description: describeSources(r.sources),
             version: r.version,
             picked,
@@ -71,7 +82,7 @@ export async function pickServerlessVersion(
     }
     const selected = await window.showQuickPick(items, {
         title: "Select serverless environment version",
-        placeHolder: `Recommended: ${items[0].version}`,
+        placeHolder: `Recommended: ${displayVersion(items[0].version)}`,
     });
     return selected?.version;
 }

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.test.ts
@@ -119,7 +119,9 @@ describe("makeServerlessVersionPrompt", () => {
         });
 
         expect(await prompt()).to.equal("4");
-        expect(ranked).to.deep.equal([["4", "5"]]);
+        // The bundle-declared "4" (weight 100) leads; the rest of the supported
+        // range is still offered at score 0, ordered by higher version.
+        expect(ranked).to.deep.equal([["4", "5", "3", "2", "1"]]);
     });
 
     it("returns undefined when the user dismisses the picker", async () => {

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -45,9 +45,30 @@ describe("scoreServerlessVersions", () => {
 
     it("always includes the fallback candidate, even with no observations", () => {
         const ranked = scoreServerlessVersions([]);
-        expect(ranked).to.have.length(1);
+        // The fallback outranks the seeded (unobserved, score 0) versions.
         expect(ranked[0].version).to.equal("5");
         expect(ranked[0].sources).to.deep.equal(["fallback"]);
+    });
+
+    it("offers every supported version, scoring unobserved ones 0", () => {
+        // Only v4 is observed, but the full v1..v5 range must still be
+        // reachable so a user can pick a lower version the project never used.
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "bundleYaml"},
+        ]);
+        expect(ranked.map((r) => r.version)).to.have.members([
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+        ]);
+        // Unobserved versions carry no sources and a score of 0.
+        const v2 = ranked.find((r) => r.version === "2")!;
+        expect(v2.score).to.equal(0);
+        expect(v2.sources).to.deep.equal([]);
+        // The observed version still ranks above the unobserved ones.
+        expect(ranked[0].version).to.equal("4");
     });
 
     it("merges the fallback into a matching observed version instead of duplicating it", () => {
@@ -82,7 +103,8 @@ describe("scoreServerlessVersions", () => {
         const fives = ranked.filter((r) => r.version === "5");
         expect(ranked.map((r) => r.version)).to.not.include("v5");
         expect(fives).to.have.length(1);
-        // "v5" was dropped, so "5" is corroborated only by the fallback.
+        // "v5" was dropped, so "5" is corroborated only by the fallback (the
+        // bundleYaml source never applied).
         expect(fives[0].sources).to.deep.equal(["fallback"]);
     });
 
@@ -99,10 +121,15 @@ describe("scoreServerlessVersions", () => {
             {version: "+5", source: "notebook"},
             {version: " 5", source: "workspaceDefault"},
         ]);
-        // Everything invalid is filtered; only the fallback survives.
-        expect(ranked).to.have.length(1);
+        // Every invalid observation is dropped, so no version carries a source
+        // other than the fallback. (The full v1..v5 range is still offered at
+        // score 0 -- see the full-range test above.)
         expect(ranked[0].version).to.equal("5");
         expect(ranked[0].sources).to.deep.equal(["fallback"]);
+        const withSources = ranked.filter((r) => r.sources.length > 0);
+        expect(withSources).to.deep.equal([
+            {version: "5", score: WEIGHTS.fallback, sources: ["fallback"]},
+        ]);
     });
 
     it("keeps every version at the supported boundaries (1 and 5)", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
@@ -90,9 +90,17 @@ function versionNumber(v: string): number {
 
 /**
  * Rank candidate versions by total weight (desc), breaking ties by higher
- * numeric version. The {@link FALLBACK_VERSION} is always included as a
- * candidate; if it coincides with an observed version the two are merged into a
- * single, better-corroborated row rather than duplicated.
+ * numeric version.
+ *
+ * Every version in the supported range [{@link MIN_SUPPORTED_VERSION},
+ * {@link MAX_SUPPORTED_VERSION}] is always offered as a candidate, so lower
+ * versions the project never used stay reachable in the picker rather than
+ * being silently unavailable. Versions with no backing observation keep a score
+ * of 0 (and no sources), so they sort below any observed candidate. The
+ * {@link FALLBACK_VERSION} additionally carries the `fallback` source, so it
+ * wins when nothing else was observed; if it coincides with an observed version
+ * the two are merged into a single, better-corroborated row rather than
+ * duplicated.
  */
 export function scoreServerlessVersions(
     observations: VersionObservation[]
@@ -106,6 +114,12 @@ export function scoreServerlessVersions(
     ];
 
     const byVersion = new Map<string, ScoredVersion>();
+    // Seed the whole supported range at score 0 so every version the CLI
+    // accepts is offered, even ones this project has never observed.
+    for (let n = MIN_SUPPORTED_VERSION; n <= MAX_SUPPORTED_VERSION; n++) {
+        const version = String(n);
+        byVersion.set(version, {version, score: 0, sources: []});
+    }
     for (const {version, source} of all) {
         const entry = byVersion.get(version) ?? {
             version,


### PR DESCRIPTION
## Why

Two defects in the serverless version picker, found during the M4 bug bash ([DECO-27917](https://databricks.atlassian.net/browse/DECO-27917) defects #4 and #5):

- **#4 — Version picker shows bare integers instead of `vN`.** It displayed "5", "4" rather than "v5", "v4", inconsistent with the compute picker, the CLI output, and the docs. Display-only issue; the payload should stay a bare integer.
- **#5 — Only observed versions are offered.** Lower versions the project never used (v1, v2, v3) were absent and unreachable, contradicting the ERD, which specifies that all known versions are listed.

## What

- **`serverlessVersionScoring.ts`**: seed the whole supported range `[MIN_SUPPORTED_VERSION, MAX_SUPPORTED_VERSION]` at score 0 before applying observations, so every CLI-accepted version is offered. Unobserved versions keep score 0 (no sources) and sort below any observed candidate; the fallback still wins when nothing was observed, and observed versions still outrank the rest.
- **`serverlessVersionPicker.ts`**: render the QuickPick labels and placeholder in the `vN` display form via a new `displayVersion` helper. **Display-only** — each item's `version` field (the value forwarded to `--serverless-version`) stays the bare integer.
- **Tests**: assert the `vN` labels keep bare-integer payloads, that the full v1–v5 range is offered with unobserved versions scored 0, and update the resolver end-to-end expectation to the full ranked range.

## Verification

- Unit suite green: **666 passing, 0 failing, 10 pending**.
- ESLint + Prettier clean on all changed files.

This pull request and its description were written by Isaac.

[DECO-27917]: https://databricks.atlassian.net/browse/DECO-27917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ