### PR TITLE
feat(python-setup): auto-reveal the setup output channel on completion

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -8,6 +8,10 @@ import {
 } from "./pythonSetupDeps";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {Telemetry} from "../../telemetry";
+import {
+    SUCCESS_DEFAULT,
+    SUCCESS_WITH_WARNINGS,
+} from "../models/fixtures/setupLocalResults";
 
 describe("makePythonSetupVisibility", () => {
     const uvDetection = {
@@ -460,7 +464,7 @@ describe("makePythonSetupDeps showError", () => {
         expect(appended.join("")).to.contain("raw conflict detail");
     });
 
-    it("offers a Show Logs action and reveals the channel when it is picked", async () => {
+    it("reveals the channel automatically and offers a Show Logs action", async () => {
         let shown = 0;
         const deps = makePythonSetupDeps(
             makeWiring({
@@ -479,10 +483,11 @@ describe("makePythonSetupDeps showError", () => {
         expect(shownWith).to.have.length(1);
         expect(shownWith[0].message).to.equal("friendly copy");
         expect(shownWith[0].actions).to.contain("Show Logs");
-        expect(shown).to.equal(1);
+        // Once on the automatic reveal, again when the button is picked.
+        expect(shown).to.equal(2);
     });
 
-    it("does not reveal the channel when the popup is dismissed", async () => {
+    it("still reveals the channel when the popup is dismissed", async () => {
         let shown = 0;
         const deps = makePythonSetupDeps(
             makeWiring({
@@ -498,7 +503,8 @@ describe("makePythonSetupDeps showError", () => {
 
         await deps.showError("friendly copy", "detail");
 
-        expect(shown).to.equal(0);
+        // The automatic reveal fires regardless of what the user clicks.
+        expect(shown).to.equal(1);
     });
 
     it("still offers the button but writes nothing when there is no detail", async () => {
@@ -513,5 +519,105 @@ describe("makePythonSetupDeps showError", () => {
 
         expect(appended).to.have.length(0);
         expect(shownWith[0].actions).to.contain("Show Logs");
+    });
+});
+
+describe("makePythonSetupDeps showSuccess", () => {
+    let originalInfo: typeof window.showInformationMessage;
+    let originalWarn: typeof window.showWarningMessage;
+    let infoShownWith: {message: string; actions: string[]}[];
+    let warnShownWith: {message: string; actions: string[]}[];
+    let reply: string | undefined;
+
+    beforeEach(() => {
+        originalInfo = window.showInformationMessage;
+        originalWarn = window.showWarningMessage;
+        infoShownWith = [];
+        warnShownWith = [];
+        reply = undefined;
+        // ts-mockito can't stub the vscode namespace, so swap the fns to
+        // capture what each notification is raised with and what the user
+        // "clicks".
+        (
+            window as unknown as {showInformationMessage: unknown}
+        ).showInformationMessage = async (
+            message: string,
+            ...actions: string[]
+        ) => {
+            infoShownWith.push({message, actions});
+            return reply;
+        };
+        (
+            window as unknown as {showWarningMessage: unknown}
+        ).showWarningMessage = async (
+            message: string,
+            ...actions: string[]
+        ) => {
+            warnShownWith.push({message, actions});
+            return reply;
+        };
+    });
+
+    afterEach(() => {
+        (
+            window as unknown as {showInformationMessage: unknown}
+        ).showInformationMessage = originalInfo;
+        (
+            window as unknown as {showWarningMessage: unknown}
+        ).showWarningMessage = originalWarn;
+    });
+
+    it("writes the details, reveals the channel and raises an info toast", async () => {
+        let shown = 0;
+        const appended: string[] = [];
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {
+                    append: (c) => appended.push(c),
+                    show: () => {
+                        shown++;
+                    },
+                },
+            })
+        );
+
+        await deps.showSuccess(SUCCESS_DEFAULT);
+
+        expect(appended.join("")).to.have.length.greaterThan(0);
+        // The automatic reveal fires regardless of what the user clicks.
+        expect(shown).to.equal(1);
+        expect(infoShownWith).to.have.length(1);
+        expect(infoShownWith[0].actions).to.contain("View Details");
+        expect(warnShownWith).to.have.length(0);
+    });
+
+    it("raises a warning toast when the run had warnings", async () => {
+        const deps = makePythonSetupDeps(makeWiring());
+
+        await deps.showSuccess(SUCCESS_WITH_WARNINGS);
+
+        expect(warnShownWith).to.have.length(1);
+        expect(warnShownWith[0].actions).to.contain("View Details");
+        expect(infoShownWith).to.have.length(0);
+    });
+
+    it("reveals the channel again when View Details is picked", async () => {
+        let shown = 0;
+        const deps = makePythonSetupDeps(
+            makeWiring({
+                log: {
+                    append: () => {},
+                    show: () => {
+                        shown++;
+                    },
+                },
+            })
+        );
+        reply = "View Details";
+
+        await deps.showSuccess(SUCCESS_DEFAULT);
+
+        // Once on the automatic reveal, again when the button is picked.
+        expect(shown).to.equal(2);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -211,12 +211,14 @@ export function makePythonSetupDeps(
             // The mapped one-liner is deliberately concise and drops the CLI's
             // own explanation; write that detail into the channel so the log the
             // popup points at actually contains it (under `--output json` the CLI
-            // streams little else). Then offer a button rather than force-opening
-            // the panel: a self-revealing, possibly-empty log is worse than one
-            // the user opens on demand.
+            // streams little else).
             if (detail !== undefined && detail.length > 0) {
                 wiring.log.append(detail);
             }
+            // Reveal the output channel automatically so the full log is in
+            // front of the user when setup fails, then still raise the
+            // notification (with its jump-to-logs button) as before.
+            wiring.log.show();
             const showLogs = "Show Logs";
             const picked = await window.showErrorMessage(message, showLogs);
             if (picked === showLogs) {
@@ -224,12 +226,16 @@ export function makePythonSetupDeps(
             }
         },
         showSuccess: async (result) => {
-            // Write the full breakdown to the log channel so "View Details"
-            // always has content: in --output json mode the CLI streams little
-            // or nothing to stderr on success, so the channel would otherwise
-            // be empty. This is where the details the one-line message omits
-            // (versions, compute, venv path, backup, full warnings) live.
+            // Write the full breakdown to the log channel: in --output json
+            // mode the CLI streams little or nothing to stderr on success, so
+            // the channel would otherwise be empty. This is where the details
+            // the one-line message omits (versions, compute, venv path, backup,
+            // full warnings) live.
             wiring.log.append(formatSetupLog(result));
+            // Reveal the output channel automatically so those details are in
+            // front of the user, then still raise the notification (with its
+            // "View Details" button) as before.
+            wiring.log.show();
             // A standard (non-modal) notification, not a modal dialog: the
             // outcome is informational, not something to interrupt the user
             // for. A run with warnings raises a warning toast so it doesn't


### PR DESCRIPTION
## Why

When local uv Python setup finishes, the "Databricks Python Environment Setup" output channel was only revealed if the user clicked the notification's button ("View Details" on success, "Show Logs" on failure). The full log — the details on success and the CLI's own explanation on failure — stayed hidden behind that extra click. We want to land the user on the output automatically, in both the success and error cases.

## What

- `showSuccess` and `showError` now call `wiring.log.show()` unconditionally after appending the log, so the output channel is revealed as soon as setup finishes — before the notification is even dismissed.
- The notification is unchanged: same info/warning/error toast and the same jump-to-logs button, which still re-reveals the channel when picked.
- `log.show()` maps to `.show(true)` (`preserveFocus: true`), so the panel is revealed without stealing focus from the editor.
- Updated the surrounding comments to reflect the new behavior.

## Tests

- Reworked the `showError` reveal tests: the channel now reveals regardless of what the user clicks, and the button reveal stacks on top of the automatic one.
- Added a `showSuccess` describe block asserting the automatic reveal (info vs warning toast) and the button re-revealing on top.
- `yarn workspace databricks run test:unit` — 706 passing.
- `yarn workspace databricks run fix` — clean.

## Note

This is a deliberate behavior change: the output panel now appears on every setup run, where before it stayed collapsed unless the user asked for it.

This pull request and its description were written by Isaac.