### PR TITLE
feat(python-setup): add "Re-run Python setup" button on the ready row

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -511,6 +511,13 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.environment.rerunPythonEnv",
+                "title": "Re-run Python setup",
+                "icon": "$(sync)",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && !databricks.context.remoteMode",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.environment.selectPythonInterpreter",
                 "title": "Change Python environment",
                 "icon": "$(gear)",
@@ -1151,6 +1158,18 @@
                     "icon": "$(gear)"
                 },
                 {
+                    "command": "databricks.environment.rerunPythonEnv",
+                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.success$/",
+                    "group": "inline@0",
+                    "icon": "$(sync)"
+                },
+                {
+                    "command": "databricks.environment.rerunPythonEnv",
+                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.success$/",
+                    "group": "navigation@0",
+                    "icon": "$(sync)"
+                },
+                {
                     "command": "databricks.environment.reinstallDBConnect",
                     "when": "view == configurationView && viewItem =~ /^databricks.environment.checkEnvironmentDependencies.success$/",
                     "group": "inline@0",
@@ -1248,6 +1267,10 @@
                 },
                 {
                     "command": "databricks.environment.setupPythonEnv",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.environment.rerunPythonEnv",
                     "when": "false"
                 },
                 {

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1002,6 +1002,14 @@ export async function activate(
             "databricks.environment.setupPythonEnv",
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
+        ),
+        // Re-run affordance on the "Python environment ready" row. Delegates to
+        // the same setup handler (re-entrancy-guarded); a distinct id lets the
+        // menu show a "Re-run Python setup" title instead of the initial one.
+        telemetry.registerCommand(
+            "databricks.environment.rerunPythonEnv",
+            pythonSetupEnvironment.setup,
+            pythonSetupEnvironment
         )
     );
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -590,10 +590,33 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 mode: "default",
                 // hasPyprojectToml defaults to true, so this is not greenfield.
                 isGreenfield: false,
+                // First run for the project: not yet ready.
+                trigger: "initial",
             },
         ]);
         expect(telemetry.results).to.deep.equal([
             {outcome: "ok", envKey: SUCCESS_REAL_RUN.compute!.envKey},
+        ]);
+    });
+
+    it("labels a run over an already-ready project as a rerun", async () => {
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                ...telemetry,
+                getDetection: async () => detection("uv", ["uv"]),
+            })
+        );
+
+        // First run provisions the env and marks the project ready.
+        await setup.setup();
+        expect(setup.ready).to.equal(true);
+        // Second run over the same (now ready) project is a re-run.
+        await setup.setup();
+
+        expect(telemetry.attempts.map((a) => a.trigger)).to.deep.equal([
+            "initial",
+            "rerun",
         ]);
     });
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -442,6 +442,11 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                     compute.kind === "serverless" ? compute.version : undefined,
                 mode: invocation.mode,
                 isGreenfield,
