### PR TITLE
feat(python-setup): report merge-warning count and per-code histogram

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -11,6 +11,7 @@ import {
 import {PythonSetupResult} from "../models/PythonSetupResult";
 import {
     SUCCESS_REAL_RUN,
+    SUCCESS_REAL_RUN_WITH_WARNINGS,
     ERROR_NO_TARGET,
 } from "../models/fixtures/setupLocalResults";
 import {SetupLocalInvocation} from "../utils/setupLocalArgs";
@@ -617,7 +618,33 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
             },
         ]);
         expect(telemetry.results).to.deep.equal([
-            {outcome: "ok", envKey: SUCCESS_REAL_RUN.compute!.envKey},
+            {
+                outcome: "ok",
+                envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                warnings: SUCCESS_REAL_RUN.warnings,
+            },
+        ]);
+    });
+
+    it("threads the CLI's merge warnings into the ok result", async () => {
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                ...telemetry,
+                cli: makeCli({resolve: SUCCESS_REAL_RUN_WITH_WARNINGS}),
+            })
+        );
+
+        await setup.setup();
+
+        // The report carries the CLI's warnings verbatim; the count and the
+        // categorical histogram are derived in the telemetry layer, not here.
+        expect(telemetry.results).to.deep.equal([
+            {
+                outcome: "ok",
+                envKey: SUCCESS_REAL_RUN_WITH_WARNINGS.compute!.envKey,
+                warnings: SUCCESS_REAL_RUN_WITH_WARNINGS.warnings,
+            },
         ]);
     });
 
@@ -761,6 +788,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 errorCode: ERROR_NO_TARGET.error!.code,
                 envKey: ERROR_NO_TARGET.compute?.envKey,
                 diskMutated: ERROR_NO_TARGET.error!.diskMutated,
+                warnings: ERROR_NO_TARGET.warnings,
             },
         ]);
     });
@@ -785,6 +813,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 outcome: "failed",
                 failurePhase: "adopt",
                 envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                warnings: SUCCESS_REAL_RUN.warnings,
             },
         ]);
     });
@@ -947,6 +976,7 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 outcome: "failed",
                 failurePhase: "persist",
                 envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                warnings: SUCCESS_REAL_RUN.warnings,
             },
         ]);
     });
@@ -1044,7 +1074,11 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         // the same way), and this project has a pyproject.toml.
         expect(telemetry.attempts[0].isGreenfield).to.equal(false);
         expect(telemetry.results).to.deep.equal([
-            {outcome: "ok", envKey: SUCCESS_REAL_RUN.compute!.envKey},
+            {
+                outcome: "ok",
+                envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                warnings: SUCCESS_REAL_RUN.warnings,
+            },
         ]);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -342,6 +342,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 errorCode: result.error?.code,
                 envKey: result.compute?.envKey,
                 diskMutated: result.error?.diskMutated,
+                warnings: result.warnings,
             });
             await this.deps.showError(
                 getPythonSetupErrorMessage(result),
@@ -366,6 +367,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 outcome: "failed",
                 failurePhase: "adopt",
                 envKey: result.compute.envKey,
+                warnings: result.warnings,
             });
             await this.deps.showError((e as Error).message);
             return;
@@ -388,6 +390,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 outcome: "failed",
                 failurePhase: "persist",
                 envKey: result.compute.envKey,
+                warnings: result.warnings,
             });
             throw e;
         }
@@ -395,7 +398,11 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         // Reported before `showSuccess` on purpose: that awaits the user
         // dismissing a toast, and folding think-time into `duration` would wreck
         // the setup-time metric this event exists to measure.
-        reportResult({outcome: "ok", envKey: result.compute.envKey});
+        reportResult({
+            outcome: "ok",
+            envKey: result.compute.envKey,
+            warnings: result.warnings,
+        });
 
         await this.deps.showSuccess(result);
     }

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
@@ -8,6 +8,7 @@ import {
     SUCCESS_DEFAULT,
     SUCCESS_CONSTRAINTS_ONLY,
     SUCCESS_REAL_RUN,
+    SUCCESS_WITH_WARNINGS,
     ERROR_NO_TARGET,
     ERROR_USAGE,
 } from "./fixtures/setupLocalResults";
