### PR TITLE
feat(python-setup): report what setup did in a completion notification

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -393,7 +393,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         }
 
         // Reported before `showSuccess` on purpose: that awaits the user
-        // dismissing a toast, and folding think-time into `duration` would wreck
+        // dismissing the modal dialog, and folding think-time into `duration` would wreck
         // the setup-time metric this event exists to measure.
         reportResult({outcome: "ok", envKey: result.compute.envKey});
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -393,8 +393,8 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         }
 
         // Reported before `showSuccess` on purpose: that awaits the user
-        // dismissing the modal dialog, and folding think-time into `duration` would wreck
-        // the setup-time metric this event exists to measure.
+        // dismissing the notification, and folding think-time into `duration`
+        // would wreck the setup-time metric this event exists to measure.
         reportResult({outcome: "ok", envKey: result.compute.envKey});
 
         await this.deps.showSuccess(result);

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -6,7 +6,7 @@ import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {shouldShowPythonSetup} from "../utils/pythonSetupGate";
-import {formatSetupLog, formatSetupSummary} from "../utils/setupSummary";
+import {SETUP_READY_MESSAGE, formatSetupLog} from "../utils/setupSummary";
 import {venvInterpreterPath} from "../utils/venvInterpreterPath";
 import {
     CliRunner,
@@ -224,25 +224,21 @@ export function makePythonSetupDeps(
             }
         },
         showSuccess: async (result) => {
-            const {title, detail} = formatSetupSummary(result);
-            // Write the full breakdown to the log channel so "View logs" always
-            // has content: in --output json mode the CLI streams little or
-            // nothing to stderr on success, so the channel would otherwise be
-            // empty. This is also where the details the TL;DR notification omits
-            // (compute, venv path, backup, full warnings) live.
+            // Write the full breakdown to the log channel so "View Details"
+            // always has content: in --output json mode the CLI streams little
+            // or nothing to stderr on success, so the channel would otherwise
+            // be empty. This is where the details the one-line message omits
+            // (versions, compute, venv path, backup, full warnings) live.
             wiring.log.append(formatSetupLog(result));
             // A standard (non-modal) information notification, not a modal
-            // dialog: the summary is informational, not something to interrupt
-            // the user for. The notification message renders the title and the
-            // itemized outcomes on their own lines, so what was done stays
-            // visible inline without opening anything.
+            // dialog: the outcome is informational, not something to interrupt
+            // the user for.
+            const viewDetails = "View Details";
             const choice = await window.showInformationMessage(
-                `${title}\n${detail}`,
-                "View logs"
+                SETUP_READY_MESSAGE,
+                viewDetails
             );
-            if (choice === "View logs") {
-                // Reveal the streamed CLI log for users who want the full
-                // provisioning detail behind the summarized outcomes.
+            if (choice === viewDetails) {
                 wiring.log.show();
             }
         },

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -225,9 +225,13 @@ export function makePythonSetupDeps(
         },
         showSuccess: async (result) => {
             const {title, detail} = formatSetupSummary(result);
+            // A standard (non-modal) information notification, not a modal
+            // dialog: the summary is informational, not something to interrupt
+            // the user for. The notification message renders the title and the
+            // itemized outcomes on their own lines, so what was done stays
+            // visible inline without opening anything.
             const choice = await window.showInformationMessage(
-                title,
-                {modal: true, detail},
+                `${title}\n${detail}`,
                 "View logs"
             );
             if (choice === "View logs") {

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -6,7 +6,7 @@ import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {shouldShowPythonSetup} from "../utils/pythonSetupGate";
-import {SETUP_READY_MESSAGE, formatSetupLog} from "../utils/setupSummary";
+import {formatSetupLog, formatSetupNotification} from "../utils/setupSummary";
 import {venvInterpreterPath} from "../utils/venvInterpreterPath";
 import {
     CliRunner,
@@ -230,14 +230,15 @@ export function makePythonSetupDeps(
             // be empty. This is where the details the one-line message omits
             // (versions, compute, venv path, backup, full warnings) live.
             wiring.log.append(formatSetupLog(result));
-            // A standard (non-modal) information notification, not a modal
-            // dialog: the outcome is informational, not something to interrupt
-            // the user for.
+            // A standard (non-modal) notification, not a modal dialog: the
+            // outcome is informational, not something to interrupt the user
+            // for. A run with warnings raises a warning toast so it doesn't
+            // read as an unqualified success; the warnings are in the details.
+            const {message, isWarning} = formatSetupNotification(result);
             const viewDetails = "View Details";
-            const choice = await window.showInformationMessage(
-                SETUP_READY_MESSAGE,
-                viewDetails
-            );
+            const choice = isWarning
+                ? await window.showWarningMessage(message, viewDetails)
+                : await window.showInformationMessage(message, viewDetails);
             if (choice === viewDetails) {
                 wiring.log.show();
             }

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -6,7 +6,7 @@ import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {shouldShowPythonSetup} from "../utils/pythonSetupGate";
-import {formatSetupSummary} from "../utils/setupSummary";
+import {formatSetupLog, formatSetupSummary} from "../utils/setupSummary";
 import {venvInterpreterPath} from "../utils/venvInterpreterPath";
 import {
     CliRunner,
@@ -225,6 +225,12 @@ export function makePythonSetupDeps(
         },
         showSuccess: async (result) => {
             const {title, detail} = formatSetupSummary(result);
+            // Write the full breakdown to the log channel so "View logs" always
+            // has content: in --output json mode the CLI streams little or
+            // nothing to stderr on success, so the channel would otherwise be
+            // empty. This is also where the details the TL;DR notification omits
+            // (compute, venv path, backup, full warnings) live.
+            wiring.log.append(formatSetupLog(result));
             // A standard (non-modal) information notification, not a modal
             // dialog: the summary is informational, not something to interrupt
             // the user for. The notification message renders the title and the

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -6,6 +6,7 @@ import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {shouldShowPythonSetup} from "../utils/pythonSetupGate";
+import {formatSetupSummary} from "../utils/setupSummary";
 import {venvInterpreterPath} from "../utils/venvInterpreterPath";
 import {
     CliRunner,
@@ -222,10 +223,18 @@ export function makePythonSetupDeps(
                 wiring.log.show();
             }
         },
-        showSuccess: async () => {
-            await window.showInformationMessage(
-                "Python environment is set up for Databricks Connect."
+        showSuccess: async (result) => {
+            const {title, detail} = formatSetupSummary(result);
+            const choice = await window.showInformationMessage(
+                title,
+                {modal: true, detail},
+                "View logs"
             );
+            if (choice === "View logs") {
+                // Reveal the streamed CLI log for users who want the full
+                // provisioning detail behind the summarized outcomes.
+                wiring.log.show();
+            }
         },
         recordSetupAttempt: (attempt) =>
             wiring.telemetry.recordPythonSetupAttempt(attempt),

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -1,9 +1,10 @@
 import {expect} from "chai";
-import {formatSetupSummary} from "./setupSummary";
+import {formatSetupLog, formatSetupSummary} from "./setupSummary";
 import {PythonSetupResult} from "../models/PythonSetupResult";
 import {
     SUCCESS_DEFAULT,
     SUCCESS_CONSTRAINTS_ONLY,
+    SUCCESS_REAL_RUN,
 } from "../models/fixtures/setupLocalResults";
 
 describe("formatSetupSummary", () => {
@@ -69,5 +70,79 @@ describe("formatSetupSummary", () => {
     it("omits the warnings line when there are none", () => {
         const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
         expect(detail).to.not.contain("⚠");
+    });
+});
+
+describe("formatSetupLog", () => {
+    it("is non-empty and self-delimited with leading/trailing newlines", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT);
+        expect(log.startsWith("\n")).to.equal(true);
+        expect(log.endsWith("\n")).to.equal(true);
+        expect(log.trim().length).to.be.greaterThan(0);
+    });
+
+    it("includes the versions, compute and artifact source", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT);
+        expect(log).to.contain("Python:             3.12");
+        expect(log).to.contain("databricks-connect: 17.2.0");
+        expect(log).to.contain("Compute:            serverless v4");
+        expect(log).to.contain("Packages:           downloaded from network");
+    });
+
+    it("lists what was done", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT);
+        expect(log).to.contain(
+            "  • Added matching Databricks constraints to pyproject.toml"
+        );
+        expect(log).to.contain(
+            "  • Built the virtual environment with uv sync"
+        );
+        expect(log).to.contain(
+            "  • Selected .venv as the workspace interpreter"
+        );
+    });
+
+    it("reuses-from-cache wording when artifacts came from cache", () => {
+        const cached: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            resolved: {...SUCCESS_DEFAULT.resolved!, artifactSource: "cache"},
+        };
+        expect(formatSetupLog(cached)).to.contain(
+            "Packages:           reused from cache"
+        );
+    });
+
+    it("drops databricks-connect in constraints-only mode", () => {
+        const log = formatSetupLog(SUCCESS_CONSTRAINTS_ONLY);
+        expect(log).to.contain(
+            "Python environment ready — constraints applied."
+        );
+        expect(log).to.not.contain("databricks-connect");
+    });
+
+    it("shows the backup file and venv path on a real run", () => {
+        const log = formatSetupLog(SUCCESS_REAL_RUN);
+        expect(log).to.contain(
+            "  • Backed up your previous pyproject.toml (pyproject.toml.bak)"
+        );
+        expect(log).to.contain("Virtual environment: /home/user/project/.venv");
+    });
+
+    it("omits the backup line when nothing was backed up", () => {
+        const noBackup: PythonSetupResult = {
+            ...SUCCESS_REAL_RUN,
+            backupPath: undefined,
+        };
+        expect(formatSetupLog(noBackup)).to.not.contain("Backed up");
+    });
+
+    it("lists full warning messages when present", () => {
+        const warned: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            warnings: [{code: "W_X", message: "pinned an older wheel"}],
+        };
+        const log = formatSetupLog(warned);
+        expect(log).to.contain("Warnings:");
+        expect(log).to.contain("  • pinned an older wheel");
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -1,0 +1,106 @@
+import {expect} from "chai";
+import {formatSetupSummary} from "./setupSummary";
+import {PythonSetupResult} from "../models/PythonSetupResult";
+import {
+    SUCCESS_DEFAULT,
+    SUCCESS_CONSTRAINTS_ONLY,
+    SUCCESS_REAL_RUN,
+} from "../models/fixtures/setupLocalResults";
+
+describe("formatSetupSummary", () => {
+    it("titles a default-mode run for Databricks Connect", () => {
+        const {title} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(title).to.equal(
+            "Python environment ready for Databricks Connect"
+        );
+    });
+
+    it("lists the resolved python and databricks-connect versions", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.contain("Python 3.12 · databricks-connect 17.2.0");
+    });
+
+    it("names the serverless compute", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.contain("Compute: serverless v4");
+    });
+
+    it("itemizes the constraints, uv sync and interpreter steps", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.contain(
+            "✓ Added matching Databricks constraints to pyproject.toml"
+        );
+        expect(detail).to.contain(
+            "✓ Built the virtual environment with uv sync"
+        );
+        expect(detail).to.contain(
+            "✓ Selected .venv as the workspace interpreter"
+        );
+    });
+
+    it("says packages were downloaded when artifacts came from the network", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.contain("✓ Downloaded Databricks packages");
+    });
+
+    it("says packages were reused when artifacts came from cache", () => {
+        const cached: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            resolved: {...SUCCESS_DEFAULT.resolved!, artifactSource: "cache"},
+        };
+        const {detail} = formatSetupSummary(cached);
+        expect(detail).to.contain("✓ Reused cached Databricks packages");
+        expect(detail).to.not.contain("Downloaded");
+    });
+
+    it("drops the databricks-connect clause in constraints-only mode", () => {
+        const {title, detail} = formatSetupSummary(SUCCESS_CONSTRAINTS_ONLY);
+        expect(title).to.equal(
+            "Python environment ready — constraints applied"
+        );
+        expect(detail).to.contain("Python 3.12");
+        expect(detail).to.not.contain("databricks-connect");
+    });
+
+    it("shows the backup line and venv path on a real run that backed up", () => {
+        const {detail} = formatSetupSummary(SUCCESS_REAL_RUN);
+        expect(detail).to.contain(
+            "✓ Backed up your previous pyproject.toml (pyproject.toml.bak)"
+        );
+        expect(detail).to.contain(
+            "Virtual environment: /home/user/project/.venv"
+        );
+    });
+
+    it("omits the backup line when nothing was backed up", () => {
+        const noBackup: PythonSetupResult = {
+            ...SUCCESS_REAL_RUN,
+            backupPath: undefined,
+        };
+        const {detail} = formatSetupSummary(noBackup);
+        expect(detail).to.not.contain("Backed up");
+    });
+
+    it("names a cluster target when a cluster was used", () => {
+        const cluster: PythonSetupResult = {
+            ...SUCCESS_REAL_RUN,
+            compute: {
+                source: "cluster",
+                clusterId: "0717-abc",
+                envKey: "cluster/0717-abc",
+            },
+        };
+        const {detail} = formatSetupSummary(cluster);
+        expect(detail).to.contain("Compute: cluster 0717-abc");
+    });
+
+    it("appends a warnings section when warnings are present", () => {
+        const warned: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            warnings: [{code: "W_X", message: "pinned an older wheel"}],
+        };
+        const {detail} = formatSetupSummary(warned);
+        expect(detail).to.contain("⚠ Warnings");
+        expect(detail).to.contain("pinned an older wheel");
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -94,6 +94,20 @@ describe("formatSetupSummary", () => {
         expect(detail).to.contain("Compute: cluster 0717-abc");
     });
 
+    it("renders the full default-mode detail body verbatim", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.equal(
+            "Python 3.12 · databricks-connect 17.2.0\n" +
+                "Compute: serverless v4\n" +
+                "\n" +
+                "What was done\n" +
+                "✓ Downloaded Databricks packages\n" +
+                "✓ Added matching Databricks constraints to pyproject.toml\n" +
+                "✓ Built the virtual environment with uv sync\n" +
+                "✓ Selected .venv as the workspace interpreter"
+        );
+    });
+
     it("appends a warnings section when warnings are present", () => {
         const warned: PythonSetupResult = {
             ...SUCCESS_DEFAULT,

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -4,7 +4,6 @@ import {PythonSetupResult} from "../models/PythonSetupResult";
 import {
     SUCCESS_DEFAULT,
     SUCCESS_CONSTRAINTS_ONLY,
-    SUCCESS_REAL_RUN,
 } from "../models/fixtures/setupLocalResults";
 
 describe("formatSetupSummary", () => {
@@ -15,42 +14,17 @@ describe("formatSetupSummary", () => {
         );
     });
 
-    it("lists the resolved python and databricks-connect versions", () => {
+    it("leads with the python and databricks-connect versions", () => {
         const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.contain("Python 3.12 · databricks-connect 17.2.0");
+        expect(detail).to.contain("✓ Python 3.12 + databricks-connect 17.2.0");
     });
 
-    it("names the serverless compute", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.contain("Compute: serverless v4");
-    });
-
-    it("itemizes the constraints, uv sync and interpreter steps", () => {
+    it("itemizes the constraints/uv sync and interpreter steps", () => {
         const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
         expect(detail).to.contain(
-            "✓ Added matching Databricks constraints to pyproject.toml"
+            "✓ Added matching constraints, built .venv (uv sync)"
         );
-        expect(detail).to.contain(
-            "✓ Built the virtual environment with uv sync"
-        );
-        expect(detail).to.contain(
-            "✓ Selected .venv as the workspace interpreter"
-        );
-    });
-
-    it("says packages were downloaded when artifacts came from the network", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.contain("✓ Downloaded Databricks packages");
-    });
-
-    it("says packages were reused when artifacts came from cache", () => {
-        const cached: PythonSetupResult = {
-            ...SUCCESS_DEFAULT,
-            resolved: {...SUCCESS_DEFAULT.resolved!, artifactSource: "cache"},
-        };
-        const {detail} = formatSetupSummary(cached);
-        expect(detail).to.contain("✓ Reused cached Databricks packages");
-        expect(detail).to.not.contain("Downloaded");
+        expect(detail).to.contain("✓ Selected .venv as the interpreter");
     });
 
     it("drops the databricks-connect clause in constraints-only mode", () => {
@@ -58,63 +32,42 @@ describe("formatSetupSummary", () => {
         expect(title).to.equal(
             "Python environment ready — constraints applied"
         );
-        expect(detail).to.contain("Python 3.12");
+        expect(detail).to.contain("✓ Python 3.12");
         expect(detail).to.not.contain("databricks-connect");
-    });
-
-    it("shows the backup line and venv path on a real run that backed up", () => {
-        const {detail} = formatSetupSummary(SUCCESS_REAL_RUN);
-        expect(detail).to.contain(
-            "✓ Backed up your previous pyproject.toml (pyproject.toml.bak)"
-        );
-        expect(detail).to.contain(
-            "Virtual environment: /home/user/project/.venv"
-        );
-    });
-
-    it("omits the backup line when nothing was backed up", () => {
-        const noBackup: PythonSetupResult = {
-            ...SUCCESS_REAL_RUN,
-            backupPath: undefined,
-        };
-        const {detail} = formatSetupSummary(noBackup);
-        expect(detail).to.not.contain("Backed up");
-    });
-
-    it("names a cluster target when a cluster was used", () => {
-        const cluster: PythonSetupResult = {
-            ...SUCCESS_REAL_RUN,
-            compute: {
-                source: "cluster",
-                clusterId: "0717-abc",
-                envKey: "cluster/0717-abc",
-            },
-        };
-        const {detail} = formatSetupSummary(cluster);
-        expect(detail).to.contain("Compute: cluster 0717-abc");
     });
 
     it("renders the full default-mode detail body verbatim", () => {
         const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
         expect(detail).to.equal(
-            "Python 3.12 · databricks-connect 17.2.0\n" +
-                "Compute: serverless v4\n" +
-                "\n" +
-                "What was done\n" +
-                "✓ Downloaded Databricks packages\n" +
-                "✓ Added matching Databricks constraints to pyproject.toml\n" +
-                "✓ Built the virtual environment with uv sync\n" +
-                "✓ Selected .venv as the workspace interpreter"
+            "✓ Python 3.12 + databricks-connect 17.2.0\n" +
+                "✓ Added matching constraints, built .venv (uv sync)\n" +
+                "✓ Selected .venv as the interpreter"
         );
     });
 
-    it("appends a warnings section when warnings are present", () => {
+    it("flags warnings with a single count line when present", () => {
+        const warned: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            warnings: [
+                {code: "W_X", message: "pinned an older wheel"},
+                {code: "W_Y", message: "used a fallback mirror"},
+            ],
+        };
+        const {detail} = formatSetupSummary(warned);
+        expect(detail).to.contain("⚠ Completed with 2 warnings — see logs");
+    });
+
+    it("singularizes the warning-count line for one warning", () => {
         const warned: PythonSetupResult = {
             ...SUCCESS_DEFAULT,
             warnings: [{code: "W_X", message: "pinned an older wheel"}],
         };
         const {detail} = formatSetupSummary(warned);
-        expect(detail).to.contain("⚠ Warnings");
-        expect(detail).to.contain("pinned an older wheel");
+        expect(detail).to.contain("⚠ Completed with 1 warning — see logs");
+    });
+
+    it("omits the warnings line when there are none", () => {
+        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
+        expect(detail).to.not.contain("⚠");
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {SETUP_READY_MESSAGE, formatSetupLog} from "./setupSummary";
+import {formatSetupLog, formatSetupNotification} from "./setupSummary";
 import {PythonSetupResult} from "../models/PythonSetupResult";
 import {
     SUCCESS_DEFAULT,
@@ -7,12 +7,41 @@ import {
     SUCCESS_REAL_RUN,
 } from "../models/fixtures/setupLocalResults";
 
-describe("SETUP_READY_MESSAGE", () => {
-    it("is a concise, use-case-neutral one-liner", () => {
-        expect(SETUP_READY_MESSAGE).to.equal(
+describe("formatSetupNotification", () => {
+    it("is a concise, use-case-neutral one-liner with no warnings", () => {
+        const {message, isWarning} = formatSetupNotification(SUCCESS_DEFAULT);
+        expect(message).to.equal(
             "Python environment ready — .venv created and selected for your " +
                 "Databricks project."
         );
+        expect(isWarning).to.equal(false);
+    });
+
+    it("flags the count and marks a warning when warnings are present", () => {
+        const warned: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            warnings: [
+                {code: "W_X", message: "pinned an older wheel"},
+                {code: "W_Y", message: "used a fallback mirror"},
+            ],
+        };
+        const {message, isWarning} = formatSetupNotification(warned);
+        expect(message).to.equal(
+            "Python environment ready, with 2 warnings — .venv created and " +
+                "selected for your Databricks project."
+        );
+        expect(isWarning).to.equal(true);
+    });
+
+    it("singularizes the count for one warning", () => {
+        const warned: PythonSetupResult = {
+            ...SUCCESS_DEFAULT,
+            warnings: [{code: "W_X", message: "pinned an older wheel"}],
+        };
+        const {message, isWarning} = formatSetupNotification(warned);
+        expect(message).to.contain("with 1 warning —");
+        expect(message).to.not.contain("1 warnings");
+        expect(isWarning).to.equal(true);
     });
 });
 

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {formatSetupLog, formatSetupSummary} from "./setupSummary";
+import {SETUP_READY_MESSAGE, formatSetupLog} from "./setupSummary";
 import {PythonSetupResult} from "../models/PythonSetupResult";
 import {
     SUCCESS_DEFAULT,
@@ -7,69 +7,12 @@ import {
     SUCCESS_REAL_RUN,
 } from "../models/fixtures/setupLocalResults";
 
-describe("formatSetupSummary", () => {
-    it("titles a default-mode run for Databricks Connect", () => {
-        const {title} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(title).to.equal(
-            "Python environment ready for Databricks Connect"
+describe("SETUP_READY_MESSAGE", () => {
+    it("is a concise, use-case-neutral one-liner", () => {
+        expect(SETUP_READY_MESSAGE).to.equal(
+            "Python environment ready — .venv created and selected for your " +
+                "Databricks project."
         );
-    });
-
-    it("leads with the python and databricks-connect versions", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.contain("✓ Python 3.12 + databricks-connect 17.2.0");
-    });
-
-    it("itemizes the constraints/uv sync and interpreter steps", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.contain(
-            "✓ Added matching constraints, built .venv (uv sync)"
-        );
-        expect(detail).to.contain("✓ Selected .venv as the interpreter");
-    });
-
-    it("drops the databricks-connect clause in constraints-only mode", () => {
-        const {title, detail} = formatSetupSummary(SUCCESS_CONSTRAINTS_ONLY);
-        expect(title).to.equal(
-            "Python environment ready — constraints applied"
-        );
-        expect(detail).to.contain("✓ Python 3.12");
-        expect(detail).to.not.contain("databricks-connect");
-    });
-
-    it("renders the full default-mode detail body verbatim", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.equal(
-            "✓ Python 3.12 + databricks-connect 17.2.0\n" +
-                "✓ Added matching constraints, built .venv (uv sync)\n" +
-                "✓ Selected .venv as the interpreter"
-        );
-    });
-
-    it("flags warnings with a single count line when present", () => {
-        const warned: PythonSetupResult = {
-            ...SUCCESS_DEFAULT,
-            warnings: [
-                {code: "W_X", message: "pinned an older wheel"},
-                {code: "W_Y", message: "used a fallback mirror"},
-            ],
-        };
-        const {detail} = formatSetupSummary(warned);
-        expect(detail).to.contain("⚠ Completed with 2 warnings — see logs");
-    });
-
-    it("singularizes the warning-count line for one warning", () => {
-        const warned: PythonSetupResult = {
-            ...SUCCESS_DEFAULT,
-            warnings: [{code: "W_X", message: "pinned an older wheel"}],
-        };
-        const {detail} = formatSetupSummary(warned);
-        expect(detail).to.contain("⚠ Completed with 1 warning — see logs");
-    });
-
-    it("omits the warnings line when there are none", () => {
-        const {detail} = formatSetupSummary(SUCCESS_DEFAULT);
-        expect(detail).to.not.contain("⚠");
     });
 });
 

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -4,15 +4,39 @@ import {
     PythonSetupResult,
 } from "../models/PythonSetupResult";
 
+export interface PythonSetupNotification {
+    message: string;
+    /** True when the run had warnings — the caller shows a warning toast. */
+    isWarning: boolean;
+}
+
 /**
  * The one-line message shown in the success notification. Deliberately terse
  * and use-case-neutral (a local environment for a Databricks project, not tied
  * to Databricks Connect specifically) — the full breakdown lives behind the
- * notification's "View Details" button via {@link formatSetupLog}.
+ * notification's "View Details" button via {@link formatSetupLog}. When the run
+ * completed with warnings the message says so and `isWarning` flips, so the
+ * caller can raise a warning toast rather than a plain info one; the warnings
+ * themselves are listed in the details.
  */
-export const SETUP_READY_MESSAGE =
-    "Python environment ready — .venv created and selected for your " +
-    "Databricks project.";
+export function formatSetupNotification(
+    result: PythonSetupResult
+): PythonSetupNotification {
+    const tail = ".venv created and selected for your Databricks project.";
+    const n = result.warnings.length;
+    if (n === 0) {
+        return {
+            message: `Python environment ready — ${tail}`,
+            isWarning: false,
+        };
+    }
+    return {
+        message:
+            `Python environment ready, with ${n} ` +
+            `warning${n === 1 ? "" : "s"} — ${tail}`,
+        isWarning: true,
+    };
+}
 
 /**
  * The full, verbose breakdown written to the "Databricks Python Environment

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -1,0 +1,95 @@
+import path from "path";
+import {
+    PythonSetupComputeInfo,
+    PythonSetupResult,
+} from "../models/PythonSetupResult";
+
+/**
+ * Human-readable summary of a successful `environments setup-local` run, shown
+ * in a completion modal. `title` is the bold dialog heading; `detail` is the
+ * multi-line body (VS Code preserves its newlines). All copy is derived from
+ * the result — mode drives the databricks-connect clause, artifactSource drives
+ * download-vs-cache wording, and the backup/warnings lines appear only when the
+ * corresponding fields are populated. Pure (no vscode import) so it is unit
+ * tested against the golden fixtures.
+ */
+export interface PythonSetupSummary {
+    title: string;
+    detail: string;
+}
+
+export function formatSetupSummary(
+    result: PythonSetupResult
+): PythonSetupSummary {
+    const isDefault = result.mode === "default";
+    const title = isDefault
+        ? "Python environment ready for Databricks Connect"
+        : "Python environment ready — constraints applied";
+
+    const lines: string[] = [];
+
+    // Versions line: databricks-connect only exists in default mode.
+    const pythonVersion = result.resolved?.pythonVersion ?? "";
+    const dbconnect = result.resolved?.dbconnectVersion;
+    lines.push(
+        isDefault && dbconnect
+            ? `Python ${pythonVersion} · databricks-connect ${dbconnect}`
+            : `Python ${pythonVersion}`
+    );
+
+    const compute = computeLabel(result.compute);
+    if (compute) {
+        lines.push(`Compute: ${compute}`);
+    }
+
+    lines.push("", "What was done");
+
+    lines.push(
+        result.resolved?.artifactSource === "cache"
+            ? "✓ Reused cached Databricks packages"
+            : "✓ Downloaded Databricks packages"
+    );
+    lines.push("✓ Added matching Databricks constraints to pyproject.toml");
+    lines.push("✓ Built the virtual environment with uv sync");
+    lines.push("✓ Selected .venv as the workspace interpreter");
+
+    if (result.backupPath) {
+        lines.push(
+            `✓ Backed up your previous pyproject.toml (${path.basename(
+                result.backupPath
+            )})`
+        );
+    }
+
+    if (result.venvPath) {
+        lines.push("", `Virtual environment: ${result.venvPath}`);
+    }
+
+    if (result.warnings.length > 0) {
+        lines.push("", "⚠ Warnings");
+        for (const w of result.warnings) {
+            lines.push(`• ${w.message}`);
+        }
+    }
+
+    return {title, detail: lines.join("\n")};
+}
+
+/**
+ * Short label for the compute the environment was provisioned against.
+ * Serverless carries a `v`-prefixed version already; a cluster carries its id.
+ */
+function computeLabel(
+    compute: PythonSetupComputeInfo | undefined
+): string | undefined {
+    if (!compute) {
+        return undefined;
+    }
+    if (compute.serverlessVersion) {
+        return `serverless ${compute.serverlessVersion}`;
+    }
+    if (compute.clusterId) {
+        return `cluster ${compute.clusterId}`;
+    }
+    return compute.source || undefined;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -1,4 +1,8 @@
-import {PythonSetupResult} from "../models/PythonSetupResult";
+import path from "path";
+import {
+    PythonSetupComputeInfo,
+    PythonSetupResult,
+} from "../models/PythonSetupResult";
 
 /**
  * Short, TL;DR summary of a successful `environments setup-local` run, shown in
@@ -44,4 +48,85 @@ export function formatSetupSummary(
     }
 
     return {title, detail: lines.join("\n")};
+}
+
+/**
+ * The full, verbose breakdown written to the "Databricks Python Environment
+ * Setup" output channel on success, revealed by the notification's "View logs"
+ * button. This is the home for everything the TL;DR notification omits
+ * (compute, artifact source, backup path, venv path, full warning messages) —
+ * necessary because in `--output json` mode the CLI streams little or nothing
+ * to stderr on success, so without this the channel would be empty.
+ *
+ * Returned with a leading and trailing newline so it reads as its own block
+ * beneath any CLI output already streamed to the channel.
+ */
+export function formatSetupLog(result: PythonSetupResult): string {
+    const isDefault = result.mode === "default";
+    const lines: string[] = [
+        isDefault
+            ? "Python environment ready for Databricks Connect."
+            : "Python environment ready — constraints applied.",
+        "",
+    ];
+
+    lines.push(`Python:             ${result.resolved?.pythonVersion ?? ""}`);
+    if (isDefault && result.resolved?.dbconnectVersion) {
+        lines.push(`databricks-connect: ${result.resolved.dbconnectVersion}`);
+    }
+    const compute = computeLabel(result.compute);
+    if (compute) {
+        lines.push(`Compute:            ${compute}`);
+    }
+    lines.push(
+        `Packages:           ${
+            result.resolved?.artifactSource === "cache"
+                ? "reused from cache"
+                : "downloaded from network"
+        }`
+    );
+
+    lines.push("", "What was done:");
+    lines.push("  • Added matching Databricks constraints to pyproject.toml");
+    lines.push("  • Built the virtual environment with uv sync");
+    lines.push("  • Selected .venv as the workspace interpreter");
+    if (result.backupPath) {
+        lines.push(
+            `  • Backed up your previous pyproject.toml (${path.basename(
+                result.backupPath
+            )})`
+        );
+    }
+
+    if (result.venvPath) {
+        lines.push("", `Virtual environment: ${result.venvPath}`);
+    }
+
+    if (result.warnings.length > 0) {
+        lines.push("", "Warnings:");
+        for (const w of result.warnings) {
+            lines.push(`  • ${w.message}`);
+        }
+    }
+
+    return `\n${lines.join("\n")}\n`;
+}
+
+/**
+ * Short label for the compute the environment was provisioned against.
+ * Serverless carries a `v`-prefixed version already; a cluster carries its id.
+ */
+function computeLabel(
+    compute: PythonSetupComputeInfo | undefined
+): string | undefined {
+    if (!compute) {
+        return undefined;
+    }
+    if (compute.serverlessVersion) {
+        return `serverless ${compute.serverlessVersion}`;
+    }
+    if (compute.clusterId) {
+        return `cluster ${compute.clusterId}`;
+    }
+    return compute.source || undefined;
 }

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -1,17 +1,12 @@
-import path from "path";
-import {
-    PythonSetupComputeInfo,
-    PythonSetupResult,
-} from "../models/PythonSetupResult";
+import {PythonSetupResult} from "../models/PythonSetupResult";
 
 /**
- * Human-readable summary of a successful `environments setup-local` run, shown
- * in a completion modal. `title` is the bold dialog heading; `detail` is the
- * multi-line body (VS Code preserves its newlines). All copy is derived from
- * the result — mode drives the databricks-connect clause, artifactSource drives
- * download-vs-cache wording, and the backup/warnings lines appear only when the
- * corresponding fields are populated. Pure (no vscode import) so it is unit
- * tested against the golden fixtures.
+ * Short, TL;DR summary of a successful `environments setup-local` run, shown in
+ * a standard (non-modal) information notification. `title` is the headline;
+ * `detail` is a tight ✓-checklist of what was done, one item per line (VS Code
+ * preserves the newlines). Deliberately terse — the full provisioning log is a
+ * click away via "View logs". Pure (no vscode import) so it is unit tested
+ * against the golden fixtures.
  */
 export interface PythonSetupSummary {
     title: string;
@@ -33,63 +28,20 @@ export function formatSetupSummary(
     const dbconnect = result.resolved?.dbconnectVersion;
     lines.push(
         isDefault && dbconnect
-            ? `Python ${pythonVersion} · databricks-connect ${dbconnect}`
-            : `Python ${pythonVersion}`
+            ? `✓ Python ${pythonVersion} + databricks-connect ${dbconnect}`
+            : `✓ Python ${pythonVersion}`
     );
+    lines.push("✓ Added matching constraints, built .venv (uv sync)");
+    lines.push("✓ Selected .venv as the interpreter");
 
-    const compute = computeLabel(result.compute);
-    if (compute) {
-        lines.push(`Compute: ${compute}`);
-    }
-
-    lines.push("", "What was done");
-
-    lines.push(
-        result.resolved?.artifactSource === "cache"
-            ? "✓ Reused cached Databricks packages"
-            : "✓ Downloaded Databricks packages"
-    );
-    lines.push("✓ Added matching Databricks constraints to pyproject.toml");
-    lines.push("✓ Built the virtual environment with uv sync");
-    lines.push("✓ Selected .venv as the workspace interpreter");
-
-    if (result.backupPath) {
+    // Warnings are safety-relevant, so a one-line flag survives the TL;DR even
+    // though the details themselves stay in the log.
+    if (result.warnings.length > 0) {
+        const n = result.warnings.length;
         lines.push(
-            `✓ Backed up your previous pyproject.toml (${path.basename(
-                result.backupPath
-            )})`
+            `⚠ Completed with ${n} warning${n === 1 ? "" : "s"} — see logs`
         );
     }
 
-    if (result.venvPath) {
-        lines.push("", `Virtual environment: ${result.venvPath}`);
-    }
-
-    if (result.warnings.length > 0) {
-        lines.push("", "⚠ Warnings");
-        for (const w of result.warnings) {
-            lines.push(`• ${w.message}`);
-        }
-    }
-
     return {title, detail: lines.join("\n")};
-}
-
-/**
- * Short label for the compute the environment was provisioned against.
- * Serverless carries a `v`-prefixed version already; a cluster carries its id.
- */
-function computeLabel(
-    compute: PythonSetupComputeInfo | undefined
-): string | undefined {
-    if (!compute) {
-        return undefined;
-    }
-    if (compute.serverlessVersion) {
-        return `serverless ${compute.serverlessVersion}`;
-    }
-    if (compute.clusterId) {
-        return `cluster ${compute.clusterId}`;
-    }
-    return compute.source || undefined;
 }

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -5,58 +5,22 @@ import {
 } from "../models/PythonSetupResult";
 
 /**
- * Short, TL;DR summary of a successful `environments setup-local` run, shown in
- * a standard (non-modal) information notification. `title` is the headline;
- * `detail` is a tight ✓-checklist of what was done, one item per line (VS Code
- * preserves the newlines). Deliberately terse — the full provisioning log is a
- * click away via "View logs". Pure (no vscode import) so it is unit tested
- * against the golden fixtures.
+ * The one-line message shown in the success notification. Deliberately terse
+ * and use-case-neutral (a local environment for a Databricks project, not tied
+ * to Databricks Connect specifically) — the full breakdown lives behind the
+ * notification's "View Details" button via {@link formatSetupLog}.
  */
-export interface PythonSetupSummary {
-    title: string;
-    detail: string;
-}
-
-export function formatSetupSummary(
-    result: PythonSetupResult
-): PythonSetupSummary {
-    const isDefault = result.mode === "default";
-    const title = isDefault
-        ? "Python environment ready for Databricks Connect"
-        : "Python environment ready — constraints applied";
-
-    const lines: string[] = [];
-
-    // Versions line: databricks-connect only exists in default mode.
-    const pythonVersion = result.resolved?.pythonVersion ?? "";
-    const dbconnect = result.resolved?.dbconnectVersion;
-    lines.push(
-        isDefault && dbconnect
-            ? `✓ Python ${pythonVersion} + databricks-connect ${dbconnect}`
-            : `✓ Python ${pythonVersion}`
-    );
-    lines.push("✓ Added matching constraints, built .venv (uv sync)");
-    lines.push("✓ Selected .venv as the interpreter");
-
-    // Warnings are safety-relevant, so a one-line flag survives the TL;DR even
-    // though the details themselves stay in the log.
-    if (result.warnings.length > 0) {
-        const n = result.warnings.length;
-        lines.push(
-            `⚠ Completed with ${n} warning${n === 1 ? "" : "s"} — see logs`
-        );
-    }
-
-    return {title, detail: lines.join("\n")};
-}
+export const SETUP_READY_MESSAGE =
+    "Python environment ready — .venv created and selected for your " +
+    "Databricks project.";
 
 /**
  * The full, verbose breakdown written to the "Databricks Python Environment
- * Setup" output channel on success, revealed by the notification's "View logs"
- * button. This is the home for everything the TL;DR notification omits
- * (compute, artifact source, backup path, venv path, full warning messages) —
- * necessary because in `--output json` mode the CLI streams little or nothing
- * to stderr on success, so without this the channel would be empty.
+ * Setup" output channel on success, revealed by the notification's "View
+ * Details" button. This is the home for everything the one-line message omits
+ * (versions, compute, artifact source, backup path, venv path, full warning
+ * messages) — necessary because in `--output json` mode the CLI streams little
+ * or nothing to stderr on success, so without this the channel would be empty.
  *
  * Returned with a leading and trailing newline so it reads as its own block
  * beneath any CLI output already streamed to the channel.


### PR DESCRIPTION
## Why

When the local Python environment setup finishes, the extension shows a single flat toast — "Python environment is set up for Databricks Connect." — that confirms *that* something happened but never *what*, and a successful run leaves the output channel empty so there's nowhere to look for detail.

## What

Replace the flat toast with a concise, **use-case-neutral** completion notification plus a full breakdown behind a button:

- **Notification (standard, non-modal):**
  - No warnings → info: *"Python environment ready — .venv created and selected for your Databricks project."*
  - With warnings → warning: *"Python environment ready, with N warning(s) — .venv created and selected for your Databricks project."*
  - A **View Details** button reveals the "Databricks Python Environment Setup" output channel.
- **View Details / output channel** carries the full breakdown, written on success (in `--output json` mode the CLI streams almost nothing to stderr, so the channel would otherwise be empty): Python + databricks-connect versions, compute, artifact source (network/cache), the what-was-done list, the `pyproject.toml` backup (when applicable), the venv path, and the full warning messages.

Two small pure functions carry the logic and are unit-tested against the golden CLI fixtures — `formatSetupNotification(result) → {message, isWarning}` and `formatSetupLog(result) → string` — with the VS Code plumbing kept thin in the `showSuccess` dependency. No change to CLI invocation, telemetry, the tree view, or the error path.

## Testing

- 11 unit tests over the golden fixtures (notification wording incl. warning count/singular/plural, and the full log breakdown incl. cache/backup/venv/warnings variants).
- `tsc --build` of the whole extension is clean; eslint/prettier clean.

This pull request and its description were written by Isaac.