+                // A run against a project already marked ready this session is a
+                // re-run (the ready row's Re-run button / row click); anything
+                // else is the first setup. Derived from state, not the command,
+                // so every entry point labels the same event correctly.
+                trigger: this.readyRoots.has(projectRoot) ? "rerun" : "initial",
             });
             return (report) => {
                 try {

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -94,6 +94,16 @@ export type TargetCompute = ComputeType | "none";
 /** What triggered a package-manager detection emission. */
 export type SetupTrigger = "auto_open" | "explicit_command" | "run" | "debug";
 
+/**
+ * Whether a setup run is the first for the project *this session* (`initial`)
+ * or a re-run over an environment already provisioned this session (`rerun`,
+ * e.g. the "Re-run Python setup" button on the ready row). Derived from the
+ * session-scoped ready state, so a run after a window reload reads as `initial`
+ * again. One event, one enum dimension — so re-runs stay analysable without
+ * fingerprinting on the command id.
+ */
+export type PythonSetupRunTrigger = "initial" | "rerun";
+
 // The uv-native ("VPEX") python-setup flow mirrors the CLI's `environments
 // setup-local --output json` contract, so the setup event unions are owned by
 // the result model (the TypeScript view of that contract) and re-exported here.
@@ -437,12 +447,19 @@ export class EventTypes {
         serverlessVersion?: string;
         mode: PythonSetupMode;
         isGreenfield?: boolean;
+        trigger: PythonSetupRunTrigger;
     }> = {
         comment:
             "A uv-native Python environment setup run is starting: emitted once the compute " +
             "target is known and immediately before the CLI is spawned, so every attempt has " +
             "exactly one matching python_env.setup.result. Categorical data only — no cluster " +
             "IDs/names, paths, or package names.",
+        trigger: {
+            comment:
+                "initial (first setup for the project this session) or rerun (re-running over an " +
+                "environment already provisioned this session, e.g. via the ready row's Re-run " +
+                "button). Session-scoped: a run after a window reload reads as initial again",
+        },
         packageManager: {
             comment:
                 "The package manager detected for the project (uv > poetry > conda > pip), or unknown",

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
@@ -41,6 +41,7 @@ describe(__filename, () => {
             serverlessVersion: "5",
             mode: "default",
             isGreenfield: true,
+            trigger: "initial",
         });
         reportResult({
             outcome: "ok",
@@ -58,6 +59,7 @@ describe(__filename, () => {
             "event.serverlessVersion": "5",
             "event.mode": "default",
             "event.isGreenfield": "true",
+            "event.trigger": "initial",
         });
         expect(events[1].props).to.deep.equal({
             "version": "1.0",
@@ -73,6 +75,7 @@ describe(__filename, () => {
             packageManager: "uv",
             targetType: "cluster",
             mode: "default",
+            trigger: "initial",
         });
         reportResult({outcome: "ok"});
 
@@ -95,6 +98,7 @@ describe(__filename, () => {
             mode: "constraints-only",
             serverlessVersion: undefined,
             isGreenfield: undefined,
+            trigger: "initial",
         });
         // A cancelled run has no phase, error code, env key or disk state.
         reportResult({
@@ -110,6 +114,7 @@ describe(__filename, () => {
             "event.packageManager": "pip",
             "event.targetType": "cluster",
             "event.mode": "constraints-only",
+            "event.trigger": "initial",
         });
         expect(events[1].props).to.deep.equal({
             "version": "1.0",
@@ -130,6 +135,7 @@ describe(__filename, () => {
             targetType: "cluster",
             mode: "default",
             isGreenfield: false,
+            trigger: "initial",
         });
         reportResult({
             outcome: "failed",
@@ -156,6 +162,7 @@ describe(__filename, () => {
             packageManager: "uv",
             targetType: "cluster",
             mode: "default",
+            trigger: "initial",
         });
         reportResult({outcome: "ok"});
         // A second call (e.g. from a future refactor that adds a terminal path
@@ -181,6 +188,7 @@ describe(__filename, () => {
                 packageManager: "uv",
                 targetType: "cluster",
                 mode: "default",
+                trigger: "initial",
             })({outcome: "ok", envKey});
             expect(events[1].props["event.envKey"]).to.equal(envKey);
         }
@@ -208,6 +216,7 @@ describe(__filename, () => {
                 packageManager: "uv",
                 targetType: "cluster",
                 mode: "default",
+                trigger: "initial",
             })({outcome: "ok", envKey});
             expect(events[1].props["event.envKey"]).to.equal("other");
         }
@@ -225,6 +234,7 @@ describe(__filename, () => {
             packageManager: "uv",
             targetType: "cluster",
             mode: "default",
+            trigger: "initial",
             clusterId: "0710-142042-secretcluster",
             projectPath: "/Users/jane/projects/acme",
         } as any)({
@@ -243,6 +253,7 @@ describe(__filename, () => {
             "event.mode",
             "event.packageManager",
             "event.targetType",
+            "event.trigger",
             "version",
         ]);
         expect(Object.keys(events[1].props).sort()).to.deep.equal([
@@ -278,6 +289,7 @@ describe(__filename, () => {
             packageManager: "uv",
             targetType: "cluster",
             mode: "default",
+            trigger: "initial",
         });
 
         expect(() => reportResult({outcome: "ok"})).to.not.throw();

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -6,6 +6,7 @@ import {
     PythonSetupFailurePhase,
     PythonSetupMode,
     PythonSetupOutcome,
+    PythonSetupRunTrigger,
 } from "./constants";
 
 /**
@@ -25,6 +26,12 @@ export interface PythonSetupAttempt {
      * `pyproject.toml` says nothing about greenfield-ness.
      */
     isGreenfield?: boolean;
+    /**
+     * Whether this is the first setup for the project this session or a re-run
+     * over an environment already provisioned this session (session-scoped).
+     * Same event, one enum dimension.
+     */
+    trigger: PythonSetupRunTrigger;
 }
 
 /** How a setup run ended, reduced to the categorical fields we report. */
@@ -137,6 +144,7 @@ Telemetry.prototype.recordPythonSetupAttempt = function (
         packageManager: attempt.packageManager,
         targetType: attempt.targetType,
         mode: attempt.mode,
+        trigger: attempt.trigger,
         ...(attempt.serverlessVersion !== undefined
             ? {serverlessVersion: attempt.serverlessVersion}
             : {}),


### PR DESCRIPTION
## Why

Once the uv-native Python setup completes, the configuration view shows a **"Python environment ready"** row with no discoverable way to run setup again — the only affordance is clicking the label, which is not obvious. This adds a button, like *Serverless → Configure Compute*, to re-trigger setup.

## What

- Add an **inline icon** and a **right-click "Re-run Python setup"** entry on the ready row (contextValue `databricks.environment.pythonSetup.success`), wired exactly like the existing `selectPythonInterpreter` entry (`inline@0` + `navigation@0`).
- Back it with a thin `databricks.environment.rerunPythonEnv` command that delegates to the existing, re-entrancy-guarded `setup` handler. A distinct id lets the menu show a "Re-run Python setup" title instead of the initial CTA's.
- **Telemetry:** run vs re-run is *one event with an enum label*, not two command-execution events. `python_env.setup.attempt` gains a required `trigger` (`initial | rerun`), derived from state (`readyRoots.has(root)`) rather than the command — so every entry point (CTA, row click, inline button, palette) labels the same event correctly.

Only the ready state gets the button; the error-state row is already a "Set up…" call-to-action.

## Verification

- `tsc --build` clean; `eslint` + `prettier -c` clean.
- 48 unit tests pass, including a new test that a second setup over an already-ready project labels the attempt `rerun`.

This pull request and its description were written by Isaac.