@@ -65,6 +66,35 @@ describe("parsePythonSetupResult", () => {
         expect(r.ok).to.equal(false);
         expect(r.error?.code).to.equal("E_USAGE");
         expect(r.error?.failurePhase).to.equal("preflight");
+    });
+
+    it("parses merge warnings, preserving codes and order (incl. repeats)", () => {
+        const r = parsePythonSetupResult(asStdout(SUCCESS_WITH_WARNINGS));
+        expect(r.ok).to.equal(true);
+        expect(r.warnings.map((w) => w.code)).to.deep.equal([
+            "W_REQUIRES_PYTHON_OVERRIDDEN",
+            "W_DBCONNECT_PIN_OVERRIDDEN",
+            "W_DBCONNECT_PIN_DUPLICATED",
+            "W_USER_CONSTRAINT_CONFLICT",
+            "W_USER_CONSTRAINT_CONFLICT",
+        ]);
+    });
+
+    it("normalizes a missing `warnings` key to an empty array", () => {
+        // An older/variant CLI that omits `warnings` must not read as
+        // undefined: the telemetry layer would then mis-record a real merge as
+        // "no result produced" instead of a clean merge (warningsCount 0).
+        const {warnings, ...withoutWarnings} = SUCCESS_REAL_RUN;
+        void warnings;
+        const r = parsePythonSetupResult(asStdout(withoutWarnings));
+        expect(r.warnings).to.deep.equal([]);
+    });
+
+    it("normalizes a null `warnings` value to an empty array", () => {
+        const r = parsePythonSetupResult(
+            asStdout({...SUCCESS_REAL_RUN, warnings: null})
+        );
+        expect(r.warnings).to.deep.equal([]);
     });
 
     it("throws PythonSetupParseError on non-JSON stdout", () => {

--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.ts
@@ -145,7 +145,18 @@ export function parsePythonSetupResult(stdout: string): PythonSetupResult {
             "CLI JSON is not a setup-local result (missing boolean `ok`)"
         );
     }
-    return obj as PythonSetupResult;
+    const result = obj as PythonSetupResult;
+    // `warnings` is typed (and documented) as an always-present array, but this
+    // parser is deliberately minimal and only structurally casts the JSON. A
+    // drifted or older CLI that omits `warnings` (or sends null) would leave the
+    // field non-array at runtime, where the telemetry layer both reads
+    // `warnings.length` and iterates it. Normalize to [] so a real run with a
+    // missing key is still recorded as a clean merge (`warningsCount` 0) instead
+    // of throwing or being mis-attributed as "the CLI produced no result".
+    if (!Array.isArray(result.warnings)) {
+        result.warnings = [];
+    }
+    return result;
 }
 
 /** Whether a parsed result represents a successful run. */

--- a/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
+++ b/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
@@ -60,6 +60,80 @@ export const SUCCESS_DEFAULT: PythonSetupResult = {
     durationMs: 0,
 };
 
