### PR TITLE
feat(telemetry): capture extension activation in remote mode

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -390,6 +390,10 @@ export async function activate(
         process.env["DATABRICKS_REMOTE_ENV"] === "1" &&
         Boolean(process.env["DATABRICKS_VIRTUAL_ENV"]);
     if (!isRemoteSshMode) {
+        telemetry.setMetadata(Metadata.CONTEXT, {
+            ...getContextMetadata(),
+            mode: "normal",
+        });
         aiToolsCommands.initializeCommand()();
     }
 
@@ -534,6 +538,10 @@ export async function activate(
             {venvPath}
         );
         customWhenContext.setRemoteMode(true);
+        telemetry.setMetadata(Metadata.CONTEXT, {
+            ...getContextMetadata(),
+            mode: "remote",
+        });
 
         try {
             await pythonExtensionWrapper.api.environments.updateActiveEnvironmentPath(
@@ -619,6 +627,7 @@ export async function activate(
         connectRemote();
 
         customWhenContext.setActivated(true);
+        telemetry.recordEvent(Events.EXTENSION_ACTIVATION);
         return;
     }
     logging.NamedLogger.getOrCreate(Loggers.Extension).debug(

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -275,8 +275,17 @@ export async function activate(
         return undefined;
     }
 
+    // Mode is fully determined by the ambient env vars, so decide it once here
+    // and bake it into the context metadata (rather than re-setting it later).
+    const isRemoteSshMode =
+        process.env["DATABRICKS_REMOTE_ENV"] === "1" &&
+        Boolean(process.env["DATABRICKS_VIRTUAL_ENV"]);
+
     const telemetry = Telemetry.createDefault();
-    telemetry.setMetadata(Metadata.CONTEXT, getContextMetadata());
+    telemetry.setMetadata(
+        Metadata.CONTEXT,
+        getContextMetadata(isRemoteSshMode ? "remote" : "normal")
+    );
 
     const loggerManager = new LoggerManager(context);
     if (workspaceConfigs.loggingEnabled) {
@@ -386,14 +395,7 @@ export async function activate(
     // Non-blocking so it doesn't delay activation. Skipped in Remote SSH mode,
     // where the AI tools commands are gated off (see the remote-mode branch
     // below) so there is nothing to initialize.
-    const isRemoteSshMode =
-        process.env["DATABRICKS_REMOTE_ENV"] === "1" &&
-        Boolean(process.env["DATABRICKS_VIRTUAL_ENV"]);
     if (!isRemoteSshMode) {
-        telemetry.setMetadata(Metadata.CONTEXT, {
-            ...getContextMetadata(),
-            mode: "normal",
-        });
         aiToolsCommands.initializeCommand()();
     }
 
@@ -538,10 +540,6 @@ export async function activate(
             {venvPath}
         );
         customWhenContext.setRemoteMode(true);
-        telemetry.setMetadata(Metadata.CONTEXT, {
-            ...getContextMetadata(),
-            mode: "remote",
-        });
 
         try {
             await pythonExtensionWrapper.api.environments.updateActiveEnvironmentPath(

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -538,6 +538,8 @@ export type EventReporter<E extends keyof EventTypes> = (
 
 export type EnvironmentType = "tests" | "prod";
 
+export type ExtensionMode = "remote" | "normal";
+
 /**
  * Additional metadata collected from the extension, independent of the event itself.
  */
@@ -574,10 +576,17 @@ export class MetadataTypes {
             comment: "The kind of authentication used by the user",
         },
     };
-    [Metadata.CONTEXT]: EventType<{environmentType: EnvironmentType}> = {
+    [Metadata.CONTEXT]: EventType<{
+        environmentType: EnvironmentType;
+        mode: ExtensionMode;
+    }> = {
         environmentType: {
             comment:
                 "A type of the environment this extension is running with (test, staging, prod)",
+        },
+        mode: {
+            comment:
+                "Whether the extension activated in remote (Databricks Remote SSH) or normal mode",
         },
     };
 }

--- a/packages/databricks-vscode/src/telemetry/index.test.ts
+++ b/packages/databricks-vscode/src/telemetry/index.test.ts
@@ -77,10 +77,7 @@ describe(__filename, () => {
 
     it("sets context metadata with the extension mode", async () => {
         delete process.env["DATABRICKS_VSCODE_INTEGRATION_TEST"];
-        telemetry.setMetadata(Metadata.CONTEXT, {
-            ...getContextMetadata(),
-            mode: "remote",
-        });
+        telemetry.setMetadata(Metadata.CONTEXT, getContextMetadata("remote"));
         telemetry.recordEvent(Events.COMMAND_EXECUTION, {
             command: "testCommand",
             success: true,

--- a/packages/databricks-vscode/src/telemetry/index.test.ts
+++ b/packages/databricks-vscode/src/telemetry/index.test.ts
@@ -75,6 +75,28 @@ describe(__filename, () => {
         });
     });
 
+    it("sets context metadata with the extension mode", async () => {
+        delete process.env["DATABRICKS_VSCODE_INTEGRATION_TEST"];
+        telemetry.setMetadata(Metadata.CONTEXT, {
+            ...getContextMetadata(),
+            mode: "remote",
+        });
+        telemetry.recordEvent(Events.COMMAND_EXECUTION, {
+            command: "testCommand",
+            success: true,
+            duration: 100,
+        });
+        const [eventName, props] = capture(reporter.sendTelemetryEvent).last();
+        assert.equal(eventName, "commandExecution");
+        assert.deepEqual(props, {
+            "version": "1.0",
+            "event.command": "testCommand",
+            "event.success": "true",
+            "context.environmentType": "prod",
+            "context.mode": "remote",
+        });
+    });
+
     it("sets user metadata correctly after logged in", async () => {
         const ws = mock(DatabricksWorkspace);
         when(ws.id).thenReturn("workspace-id");

--- a/packages/databricks-vscode/src/telemetry/index.ts
+++ b/packages/databricks-vscode/src/telemetry/index.ts
@@ -5,6 +5,7 @@ import {
     DEV_APP_INSIGHTS_CONFIGURATION_KEY,
     EventProperties,
     EventTypes,
+    ExtensionMode,
     ExtraMetadata,
     Metadata,
     MetadataTypes,
@@ -81,9 +82,12 @@ export async function toUserMetadata(
     return {...dbWorkspaceMetadata, ...authType};
 }
 
-export function getContextMetadata(): ExtraMetadata[Metadata.CONTEXT] {
+export function getContextMetadata(
+    mode?: ExtensionMode
+): ExtraMetadata[Metadata.CONTEXT] {
     return {
         environmentType: isIntegrationTest() ? "tests" : "prod",
+        ...(mode ? {mode} : {}),
     };
 }
 


### PR DESCRIPTION
## Changes

In a Databricks Remote SSH session, activate() takes a minimal branch and returns early before the normal-flow EXTENSION_ACTIVATION event ever fires, so remote-mode activations were invisible in telemetry and the events that did fire (connection state, Unity Catalog) couldn't be told apart from normal-mode ones.

Record EXTENSION_ACTIVATION from the remote branch too, and tag every event with the execution mode. A new `mode: "remote" | "normal"` field on Metadata.CONTEXT is set at each branch point, so the mode rides ambiently on all events tracked by the Telemetry instance mirroring how environmentType already works, rather than adding a per-event property or a separate event

## Tests

telemetry/index.test.ts
