### PR TITLE
fix(python-setup): surface the CLI failure detail in the setup log

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -310,6 +310,28 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         );
     });
 
+    it("passes the CLI's raw failure detail to the log, not just the popup copy", async () => {
+        const shown: {message: string; detail?: string}[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: ERROR_NO_TARGET}),
+                showError: async (message, detail) => {
+                    shown.push({message, detail});
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(shown).to.have.length(1);
+        // The popup stays the concise mapped copy (no raw CLI flag noise)...
+        expect(shown[0].message).to.not.contain("--serverless-version");
+        // ...while the detail carries the CLI's own explanation plus the
+        // phase/code, so the "Show Logs" button leads somewhere useful.
+        expect(shown[0].detail).to.contain("No compute target is selected");
+        expect(shown[0].detail).to.contain("E_NO_TARGET");
+    });
+
     it("surfaces the raw error message when the CLI run rejects", async () => {
         const shownErrors: string[] = [];
         const setup = new PythonSetupEnvironmentSetup(

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -9,6 +9,7 @@ import {
     PythonSetupResult,
 } from "../models/PythonSetupResult";
 import {
+    formatSetupFailureDetail,
     getPythonSetupErrorMessage,
     NO_COMPUTE_TARGET_MESSAGE,
 } from "../utils/errorMessages";
@@ -119,13 +120,18 @@ export interface PythonSetupSetupDeps {
 
     /**
      * A plain user-facing notification for pre-flight guidance (e.g. no compute
-     * attached), where no CLI ran. Unlike {@link showError} it does not reveal
-     * the output channel — there is no log to show.
+     * attached), where no CLI ran. Unlike {@link showError} it offers no log
+     * affordance — there is no log to show.
      */
     notify: (message: string) => Promise<void>;
 
-    /** Shows the mapped, user-facing copy — not raw CLI text. */
-    showError: (message: string) => Promise<void>;
+    /**
+     * Shows the mapped, user-facing copy — not raw CLI text — with a "Show Logs"
+     * action that reveals the setup output channel. `detail`, when given, is
+     * written to that channel first (see `formatSetupFailureDetail`), so the
+     * button leads to the CLI's full explanation instead of an empty log.
+     */
+    showError: (message: string, detail?: string) => Promise<void>;
 
     showSuccess: (result: PythonSetupResult) => Promise<void>;
 
@@ -337,7 +343,10 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 envKey: result.compute?.envKey,
                 diskMutated: result.error?.diskMutated,
             });
-            await this.deps.showError(getPythonSetupErrorMessage(result));
+            await this.deps.showError(
+                getPythonSetupErrorMessage(result),
+                formatSetupFailureDetail(result)
+            );
             return;
         }
 

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {Uri} from "vscode";
+import {Uri, window} from "vscode";
 import {
     makePythonSetupDeps,
     makePythonSetupVisibility,
@@ -421,5 +421,97 @@ describe("makePythonSetupDeps withProgress", () => {
         // cancellable:true, so this reflects the user's Cancel button.
         expect(token).to.not.equal(undefined);
         expect(token.isCancellationRequested).to.equal(false);
+    });
+});
+
+describe("makePythonSetupDeps showError", () => {
+    let originalShowError: typeof window.showErrorMessage;
+    let shownWith: {message: string; actions: string[]}[];
+    let reply: string | undefined;
+
+    beforeEach(() => {
+        originalShowError = window.showErrorMessage;
+        shownWith = [];
+        reply = undefined;
+        // Capture what the error popup is shown with, and control what the user
+        // "clicks". (ts-mockito can't stub the vscode namespace, so swap the fn.)
+        (window as unknown as {showErrorMessage: unknown}).showErrorMessage =
+            async (message: string, ...actions: string[]) => {
+                shownWith.push({message, actions});
+                return reply;
+            };
+    });
+
+    afterEach(() => {
+        (window as unknown as {showErrorMessage: unknown}).showErrorMessage =
+            originalShowError;
+    });
+
+    it("writes the detail into the log channel", async () => {
+        const appended: string[] = [];
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {append: (c) => appended.push(c), show: () => {}},
+            })
+        );
+
+        await deps.showError("friendly copy", "raw conflict detail");
+
+        expect(appended.join("")).to.contain("raw conflict detail");
+    });
+
+    it("offers a Show Logs action and reveals the channel when it is picked", async () => {
+        let shown = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {
+                    append: () => {},
+                    show: () => {
+                        shown++;
+                    },
+                },
+            })
+        );
+        reply = "Show Logs";
+
+        await deps.showError("friendly copy", "detail");
+
+        expect(shownWith).to.have.length(1);
+        expect(shownWith[0].message).to.equal("friendly copy");
+        expect(shownWith[0].actions).to.contain("Show Logs");
+        expect(shown).to.equal(1);
+    });
+
+    it("does not reveal the channel when the popup is dismissed", async () => {
+        let shown = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {
+                    append: () => {},
+                    show: () => {
+                        shown++;
+                    },
+                },
+            })
+        );
+        reply = undefined; // user dismissed the popup without clicking
+
+        await deps.showError("friendly copy", "detail");
+
+        expect(shown).to.equal(0);
+    });
+
+    it("still offers the button but writes nothing when there is no detail", async () => {
+        const appended: string[] = [];
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {append: (c) => appended.push(c), show: () => {}},
+            })
+        );
+
+        await deps.showError("friendly copy");
+
+        expect(appended).to.have.length(0);
+        expect(shownWith[0].actions).to.contain("Show Logs");
     });
 });

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -206,11 +206,21 @@ export function makePythonSetupDeps(
             // revealing the (empty) output channel.
             await window.showWarningMessage(message);
         },