+/**
+ * merge-warnings-json: default mode, --dry-run, over an *existing* project whose
+ * pins conflict with the environment's. Mirrors the CLI golden
+ * (acceptance/localenv/merge-warnings-json) verbatim, including the repeated
+ * W_USER_CONSTRAINT_CONFLICT. The golden redacts durationMs as `[DURATION_MS]`;
+ * a representative non-zero value stands in here (the extension never reads it).
+ */
+export const SUCCESS_WITH_WARNINGS: PythonSetupResult = {
+    schemaVersion: 1,
+    command: "environments setup-local",
+    ok: true,
+    mode: "default",
+    dryRun: true,
+    compute: {
+        source: "serverless",
+        serverlessVersion: "v4",
+        envKey: "serverless/serverless-v4",
+    },
+    resolved: {
+        pythonVersion: "3.12",
+        dbconnectVersion: "17.2.0",
+        artifactSource: "network",
+    },
+    greenfield: false,
+    plan: {
+        wouldWrite: "[TEST_TMP_DIR]/pyproject.toml",
+        wouldBackup: "[TEST_TMP_DIR]/pyproject.toml.bak",
+        wouldInstallPython: "3.12",
+        diff: "--- pyproject.toml\n+++ pyproject.toml.new\n",
+    },
+    phases: [
+        {phase: "preflight", status: "ok"},
+        {phase: "resolve", status: "ok"},
+        {phase: "fetch", status: "ok"},
+        {phase: "merge", status: "ok"},
+        {phase: "provision", status: "ok"},
+        {phase: "validate", status: "ok"},
+    ],
+    warnings: [
+        {
+            code: "W_REQUIRES_PYTHON_OVERRIDDEN",
+            message:
+                'requires-python ">=3.10" is replaced by the environment\'s ">=3.12"',
+        },
+        {
+            code: "W_DBCONNECT_PIN_OVERRIDDEN",
+            message:
+                'databricks-connect "databricks-connect~=16.0.0" is replaced by ' +
+                'the environment\'s "databricks-connect~=17.2.0"',
+        },
+        {
+            code: "W_DBCONNECT_PIN_DUPLICATED",
+            message:
+                'databricks-connect "databricks-connect==15.0.0" is not rewritten ' +
+                'by the merge; the environment\'s "databricks-connect~=17.2.0" ' +
+                'sits in "dev" alongside it, and no version satisfies both',
+        },
+        {
+            code: "W_USER_CONSTRAINT_CONFLICT",
+            message:
+                'dependency "pyarrow==21.0.0" conflicts with the environment ' +
+                'constraint "pyarrow<19"',
+        },
+        {
+            code: "W_USER_CONSTRAINT_CONFLICT",
+            message:
+                'dependency "pandas==4.0.0" conflicts with the environment ' +
+                'constraint "pandas<3"',
+        },
+    ],
+    error: null,
+    durationMs: 1234,
+};
+
 /** constraints-only: note `resolved` omits `dbconnectVersion`. */
 export const SUCCESS_CONSTRAINTS_ONLY: PythonSetupResult = {
     schemaVersion: 1,
@@ -188,4 +262,34 @@ export const SUCCESS_REAL_RUN: PythonSetupResult = {
     warnings: [],
     error: null,
     durationMs: 0,
+};
+
+/**
+ * Synthesized real run over an existing project that merges cleanly except for a
+ * couple of pin conflicts: {@link SUCCESS_REAL_RUN} plus the merge warnings a
+ * consumer counts. Exercises the ok path threading `result.warnings` into the
+ * setup-result event (no committed CLI golden runs a real provision).
+ */
+export const SUCCESS_REAL_RUN_WITH_WARNINGS: PythonSetupResult = {
+    ...SUCCESS_REAL_RUN,
+    warnings: [
+        {
+            code: "W_DBCONNECT_PIN_OVERRIDDEN",
+            message:
+                'databricks-connect "databricks-connect~=16.0.0" is replaced by ' +
+                'the environment\'s "databricks-connect~=17.2.0"',
+        },
+        {
+            code: "W_USER_CONSTRAINT_CONFLICT",
+            message:
+                'dependency "pyarrow==21.0.0" conflicts with the environment ' +
+                'constraint "pyarrow<19"',
+        },
+        {
+            code: "W_USER_CONSTRAINT_CONFLICT",
+            message:
+                'dependency "pandas==4.0.0" conflicts with the environment ' +
+                'constraint "pandas<3"',
+        },
+    ],
 };

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -491,6 +491,12 @@ export class EventTypes {
         errorCode?: PythonSetupErrorCode;
         envKey?: string;
         diskMutated?: boolean;
+        warningsCount?: number;
+        // A code->count histogram, not a list: JSON-stringified into a property
+        // by recordEvent (numbers alone become metrics). Keys are a closed
+        // categorical set (the CLI's W_* codes, or "other"); never the warning
+        // messages, which carry package names and version specifiers.
+        warningCodeCounts?: Record<string, number>;
         // Optional rather than the usual required DurationMeasurement: the
         // `no_compute` outcome is reported without a run having started, so
         // there is no elapsed time. Emitting 0 there would drag the
@@ -528,6 +534,19 @@ export class EventTypes {
         diskMutated: {
             comment:
                 "Whether the failed run had already modified project files. Omitted when the CLI reported no error object",
+        },
+        warningsCount: {
+            comment:
+                "How many merge-phase advisories the CLI emitted (env-owned pins conflicting with the " +
+                "user's existing project) — a proxy for merge quality. 0 is a real value (a clean " +
+                "merge); omitted only when the CLI produced no result at all (cancelled/not_started/no_compute)",
+        },
+        warningCodeCounts: {
+            comment:
+                "Per-code histogram of the merge warnings (e.g. W_DBCONNECT_PIN_DUPLICATED: 1), so a " +
+                "consumer sees which conflicts occurred, not just how many. Codes are a closed set; any " +
+                'unrecognised code collapses to "other". Omitted when there were no warnings. Categorical ' +
+                "counts only — never the human-readable warning messages",
         },
         // Measured by the extension around the whole run, not read from the
         // CLI's own durationMs (documented as reserved and always 0). This is

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
@@ -222,6 +222,110 @@ describe(__filename, () => {
         }
     });
 
+    it("emits a warning count and a categorical per-code histogram", () => {
+        const {telemetry, events} = makeTelemetry();
+
+        telemetry.recordPythonSetupAttempt({
+            packageManager: "uv",
+            targetType: "serverless",
+            serverlessVersion: "5",
+            mode: "default",
+            trigger: "initial",
+        })({
+            outcome: "ok",
+            envKey: "serverless/serverless-v5",
+            warnings: [
+                {code: "W_REQUIRES_PYTHON_OVERRIDDEN", message: "irrelevant"},
+                {code: "W_DBCONNECT_PIN_OVERRIDDEN", message: "irrelevant"},
+                {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
+                {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
+            ],
+        });
+
+        // The total is a numeric metric, not a property.
+        expect(events[1].metrics["event.warningsCount"]).to.equal(4);
+        expect(events[1].props).to.not.have.property("event.warningsCount");
+        // The per-code counts are a JSON-stringified property (objects never
+        // become metrics), with the repeated code counted twice.
+        expect(
+            JSON.parse(events[1].props["event.warningCodeCounts"])
+        ).to.deep.equal({
+            W_REQUIRES_PYTHON_OVERRIDDEN: 1,
+            W_DBCONNECT_PIN_OVERRIDDEN: 1,
+            W_USER_CONSTRAINT_CONFLICT: 2,
+        });
+    });
+
+    it("reports warningsCount 0 and omits the histogram for a clean merge", () => {
+        const {telemetry, events} = makeTelemetry();
+
+        // A result with no warnings: 0 is a real value (unlike an omitted field),
+        // so it is emitted — but an empty "{}" histogram string is not.
+        telemetry.recordPythonSetupAttempt({
+            packageManager: "uv",
+            targetType: "serverless",
+            serverlessVersion: "5",
+            mode: "default",
+            trigger: "initial",
+        })({outcome: "ok", envKey: "serverless/serverless-v5", warnings: []});
+
+        expect(events[1].metrics["event.warningsCount"]).to.equal(0);
+        expect(events[1].props).to.not.have.property("event.warningCodeCounts");
+    });
+
+    it("collapses an unrecognised warning code to 'other'", () => {
+        // A code the CLI adds before this list is updated (or any drift) must not
+        // mint a new histogram bucket, and the free-form parts of a warning must
+        // never reach the wire.
+        const {telemetry, events} = makeTelemetry();
+
+        telemetry.recordPythonSetupAttempt({
+            packageManager: "uv",
+            targetType: "cluster",
+            mode: "default",
+            trigger: "initial",
+        })({
+            outcome: "ok",
+            warnings: [
+                {code: "W_REQUIRES_PYTHON_OVERRIDDEN", message: "irrelevant"},
+                {
+                    code: "W_SOME_FUTURE_CLI_CODE",
+                    message: "resolving for jane@example.com",
+                },
+                {code: "/Users/jane/secret-project", message: "irrelevant"},
+            ],
+        });
+
+        expect(events[1].metrics["event.warningsCount"]).to.equal(3);
+        expect(
+            JSON.parse(events[1].props["event.warningCodeCounts"])
+        ).to.deep.equal({
+            W_REQUIRES_PYTHON_OVERRIDDEN: 1,
+            other: 2,
+        });
+        const serialized = JSON.stringify(events[1].props);
+        expect(serialized).to.not.contain("jane");
+        expect(serialized).to.not.contain("example.com");
+        expect(serialized).to.not.contain("secret-project");
+    });
+
+    it("omits the warning fields when the CLI produced no result", () => {
+        const {telemetry, events} = makeTelemetry();
+
+        // cancelled / not_started / no_compute carry no `warnings` array, so
+        // neither the count nor the histogram is emitted (0 would be a lie: no
+        // merge ran).
+        telemetry.recordPythonSetupAttempt({
+            packageManager: "uv",
+            targetType: "cluster",
+            mode: "default",
+            trigger: "initial",
+        })({outcome: "cancelled"});
+
+        expect(events[1].metrics).to.not.have.property("event.warningsCount");
+        expect(events[1].props).to.not.have.property("event.warningCodeCounts");
+    });
+
     it("emits only the schema's fields, never extra ones on the caller's object", () => {
         const {telemetry, events} = makeTelemetry();
 

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
@@ -237,21 +237,24 @@ describe(__filename, () => {
             warnings: [
                 {code: "W_REQUIRES_PYTHON_OVERRIDDEN", message: "irrelevant"},
                 {code: "W_DBCONNECT_PIN_OVERRIDDEN", message: "irrelevant"},
+                {code: "W_DBCONNECT_PIN_DUPLICATED", message: "irrelevant"},
                 {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
                 {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
             ],
         });
 
         // The total is a numeric metric, not a property.
-        expect(events[1].metrics["event.warningsCount"]).to.equal(4);
+        expect(events[1].metrics["event.warningsCount"]).to.equal(5);
         expect(events[1].props).to.not.have.property("event.warningsCount");
         // The per-code counts are a JSON-stringified property (objects never
-        // become metrics), with the repeated code counted twice.
+        // become metrics), covering all four known codes with the repeated one
+        // counted twice.
         expect(
             JSON.parse(events[1].props["event.warningCodeCounts"])
         ).to.deep.equal({
             W_REQUIRES_PYTHON_OVERRIDDEN: 1,
             W_DBCONNECT_PIN_OVERRIDDEN: 1,
+            W_DBCONNECT_PIN_DUPLICATED: 1,
             W_USER_CONSTRAINT_CONFLICT: 2,
         });
     });

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -8,6 +8,7 @@ import {
     PythonSetupOutcome,
     PythonSetupRunTrigger,
 } from "./constants";
+import {PythonSetupWarning} from "../python-setup/models/PythonSetupResult";
 
 /**
  * What a starting setup run is about to do. Everything here is known before the
@@ -41,6 +42,15 @@ export interface PythonSetupOutcomeReport {
     errorCode?: PythonSetupErrorCode;
     envKey?: string;
     diskMutated?: boolean;
+    /**
+     * The CLI's merge-phase warnings, verbatim from the result. Present whenever
+     * the CLI produced a result (so `[]` reads as "a run happened with no
+     * warnings"); absent when no result exists (cancelled / not_started /
+     * no_compute). Passed raw — the count and the categorical per-code histogram
+     * are derived at emission (see {@link warningCodeCounts}), the same split as
+     * {@link categoricalEnvKey}.
+     */
+    warnings?: PythonSetupWarning[];
 }
 
 /** Reports the outcome of the run whose attempt returned it. */
@@ -87,6 +97,53 @@ function categoricalEnvKey(envKey: string | undefined): string | undefined {
     return ENV_KEY_PATTERNS.some((p) => p.test(envKey))
         ? envKey
         : UNRECOGNISED_ENV_KEY;
+}
+
+/**
+ * The CLI's closed set of merge-phase warning codes (see `libs/localenv/result.go`).
+ * All are emitted from the merge phase, where an existing project's pins can
+ * conflict with the environment's managed pins:
+ *
+ * - `W_REQUIRES_PYTHON_OVERRIDDEN` — the user's `requires-python` is replaced.
+ * - `W_DBCONNECT_PIN_OVERRIDDEN` — the user's databricks-connect pin is replaced.
+ * - `W_DBCONNECT_PIN_DUPLICATED` — a retained databricks-connect pin now sits
+ *   alongside the managed one, with no version satisfying both (needs a manual fix).
+ * - `W_USER_CONSTRAINT_CONFLICT` — a user dependency is provably disjoint from an
+ *   env constraint.
+ *
+ * Held as a set so an unknown code (schema drift, or a code added CLI-side before
+ * this list is updated) collapses to {@link UNRECOGNISED_WARNING_CODE} rather than
+ * silently minting a new histogram bucket -- the same closed-vocabulary discipline
+ * {@link categoricalEnvKey} applies to the env key.
+ */
+const KNOWN_WARNING_CODES: ReadonlySet<string> = new Set([
+    "W_REQUIRES_PYTHON_OVERRIDDEN",
+    "W_DBCONNECT_PIN_OVERRIDDEN",
+    "W_DBCONNECT_PIN_DUPLICATED",
+    "W_USER_CONSTRAINT_CONFLICT",
+]);
+
+/** Bucket for a warning code outside {@link KNOWN_WARNING_CODES}. */
+const UNRECOGNISED_WARNING_CODE = "other";
+
+/**
+ * Reduce the CLI's warnings to a per-code count, collapsing unknown codes to
+ * `other`. The result is a bounded, categorical histogram (at most one bucket per
+ * known code, plus `other`) — never the free-form warning messages, which carry
+ * package names and version specifiers. Returns an empty object for no warnings,
+ * so the caller can decide whether to emit the field at all.
+ */
+function warningCodeCounts(
+    warnings: PythonSetupWarning[]
+): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const {code} of warnings) {
+        const bucket = KNOWN_WARNING_CODES.has(code)
+            ? code
+            : UNRECOGNISED_WARNING_CODE;
+        counts[bucket] = (counts[bucket] ?? 0) + 1;
+    }
+    return counts;
 }
 
 declare module "." {
@@ -177,6 +234,24 @@ Telemetry.prototype.recordPythonSetupAttempt = function (
                 : {}),
             ...(report.diskMutated !== undefined
                 ? {diskMutated: report.diskMutated}
+                : {}),
+            // A present `warnings` array means the CLI produced a result, so the
+            // count is meaningful even at 0 (a clean merge) -- unlike the omitted
+            // fields above, 0 is a value, not "unknown". The per-code histogram is
+            // a categorical map JSON-stringified by recordEvent (objects go to
+            // properties); it is omitted when empty so a no-warning run does not
+            // carry a "{}" string.
+            ...(report.warnings !== undefined
+                ? {
+                      warningsCount: report.warnings.length,
+                      ...(report.warnings.length > 0
+                          ? {
+                                warningCodeCounts: warningCodeCounts(
+                                    report.warnings
+                                ),
+                            }
+                          : {}),
+                  }
                 : {}),
         });
     };


### PR DESCRIPTION
## Why

The `python_env.setup.result` telemetry event intentionally omitted the merge-warning signal because the CLI never populated `Result.warnings` (it was always `[]`). The CLI now emits a closed, categorical set of merge-phase warning codes, so the extension can finally report merge quality — a proxy for how cleanly an existing project's pins reconcile with the environment's — without parsing free-form text.

## What

- `python_env.setup.result` now carries two new fields whenever the CLI produced a result:
  - **`warningsCount`** — total merge warnings, as a numeric metric. `0` is emitted for a clean merge (a real value); the field is omitted only when the CLI produced no result at all (cancelled / not_started / no_compute).
  - **`warningCodeCounts`** — a per-code histogram (e.g. `{"W_USER_CONSTRAINT_CONFLICT": 2}`), JSON-stringified into a property. Omitted when there were no warnings.
- Warning codes are constrained to the CLI's closed set (`W_REQUIRES_PYTHON_OVERRIDDEN`, `W_DBCONNECT_PIN_OVERRIDDEN`, `W_DBCONNECT_PIN_DUPLICATED`, `W_USER_CONSTRAINT_CONFLICT`); any unrecognized code collapses to `other`, mirroring the existing `envKey` categorical guard. The human-readable warning **messages** are never emitted (they carry package names and version specifiers).
- The orchestrator threads `result.warnings` into every result-bearing report path (ok, CLI failure, adopt failure, persist failure).
- Added fixtures mirroring the CLI's `merge-warnings-json` acceptance golden, plus a synthesized real-run variant.

## Verification

- `tsc --noEmit`: clean.
- Full unit suite: **687 passing, 0 failing**.
- `yarn fix` / prettier: clean.
- New tests cover the histogram, the `other` collapse, the clean-merge `0` case, field omission when no result exists, and the orchestrator threading warnings on the ok path.

This pull request and its description were written by Isaac.