### PR TITLE
feat(python-setup): refresh setup-complete output with notebook guidance

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -345,6 +345,12 @@ The choices that affect how you write:
 - `(x) => …` — always parenthesize arrow params.
 - Trailing commas where ES5 allows.
 - Prefer `===` / `!==` and always use curly braces (`curly`).
+- **Windows too — don't hard-code POSIX paths.** The extension ships on Windows as
+  well as macOS/Linux, so any path or executable — in code _and_ in user-facing
+  text — must account for the platform. A venv interpreter is `.venv/bin/python` on
+  macOS/Linux but `.venv\Scripts\python.exe` on Windows. Build paths with `path`
+  (or a helper like `venvInterpreterPath`) instead of concatenating POSIX literals,
+  and when a message quotes a concrete path, pick it per `process.platform`.
 
 ---
 

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -8,6 +8,7 @@ import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {shouldShowPythonSetup} from "../utils/pythonSetupGate";
 import {formatSetupLog, formatSetupNotification} from "../utils/setupSummary";
 import {venvInterpreterPath} from "../utils/venvInterpreterPath";
+import {readVenvProjectName} from "../utils/venvProjectName";
 import {
     CliRunner,
     PythonSetupPersistedState,
@@ -229,9 +230,13 @@ export function makePythonSetupDeps(
             // Write the full breakdown to the log channel: in --output json
             // mode the CLI streams little or nothing to stderr on success, so
             // the channel would otherwise be empty. This is where the details
-            // the one-line message omits (versions, compute, venv path, backup,
-            // full warnings) live.
-            wiring.log.append(formatSetupLog(result));
+            // the one-line message omits (versions, compute, backup, how to run
+            // notebooks, full warnings) live. Enrich the venv lines with the
+            // project name uv recorded in pyvenv.cfg when it can be read.
+            const projectName = result.venvPath
+                ? await readVenvProjectName(result.venvPath)
+                : undefined;
+            wiring.log.append(formatSetupLog(result, projectName));
             // Reveal the output channel automatically so those details are in
             // front of the user, then still raise the notification (with its
             // "View Details" button) as before.

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -74,7 +74,7 @@ describe("formatSetupLog", () => {
     });
 
     it("shows the project name beside .venv when one is resolved", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project");
+        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project", "linux");
         expect(log).to.contain(
             "  • Built a new virtual environment with uv sync called " +
                 ".venv (my-project)"
@@ -88,11 +88,20 @@ describe("formatSetupLog", () => {
     });
 
     it("tells the user how to run notebooks with the venv", () => {
-        expect(formatSetupLog(SUCCESS_DEFAULT)).to.contain(
+        expect(formatSetupLog(SUCCESS_DEFAULT, undefined, "linux")).to.contain(
             "To run notebooks using this virtual environment, click Select " +
                 "Kernel in the upper right of a notebook and ensure that the " +
                 "virtual environment is selected (`.venv/bin/python`)."
         );
+    });
+
+    it("uses the Windows interpreter path in the notebook hint", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project", "win32");
+        expect(log).to.contain(
+            "virtual environment is selected: my-project " +
+                "(`.venv\\Scripts\\python.exe`)."
+        );
+        expect(log).to.not.contain(".venv/bin/python");
     });
 
     it("drops databricks-connect in constraints-only mode", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -53,34 +53,45 @@ describe("formatSetupLog", () => {
         expect(log.trim().length).to.be.greaterThan(0);
     });
 
-    it("includes the versions, compute and artifact source", () => {
+    it("includes the versions and capitalized compute label", () => {
         const log = formatSetupLog(SUCCESS_DEFAULT);
         expect(log).to.contain("Python:             3.12");
         expect(log).to.contain("databricks-connect: 17.2.0");
-        expect(log).to.contain("Compute:            serverless v4");
-        expect(log).to.contain("Packages:           downloaded from network");
+        expect(log).to.contain("Compute:            Serverless v4");
     });
 
-    it("lists what was done", () => {
+    it("lists what was done, falling back to the bare .venv name", () => {
         const log = formatSetupLog(SUCCESS_DEFAULT);
         expect(log).to.contain(
             "  • Added matching Databricks constraints to pyproject.toml"
         );
         expect(log).to.contain(
-            "  • Built the virtual environment with uv sync"
+            "  • Built a new virtual environment with uv sync called .venv"
         );
         expect(log).to.contain(
             "  • Selected .venv as the workspace interpreter"
         );
     });
 
-    it("reuses-from-cache wording when artifacts came from cache", () => {
-        const cached: PythonSetupResult = {
-            ...SUCCESS_DEFAULT,
-            resolved: {...SUCCESS_DEFAULT.resolved!, artifactSource: "cache"},
-        };
-        expect(formatSetupLog(cached)).to.contain(
-            "Packages:           reused from cache"
+    it("shows the project name beside .venv when one is resolved", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project");
+        expect(log).to.contain(
+            "  • Built a new virtual environment with uv sync called " +
+                ".venv (my-project)"
+        );
+        expect(log).to.contain(
+            "  • Selected .venv (my-project) as the workspace interpreter"
+        );
+        expect(log).to.contain(
+            "virtual environment is selected: my-project (`.venv/bin/python`)."
+        );
+    });
+
+    it("tells the user how to run notebooks with the venv", () => {
+        expect(formatSetupLog(SUCCESS_DEFAULT)).to.contain(
+            "To run notebooks using this virtual environment, click Select " +
+                "Kernel in the upper right of a notebook and ensure that the " +
+                "virtual environment is selected (`.venv/bin/python`)."
         );
     });
 
@@ -92,12 +103,11 @@ describe("formatSetupLog", () => {
         expect(log).to.not.contain("databricks-connect");
     });
 
-    it("shows the backup file and venv path on a real run", () => {
+    it("shows the backup file on a real run", () => {
         const log = formatSetupLog(SUCCESS_REAL_RUN);
         expect(log).to.contain(
             "  • Backed up your previous pyproject.toml (pyproject.toml.bak)"
         );
-        expect(log).to.contain("Virtual environment: /home/user/project/.venv");
     });
 
     it("omits the backup line when nothing was backed up", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -3,6 +3,7 @@ import {
     PythonSetupComputeInfo,
     PythonSetupResult,
 } from "../models/PythonSetupResult";
+import {venvInterpreterPath} from "./venvInterpreterPath";
 
 export interface PythonSetupNotification {
     message: string;
@@ -51,12 +52,17 @@ export function formatSetupNotification(
  * caller from `.venv/pyvenv.cfg`. It is shown in parentheses beside the venv
  * folder when known; when omitted the bare `.venv` folder name stands alone.
  *
+ * `platform` selects the OS-specific interpreter path shown in the notebook
+ * hint (`.venv/bin/python` vs `.venv\Scripts\python.exe`); it defaults to the
+ * host and is injectable so the output is deterministic in tests.
+ *
  * Returned with a leading and trailing newline so it reads as its own block
  * beneath any CLI output already streamed to the channel.
  */
 export function formatSetupLog(
     result: PythonSetupResult,
-    projectName?: string
+    projectName?: string,
+    platform: NodeJS.Platform = process.platform
 ): string {
     const isDefault = result.mode === "default";
     // The venv folder is always `.venv`; when the caller resolved the project
@@ -94,10 +100,12 @@ export function formatSetupLog(
     }
 
     // Name the environment to look for in the picker when we have it; the
-    // interpreter path is the version-proof anchor either way.
+    // interpreter path is the version-proof anchor either way. Render it
+    // OS-aware (`.venv/bin/python` vs `.venv\Scripts\python.exe`).
+    const interpreter = venvInterpreterPath(".venv", platform);
     const selectedHint = projectName
-        ? `is selected: ${projectName} (\`.venv/bin/python\`).`
-        : "is selected (`.venv/bin/python`).";
+        ? `is selected: ${projectName} (\`${interpreter}\`).`
+        : `is selected (\`${interpreter}\`).`;
     lines.push(
         "",
         "To run notebooks using this virtual environment, click Select " +

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -42,15 +42,27 @@ export function formatSetupNotification(
  * The full, verbose breakdown written to the "Databricks Python Environment
  * Setup" output channel on success, revealed by the notification's "View
  * Details" button. This is the home for everything the one-line message omits
- * (versions, compute, artifact source, backup path, venv path, full warning
+ * (versions, compute, backup path, how to run notebooks, full warning
  * messages) — necessary because in `--output json` mode the CLI streams little
  * or nothing to stderr on success, so without this the channel would be empty.
+ *
+ * `projectName` is the human-readable name uv associated with the venv (from
+ * pyproject's `[project].name`, else the project folder name), surfaced by the
+ * caller from `.venv/pyvenv.cfg`. It is shown in parentheses beside the venv
+ * folder when known; when omitted the bare `.venv` folder name stands alone.
  *
  * Returned with a leading and trailing newline so it reads as its own block
  * beneath any CLI output already streamed to the channel.
  */
-export function formatSetupLog(result: PythonSetupResult): string {
+export function formatSetupLog(
+    result: PythonSetupResult,
+    projectName?: string
+): string {
     const isDefault = result.mode === "default";
+    // The venv folder is always `.venv`; when the caller resolved the project
+    // name, show it alongside so the line reads like the label VS Code puts on
+    // the interpreter (e.g. ".venv (my-project)").
+    const venvLabel = projectName ? `.venv (${projectName})` : ".venv";
     const lines: string[] = [
         isDefault
             ? "Python environment ready for Databricks Connect."
@@ -66,18 +78,13 @@ export function formatSetupLog(result: PythonSetupResult): string {
     if (compute) {
         lines.push(`Compute:            ${compute}`);
     }
-    lines.push(
-        `Packages:           ${
-            result.resolved?.artifactSource === "cache"
-                ? "reused from cache"
-                : "downloaded from network"
-        }`
-    );
 
     lines.push("", "What was done:");
     lines.push("  • Added matching Databricks constraints to pyproject.toml");
-    lines.push("  • Built the virtual environment with uv sync");
-    lines.push("  • Selected .venv as the workspace interpreter");
+    lines.push(
+        `  • Built a new virtual environment with uv sync called ${venvLabel}`
+    );
+    lines.push(`  • Selected ${venvLabel} as the workspace interpreter`);
     if (result.backupPath) {
         lines.push(
             `  • Backed up your previous pyproject.toml (${path.basename(
@@ -86,9 +93,17 @@ export function formatSetupLog(result: PythonSetupResult): string {
         );
     }
 
-    if (result.venvPath) {
-        lines.push("", `Virtual environment: ${result.venvPath}`);
-    }
+    // Name the environment to look for in the picker when we have it; the
+    // interpreter path is the version-proof anchor either way.
+    const selectedHint = projectName
+        ? `is selected: ${projectName} (\`.venv/bin/python\`).`
+        : "is selected (`.venv/bin/python`).";
+    lines.push(
+        "",
+        "To run notebooks using this virtual environment, click Select " +
+            "Kernel in the upper right of a notebook and ensure that the " +
+            `virtual environment ${selectedHint}`
+    );
 
     if (result.warnings.length > 0) {
         lines.push("", "Warnings:");
@@ -111,7 +126,7 @@ function computeLabel(
         return undefined;
     }
     if (compute.serverlessVersion) {
-        return `serverless ${compute.serverlessVersion}`;
+        return `Serverless ${compute.serverlessVersion}`;
     }
     if (compute.clusterId) {
         return `cluster ${compute.clusterId}`;

--- a/packages/databricks-vscode/src/python-setup/utils/venvProjectName.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/venvProjectName.test.ts
@@ -1,0 +1,40 @@
+import {expect} from "chai";
+import {parsePyvenvPrompt} from "./venvProjectName";
+
+describe("parsePyvenvPrompt", () => {
+    const pyvenvCfg = (prompt: string) =>
+        [
+            "home = /usr/bin",
+            "implementation = CPython",
+            "version_info = 3.12",
+            "include-system-site-packages = false",
+            `prompt = ${prompt}`,
+        ].join("\n");
+
+    it("returns the prompt value uv wrote", () => {
+        expect(parsePyvenvPrompt(pyvenvCfg("my-project"))).to.equal(
+            "my-project"
+        );
+    });
+
+    it("trims surrounding whitespace and tolerates CRLF line endings", () => {
+        const contents = "version_info = 3.12\r\nprompt =   spaced-out  \r\n";
+        expect(parsePyvenvPrompt(contents)).to.equal("spaced-out");
+    });
+
+    it("returns undefined when there is no prompt line", () => {
+        expect(
+            parsePyvenvPrompt("home = /usr/bin\nversion_info = 3.12")
+        ).to.equal(undefined);
+    });
+
+    it("returns undefined when the prompt value is empty", () => {
+        expect(parsePyvenvPrompt("prompt = ")).to.equal(undefined);
+    });
+
+    it("keeps names that contain spaces", () => {
+        expect(parsePyvenvPrompt("prompt = My Data Project")).to.equal(
+            "My Data Project"
+        );
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/venvProjectName.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/venvProjectName.ts
@@ -1,0 +1,40 @@
+import {readFile} from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Pull the human-readable environment name out of a venv's `pyvenv.cfg`
+ * `prompt` line. uv sets `prompt` to pyproject's `[project].name`, falling back
+ * to the project folder name — the same label a shell shows on activation and a
+ * friendlier handle than the bare `.venv` folder. Returns undefined when there
+ * is no usable `prompt`, so callers fall back to the plain folder name.
+ */
+export function parsePyvenvPrompt(contents: string): string | undefined {
+    for (const line of contents.split(/\r?\n/)) {
+        const match = /^\s*prompt\s*=\s*(.*)$/.exec(line);
+        if (match) {
+            const value = match[1].trim();
+            return value.length > 0 ? value : undefined;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Best-effort read of the venv's project name from `<venvDir>/pyvenv.cfg`. The
+ * name only enriches the success summary, so this never throws: a missing or
+ * unreadable file, or one without a `prompt`, yields undefined and the caller
+ * shows the bare `.venv` folder name instead.
+ */
+export async function readVenvProjectName(
+    venvDir: string
+): Promise<string | undefined> {
+    try {
+        const contents = await readFile(
+            path.join(venvDir, "pyvenv.cfg"),
+            "utf-8"
+        );
+        return parsePyvenvPrompt(contents);
+    } catch {
+        return undefined;
+    }
+}


### PR DESCRIPTION
## What

Polishes the setup-complete breakdown written to the "Databricks Python Environment Setup" output channel on success.

Before:

```
Python:             3.12
databricks-connect: 17.3.12
Compute:            serverless v4
Packages:           downloaded from network

What was done:
  • Added matching Databricks constraints to pyproject.toml
  • Built the virtual environment with uv sync
  • Selected .venv as the workspace interpreter
  • Backed up your previous pyproject.toml (pyproject.toml.bak)

Virtual environment: /path/to/.venv
```

After:

```
Python:             3.12
databricks-connect: 17.3.12
Compute:            Serverless v4

What was done:
  • Added matching Databricks constraints to pyproject.toml
  • Built a new virtual environment with uv sync called .venv (my-project)
  • Selected .venv (my-project) as the workspace interpreter
  • Backed up your previous pyproject.toml (pyproject.toml.bak)

To run notebooks using this virtual environment, click Select Kernel in the upper right of a notebook and ensure that the virtual environment is selected: my-project (`.venv/bin/python`).
```

Changes:

- **Name the venv with its project name** — rendered `.venv (name)` on the two "What was done" lines, and as `: name` in the notebook guidance. The name is read from the `prompt` uv writes into `.venv/pyvenv.cfg` (uv derives it from `[project].name`, else the project folder name — the same label a shell shows on activation). Falls back to the bare `.venv` folder name (and the guidance drops the `: name`) whenever it can't be read.
- **Add notebook-run guidance**, pointing at the stable interpreter path `.venv/bin/python`, and drop the raw `Virtual environment: <path>` line it replaces.
- **Drop the internal-looking `Packages:` line.**
- **Capitalize the compute label** (`Serverless v4`).

## How

- New util `venvProjectName.ts`: a pure `parsePyvenvPrompt(contents)` plus a thin, best-effort `readVenvProjectName(venvDir)` that never throws (the name is a cosmetic enrichment, not load-bearing). Co-located unit test.
- `formatSetupLog` takes an optional `projectName` and stays pure; the `showSuccess` caller resolves the name from `result.venvPath` and passes it in.

## Test

- `yarn workspace databricks run build`: clean.
- `yarn workspace databricks run test:lint` (Prettier + ESLint): clean.
- Unit suite: new `parsePyvenvPrompt` tests and updated `formatSetupLog` specs (project-name and notebook-line variants) pass.

This pull request and its description were written by Isaac.