-        showError: async (message: string) => {
-            // Reveal the streamed CLI log alongside the mapped one-liner so the
-            // user can see why the run failed, not just that it did.
-            wiring.log.show();
-            await window.showErrorMessage(message);
+        showError: async (message: string, detail?: string) => {
+            // The mapped one-liner is deliberately concise and drops the CLI's
+            // own explanation; write that detail into the channel so the log the
+            // popup points at actually contains it (under `--output json` the CLI
+            // streams little else). Then offer a button rather than force-opening
+            // the panel: a self-revealing, possibly-empty log is worse than one
+            // the user opens on demand.
+            if (detail !== undefined && detail.length > 0) {
+                wiring.log.append(detail);
+            }
+            const showLogs = "Show Logs";
+            const picked = await window.showErrorMessage(message, showLogs);
+            if (picked === showLogs) {
+                wiring.log.show();
+            }
         },
         showSuccess: async () => {
             await window.showInformationMessage(

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -1,5 +1,8 @@
 import {expect} from "chai";
-import {getPythonSetupErrorMessage} from "./errorMessages";
+import {
+    formatSetupFailureDetail,
+    getPythonSetupErrorMessage,
+} from "./errorMessages";
 import {
     PythonSetupResult,
     PythonSetupErrorCode,
@@ -199,5 +202,53 @@ describe("getPythonSetupErrorMessage", () => {
 
         const usage = getPythonSetupErrorMessage(ERROR_USAGE);
         expect(usage).to.be.a("string").and.not.be.empty;
+    });
+});
+
+describe("formatSetupFailureDetail", () => {
+    it("names the failing phase and error code", () => {
+        const detail = formatSetupFailureDetail(
+            failure("E_PROVISION", {failurePhase: "provision"})
+        );
+        expect(detail).to.contain("provision");
+        expect(detail).to.contain("E_PROVISION");
+    });
+
+    it("includes the raw CLI message (the detail the friendly copy drops)", () => {
+        // This is the whole point: the uv conflict text lives in error.message,
+        // which the mapped popup copy discards. It must reach the log channel.
+        const detail = formatSetupFailureDetail(
+            failure("E_PROVISION", {
+                message:
+                    "x==1 depends on y<2, but the runtime requires y==2 (conflict)",
+            })
+        );
+        expect(detail).to.contain("x==1 depends on y<2");
+        expect(detail).to.contain("conflict");
+    });
+
+    it("lists the per-phase statuses so the break point is visible", () => {
+        const detail = formatSetupFailureDetail(
+            failure(
+                "E_PROVISION",
+                {failurePhase: "provision"},
+                {
+                    phases: [
+                        {phase: "preflight", status: "ok"},
+                        {phase: "resolve", status: "ok"},
+                        {phase: "provision", status: "error"},
+                    ],
+                }
+            )
+        );
+        expect(detail).to.contain("preflight");
+        expect(detail).to.contain("resolve");
+        expect(detail).to.match(/provision.*error/);
+    });
+
+    it("returns undefined when the result carries no error (nothing to log)", () => {
+        const ok = failure("E_PROVISION");
+        ok.error = null;
+        expect(formatSetupFailureDetail(ok)).to.equal(undefined);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -77,6 +77,42 @@ export function getPythonSetupErrorMessage(result: PythonSetupResult): string {
 }
 
 /**
+ * The detailed failure text for the "Databricks Python Environment Setup" output
+ * channel — the counterpart to {@link getPythonSetupErrorMessage}'s concise
+ * popup copy. The popup is mapped from the error *code* and deliberately drops
+ * the CLI's raw `error.message`; under `--output json` that message (e.g. uv's
+ * version-conflict explanation) is otherwise nowhere the user can see it. This
+ * puts it, the failing phase/code, and the per-phase status line into the log
+ * so "review the conflict in the logs" actually leads somewhere.
+ *
+ * Returns `undefined` when the result carries no error, i.e. there is nothing to
+ * add to the log.
+ */
+export function formatSetupFailureDetail(
+    result: PythonSetupResult
+): string | undefined {
+    const err = result.error;
+    if (!err) {
+        return undefined;
+    }
+    const lines = [
+        `Setup failed in the ${err.failurePhase} phase (${err.code}).`,
+    ];
+    if (err.message) {
+        lines.push(err.message);
+    }
+    if (result.phases.length > 0) {
+        lines.push(
+            "Phases: " +
+                result.phases.map((p) => `${p.phase}=${p.status}`).join(", ")
+        );
+    }
+    // Bracket with blank lines so the block stands apart from any streamed CLI
+    // output already in the channel.
+    return `\n${lines.join("\n")}\n`;
+}
+
+/**
  * Trailing sentence describing what, if anything, changed on disk — so we never
  * point the user at a rollback path that does not exist.
  */


### PR DESCRIPTION
## Why

On a failed `environments setup-local` run, the error popup shows a concise
message mapped from the error *code* and drops the CLI's own `error.message`.
Under `--output json` the CLI streams almost nothing to stderr, so that message
— e.g. uv's dependency version-conflict explanation — reaches neither the popup
nor the **Databricks Python Environment Setup** output channel. The
`E_PROVISION` copy nonetheless tells the user to "review the conflict in the
logs", which were effectively empty, so the failure was undiagnosable from the
UI.

## What

- **`errorMessages.ts`** — add `formatSetupFailureDetail`, a pure helper that
  builds the log detail block: the failing phase + error code, the raw
  `error.message`, and the per-phase status line.
- **`PythonSetupEnvironmentSetup.ts`** — widen the `showError` seam to
  `(message, detail?)` and pass `formatSetupFailureDetail(result)` at the
  failed-result site, so the CLI's explanation reaches the channel.
- **`pythonSetupDeps.ts`** — `showError` writes `detail` to the channel and, in
  place of force-revealing it, offers a **"Show Logs"** action that opens the
  channel only when the user asks. A self-opening, possibly-empty log is worse
  than one opened on demand.

Net: the popup stays concise, gains a **Show Logs** button, and the log it opens
now contains the actual conflict.

## Testing

- Unit suite (VS Code host): **668 passing**, 10 pending. The 7 failures are
  pre-existing `CliWrapper` tests that require the bundled `bin/databricks`
  (absent in a fresh checkout — `spawn … ENOENT`) and are unrelated to this
  change.
- New tests: `formatSetupFailureDetail` (phase/code, raw message, phase table,
  no-error → `undefined`); the real `showError` (writes detail, offers
  "Show Logs", reveals only when picked, writes nothing when there is no
  detail); the orchestrator passes the detail on a failed result.
- ESLint + Prettier clean on all changed files.

This pull request and its description were written by Isaac.