### PR TITLE
Promote uv Python setup entry to the top level of the Configuration view

### DIFF
--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
@@ -7,7 +7,10 @@ import {ConfigModel} from "../../configuration/models/ConfigModel";
 import {ConfigurationTreeItem} from "./types";
 import {PythonSetupEntry} from "./pythonSetupEntry";
 
-const ENVIRONMENT_ROOT = {id: "ENVIRONMENT"} as ConfigurationTreeItem;
+const ENVIRONMENT_COMPONENT_ID = "ENVIRONMENT";
+const ENVIRONMENT_ROOT = {
+    id: ENVIRONMENT_COMPONENT_ID,
+} as ConfigurationTreeItem;
 const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
 
 /** A stub {@link PythonSetupEntry} with no VS Code dependency. */
@@ -81,14 +84,26 @@ describe("EnvironmentComponent dispatch", () => {
         expect(children.map((c) => c.id)).to.not.include(PYTHON_SETUP_ENTRY_ID);
     });
 
-    it("shows only the uv entry (not the checklist) when visible", async () => {
-        const children = await make(
-            stubPythonSetup({visible: true, ready: false})
-        ).getChildren(ENVIRONMENT_ROOT);
+    it("shows the Python Environment group at the top level when not visible", async () => {
+        const root = await make(
+            stubPythonSetup({visible: false, ready: false})
+        ).getChildren();
 
-        // Mutually exclusive: exactly the one uv entry, checklist skipped.
-        expect(children).to.have.length(1);
-        expect(children[0].id).to.equal(PYTHON_SETUP_ENTRY_ID);
-        expect(children.map((c) => c.label)).to.not.include("Install deps");
+        expect(root).to.have.length(1);
+        expect(root[0].id).to.equal(ENVIRONMENT_COMPONENT_ID);
+    });
+
+    it("promotes the uv entry to the top level when visible", async () => {
+        const component = make(stubPythonSetup({visible: true, ready: false}));
+
+        // The top-level row is the uv entry itself, not a "Python Environment"
+        // group wrapping it.
+        const root = await component.getChildren();
+        expect(root).to.have.length(1);
+        expect(root[0].id).to.equal(PYTHON_SETUP_ENTRY_ID);
+
+        // Being a leaf, it has no children — so the checklist never renders.
+        const children = await component.getChildren(root[0]);
+        expect(children).to.have.length(0);
     });
 });

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -36,6 +36,17 @@ export class EnvironmentComponent extends BaseComponent {
     }
 
     public async getRoot(): Promise<ConfigurationTreeItem[]> {
+        // With the uv-native setup, the group would hold a single child, so
+        // promote that entry to the top level and drop the empty wrapper. The
+        // legacy checklist keeps its "Python Environment" group, which nests
+        // multiple step rows.
+        const pythonSetup = this.pythonSetup;
+        if (pythonSetup && (await pythonSetup.isVisible())) {
+            return buildPythonSetupEntry(
+                {ready: pythonSetup.ready},
+                PYTHON_SETUP_COMMAND
+            );
+        }
         const environmentState = await this.featureManager.isEnabled(
             "environment.dependencies"
         );
@@ -75,16 +86,9 @@ export class EnvironmentComponent extends BaseComponent {
         if (parent.id !== ENVIRONMENT_COMPONENT_ID) {
             return [];
         }
-        // The uv-native setup and the legacy pip checklist are mutually
-        // exclusive: when the python-setup entry is visible (opted-in + a
-        // clean uv/greenfield project), show only it and skip the checklist.
-        const pythonSetup = this.pythonSetup;
-        if (pythonSetup && (await pythonSetup.isVisible())) {
-            return buildPythonSetupEntry(
-                {ready: pythonSetup.ready},
-                PYTHON_SETUP_COMMAND
-            );
-        }
+        // Only the legacy checklist nests under the "Python Environment" group.
+        // The uv-native entry (mutually exclusive with the checklist) is a
+        // top-level row instead — see getRoot — so it never reaches here.
         const environmentState = await this.featureManager.isEnabled(
             "environment.dependencies"
         );


### PR DESCRIPTION
## Why

When the uv-native Python setup is enabled, the **Python Environment** group in the Configuration view holds a single child — the **Set up Python environment** entry. The wrapping group adds an extra expand arrow and a level of nesting with no content of its own, so the entry is easier to find promoted to the top level.

## What

- `EnvironmentComponent.getRoot()` now checks the uv entry's visibility first. When visible (feature enabled + uv-suitable project) it returns the setup entry directly as a top-level row; otherwise it returns the **Python Environment** group unchanged for the legacy pip checklist.
- Removed the now-dead uv branch from `getChildren()`: the group only renders on the legacy path, so its children are always the checklist.
- Updated tests to assert the uv entry is a top-level leaf (no group, no children) when visible, and that the group still appears when it is not.

**Net effect:**
- uv setup enabled → a single top-level "Set up Python environment" row (no empty group, no expand arrow).
- uv setup disabled → the "Python Environment" group + legacy checklist, exactly as before.

## Verification

- `tsc --build --force`: clean
- `yarn test:unit`: 667 passing, 0 failing
- `eslint` + `prettier`: clean

No persisted or collapse state is keyed to the group, so there is nothing to migrate.

This pull request and its description were written by Isaac.