### PR TITLE
feat(python-setup): detect compute drift and offer re-run

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1159,13 +1159,13 @@
                 },
                 {
                     "command": "databricks.environment.rerunPythonEnv",
-                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.success$/",
+                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.(success|drifted)$/",
                     "group": "inline@0",
                     "icon": "$(sync)"
                 },
                 {
                     "command": "databricks.environment.rerunPythonEnv",
-                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.success$/",
+                    "when": "view == configurationView && viewItem =~ /^databricks.environment.pythonSetup.(success|drifted)$/",
                     "group": "navigation@0",
                     "icon": "$(sync)"
                 },

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1039,6 +1039,24 @@ export async function activate(
         isVisible: () => pythonSetupEnvironment.isVisible(),
         getPersistedEnvKey: () =>
             stateStorage.get("databricks.pythonSetup.setupState")?.envKey,
+        // Cheap, synchronous compute identity (no CLI). A cluster's env key is
+        // derived from its Spark version, so include it: a runtime-state change
+        // (RUNNING -> TERMINATED) keeps the descriptor stable and is skipped,
+        // while a DBR edit changes it and re-checks. undefined means nothing
+        // comparable is attached (drift is then meaningless).
+        getComputeDescriptor: () => {
+            const cluster = connectionManager.cluster;
+            if (cluster) {
+                return `cluster:${cluster.id}:${cluster.sparkVersion}`;
+            }
+            if (connectionManager.serverless) {
+                const version = connectionManager.serverlessVersion;
+                return version === undefined
+                    ? undefined
+                    : `serverless:${version}`;
+            }
+            return undefined;
+        },
         resolveCurrentEnvKey: async (token) => {
             // activeProjectUri throws when no project is active; degrade to
             // "unknown" rather than letting it reject into the drift check.
@@ -1080,8 +1098,15 @@ export async function activate(
         connectionManager.onDidChangeCluster(() =>
             pythonSetupDrift.check("computeChange")
         ),
-        // Serverless selection / version changes flow through connection state.
+        // Serverless enable/disable and connection churn flow through state.
         connectionManager.onDidChangeState(() =>
+            pythonSetupDrift.check("computeChange")
+        ),
+        // Re-picking the serverless version while serverless is already selected
+        // fires neither onDidChangeCluster nor onDidChangeState -- it only writes
+        // the `serverlessVersion` config key -- so watch that key directly, or a
+        // v4 -> v2 switch would silently miss drift.
+        configModel.onDidChangeKey("serverlessVersion")(async () =>
             pythonSetupDrift.check("computeChange")
         ),
         // A completed setup updates the persisted state; re-evaluate so a

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -2,7 +2,6 @@ import {
     commands,
     debug,
     env,
-    EventEmitter,
     ExtensionContext,
     extensions,
     OutputChannel,
@@ -53,7 +52,11 @@ import {
 import {PythonSetupManagerDetector} from "./python-setup/utils/PythonSetupManagerDetector";
 import {PythonSetupCliClient} from "./python-setup/gateways/PythonSetupCliClient";
 import {PythonSetupEnvironmentSetup} from "./python-setup/controllers/PythonSetupEnvironmentSetup";
-import {makePythonSetupDeps} from "./python-setup/controllers/pythonSetupDeps";
+import {
+    makePythonSetupDeps,
+    resolveComputeFrom,
+} from "./python-setup/controllers/pythonSetupDeps";
+import {PythonSetupDriftManager} from "./python-setup/controllers/PythonSetupDriftManager";
 import {resolveCliPath} from "./python-setup/utils/setupLocalArgs";
 import {
     isPythonSetupEnabled,
@@ -1016,23 +1019,82 @@ export async function activate(
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
         ),
-        // Re-run affordance on the "Python environment ready" row. Delegates to
-        // the same setup handler (re-entrancy-guarded); a distinct id lets the
-        // menu show a "Re-run Python setup" title instead of the initial one.
+        // Re-run affordance shared by the "Python environment ready" row and the
+        // drifted row. Delegates to the same setup handler (re-entrancy-guarded);
+        // a distinct command id lets the menu show a "Re-run Python setup" title
+        // and gives re-runs their own COMMAND_EXECUTION telemetry.
         telemetry.registerCommand(
             "databricks.environment.rerunPythonEnv",
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
         )
     );
+    // Drives the config-view row's "out of date" state: on compute/open/setup
+    // triggers it silently resolves the selected compute's env key via a CLI
+    // dry-run and compares it against the last successful setup's key. Every
+    // resolution path is fail-safe (returns undefined => "unknown", no drift) and
+    // never surfaces UI.
+    const pythonSetupDrift = new PythonSetupDriftManager({
+        // Reuse the exact feature+greenfield gate the row is shown under.
+        isVisible: () => pythonSetupEnvironment.isVisible(),
+        getPersistedEnvKey: () =>
+            stateStorage.get("databricks.pythonSetup.setupState")?.envKey,
+        resolveCurrentEnvKey: async (token) => {
+            // activeProjectUri throws when no project is active; degrade to
+            // "unknown" rather than letting it reject into the drift check.
+            let root: string | undefined;
+            try {
+                root = workspaceFolderManager.activeProjectUri.fsPath;
+            } catch {
+                return undefined;
+            }
+            const resolution = resolveComputeFrom({
+                serverless: connectionManager.serverless,
+                cluster: connectionManager.cluster
+                    ? {id: connectionManager.cluster.id}
+                    : undefined,
+                serverlessVersion: connectionManager.serverlessVersion,
+            });
+            if (resolution.status !== "ok") {
+                return undefined;
+            }
+            try {
+                const result = await pythonSetupClient.run(
+                    {
+                        mode: "default",
+                        dryRun: true,
+                        compute: resolution.compute,
+                    },
+                    {cwd: root, token}
+                );
+                return result.compute?.envKey;
+            } catch {
+                return undefined;
+            }
+        },
+        recordDrift: (report) => telemetry.recordPythonSetupDrift(report),
+    });
+    context.subscriptions.push(
+        pythonSetupDrift,
+        // Compute target changed (cluster attach/detach/switch).
+        connectionManager.onDidChangeCluster(() =>
+            pythonSetupDrift.check("computeChange")
+        ),
+        // Serverless selection / version changes flow through connection state.
+        connectionManager.onDidChangeState(() =>
+            pythonSetupDrift.check("computeChange")
+        ),
+        // A completed setup updates the persisted state; re-evaluate so a
+        // successful re-run clears the badge promptly.
+        pythonSetupEnvironment.onDidChangeState(() =>
+            pythonSetupDrift.check("setupCompleted")
+        )
+    );
+    // The "workspace open" trigger: evaluate once now that everything is wired.
+    pythonSetupDrift.check("workspaceOpen");
+
     // The config-view entry combines the setup controller's readiness with the
-    // drift manager's `drifted` signal. The drift manager is not wired here yet,
-    // so pass an inert drift source (never drifted) for now: behaviour is
-    // identical to before, and the wiring drops in without touching this call.
-    const pythonSetupDrift = {
-        drifted: false,
-        onDidChangeState: new EventEmitter<void>().event,
-    };
+    // drift manager's `drifted` signal.
     const pythonSetupEntry = composePythonSetupEntry(
         pythonSetupEnvironment,
         pythonSetupDrift

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -2,6 +2,7 @@ import {
     commands,
     debug,
     env,
+    EventEmitter,
     ExtensionContext,
     extensions,
     OutputChannel,
@@ -16,6 +17,7 @@ import {ClusterListDataProvider} from "./cluster/ClusterListDataProvider";
 import {ClusterModel} from "./cluster/ClusterModel";
 import {ClusterCommands} from "./cluster/ClusterCommands";
 import {ConfigurationDataProvider} from "./ui/configuration-view/ConfigurationDataProvider";
+import {composePythonSetupEntry} from "./ui/configuration-view/pythonSetupEntry";
 import {AiToolsManager} from "./aitools/AiToolsManager";
 import {AiToolsCommands} from "./aitools/AiToolsCommands";
 import {RunCommands} from "./run/RunCommands";
@@ -1023,6 +1025,19 @@ export async function activate(
             pythonSetupEnvironment
         )
     );
+    // The config-view entry combines the setup controller's readiness with the
+    // drift manager's `drifted` signal. The drift manager is not wired here yet,
+    // so pass an inert drift source (never drifted) for now: behaviour is
+    // identical to before, and the wiring drops in without touching this call.
+    const pythonSetupDrift = {
+        drifted: false,
+        onDidChangeState: new EventEmitter<void>().event,
+    };
+    const pythonSetupEntry = composePythonSetupEntry(
+        pythonSetupEnvironment,
+        pythonSetupDrift
+    );
+    context.subscriptions.push(pythonSetupEntry);
 
     const environmentCommands = new EnvironmentCommands(
         featureManager,
@@ -1143,7 +1158,7 @@ export async function activate(
         featureManager,
         workspaceFolderManager,
         aiToolsManager,
-        pythonSetupEnvironment
+        pythonSetupEntry
     );
     const configurationView = window.createTreeView("configurationView", {
         treeDataProvider: configurationDataProvider,

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1019,31 +1019,27 @@ export async function activate(
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
         ),
-        // Re-run affordance shared by the "Python environment ready" row and the
-        // drifted row. Delegates to the same setup handler (re-entrancy-guarded);
-        // a distinct command id lets the menu show a "Re-run Python setup" title
-        // and gives re-runs their own COMMAND_EXECUTION telemetry.
+        // Re-run affordance shared by the ready and out-of-sync rows. Delegates
+        // to the same (re-entrancy-guarded) setup handler; a distinct command id
+        // gives the menu a "Re-run Python setup" title and its own telemetry.
         telemetry.registerCommand(
             "databricks.environment.rerunPythonEnv",
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
         )
     );
-    // Drives the config-view row's "out of date" state: on compute/open/setup
+    // Drives the config-view row's out-of-sync state: on compute/open/setup
     // triggers it silently resolves the selected compute's env key via a CLI
-    // dry-run and compares it against the last successful setup's key. Every
-    // resolution path is fail-safe (returns undefined => "unknown", no drift) and
-    // never surfaces UI.
+    // dry-run and compares it against the last setup's. Fail-safe throughout
+    // (undefined => "unknown", no drift) and never surfaces UI.
     const pythonSetupDrift = new PythonSetupDriftManager({
-        // Reuse the exact feature+greenfield gate the row is shown under.
+        // Reuse the exact gate the row is shown under.
         isVisible: () => pythonSetupEnvironment.isVisible(),
         getPersistedEnvKey: () =>
             stateStorage.get("databricks.pythonSetup.setupState")?.envKey,
-        // Cheap, synchronous compute identity (no CLI). A cluster's env key is
-        // derived from its Spark version, so include it: a runtime-state change
-        // (RUNNING -> TERMINATED) keeps the descriptor stable and is skipped,
-        // while a DBR edit changes it and re-checks. undefined means nothing
-        // comparable is attached (drift is then meaningless).
+        // Cheap, synchronous compute identity (no CLI). A cluster's Spark version
+        // is included so a DBR edit re-checks while a runtime-state change
+        // (RUNNING -> TERMINATED) is skipped. undefined => nothing comparable.
         getComputeDescriptor: () => {
             const cluster = connectionManager.cluster;
             if (cluster) {
@@ -1059,7 +1055,7 @@ export async function activate(
         },
         resolveCurrentEnvKey: async (token) => {
             // activeProjectUri throws when no project is active; degrade to
-            // "unknown" rather than letting it reject into the drift check.
+            // "unknown" instead of rejecting into the drift check.
             let root: string | undefined;
             try {
                 root = workspaceFolderManager.activeProjectUri.fsPath;
@@ -1102,24 +1098,22 @@ export async function activate(
         connectionManager.onDidChangeState(() =>
             pythonSetupDrift.check("computeChange")
         ),
-        // Re-picking the serverless version while serverless is already selected
-        // fires neither onDidChangeCluster nor onDidChangeState -- it only writes
-        // the `serverlessVersion` config key -- so watch that key directly, or a
+        // Re-picking the serverless version fires neither event above — it only
+        // writes the `serverlessVersion` key — so watch it directly, or a
         // v4 -> v2 switch would silently miss drift.
         configModel.onDidChangeKey("serverlessVersion")(async () =>
             pythonSetupDrift.check("computeChange")
         ),
-        // A completed setup updates the persisted state; re-evaluate so a
-        // successful re-run clears the badge promptly.
+        // A completed setup moves the persisted baseline; re-evaluate to clear
+        // the badge promptly after a successful re-run.
         pythonSetupEnvironment.onDidChangeState(() =>
             pythonSetupDrift.check("setupCompleted")
         )
     );
-    // The "workspace open" trigger: evaluate once now that everything is wired.
+    // Evaluate once now that everything is wired.
     pythonSetupDrift.check("workspaceOpen");
 
-    // The config-view entry combines the setup controller's readiness with the
-    // drift manager's `drifted` signal.
+    // Combine the setup controller's readiness with the drift signal.
     const pythonSetupEntry = composePythonSetupEntry(
         pythonSetupEnvironment,
         pythonSetupDrift

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -198,6 +198,34 @@ describe("PythonSetupDriftManager", () => {
         m.dispose();
     });
 
+    it("drops the result when the setup baseline moved during the dry-run", async () => {
+        // A setup can complete mid-flight and re-provision the baseline; comparing
+        // the stale baseline against the fresh key would log a false drift event.
+        let persisted = "serverless/serverless-v4";
+        const {deps, recorded} = makeDeps({
+            getPersistedEnvKey: () => persisted,
+            resolveCurrentEnvKey: async () => {
+                persisted = "dbr/15.4.x-scala2.12"; // setup completed mid-flight
+                return "dbr/15.4.x-scala2.12";
+            },
+        });
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(m.state).to.equal("ready");
+        expect(recorded).to.have.length(0);
+        m.dispose();
+    });
+
+    it("ignores triggers once disposed", async () => {
+        const {deps, recorded, calls} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        m.dispose();
+        m.check("computeChange");
+        await m.evaluate("computeChange");
+        expect(calls.resolve).to.equal(0);
+        expect(recorded).to.have.length(0);
+    });
+
     it("does not mutate state or record telemetry after disposal", async () => {
         // A resolver that ignores cancellation must not commit a result once the
         // manager is disposed.

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -28,6 +28,19 @@ function makeDeps(over: Partial<PythonSetupDriftDeps> = {}): {
 }
 
 describe("PythonSetupDriftManager", () => {
+    it("derives state from persisted setup before any check runs", () => {
+        // On a fresh reload, before any dry-run, the state must already reflect
+        // the persisted record: `ready` when one exists, `unset` when it doesn't.
+        const withState = new PythonSetupDriftManager(makeDeps().deps);
+        expect(withState.state).to.equal("ready");
+        withState.dispose();
+
+        const {deps} = makeDeps({getPersistedEnvKey: () => undefined});
+        const withoutState = new PythonSetupDriftManager(deps);
+        expect(withoutState.state).to.equal("unset");
+        withoutState.dispose();
+    });
+
     it("flags drift and reports telemetry when keys differ", async () => {
         const {deps, recorded} = makeDeps();
         const m = new PythonSetupDriftManager(deps);
@@ -36,7 +49,7 @@ describe("PythonSetupDriftManager", () => {
 
         await m.evaluate("computeChange");
 
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
         expect(fired).to.equal(1);
         expect(recorded).to.deep.equal([
             {
@@ -48,13 +61,13 @@ describe("PythonSetupDriftManager", () => {
         m.dispose();
     });
 
-    it("does not flag drift when the keys match", async () => {
+    it("stays ready when the keys match", async () => {
         const {deps, recorded} = makeDeps({
             resolveCurrentEnvKey: async () => "serverless/serverless-v4",
         });
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.equal("ready");
         expect(recorded).to.have.length(0);
         m.dispose();
     });
@@ -63,43 +76,43 @@ describe("PythonSetupDriftManager", () => {
         const {deps, recorded} = makeDeps({isVisible: async () => false});
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.not.equal("drifted");
         expect(recorded).to.have.length(0);
         m.dispose();
     });
 
-    it("does not flag drift when there is no persisted state", async () => {
+    it("is unset when there is no persisted state", async () => {
         const {deps} = makeDeps({getPersistedEnvKey: () => undefined});
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.equal("unset");
         m.dispose();
     });
 
-    it("leaves the flag unchanged when the current key is unknown", async () => {
+    it("leaves the state unchanged when the current key is unknown", async () => {
         // Start drifted, then a later check can't resolve the key: stay drifted.
         const {deps} = makeDeps();
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("computeChange");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
 
         (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
             async () => undefined;
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
         m.dispose();
     });
 
-    it("clears drift once the keys match again", async () => {
+    it("returns to ready once the keys match again", async () => {
         const {deps} = makeDeps();
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("computeChange");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
 
         (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
             async () => "serverless/serverless-v4";
         await m.evaluate("setupCompleted");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.equal("ready");
         m.dispose();
     });
 
@@ -138,24 +151,24 @@ describe("PythonSetupDriftManager", () => {
         m.dispose();
     });
 
-    it("clears drift when no comparable compute is attached", async () => {
+    it("returns to ready when no comparable compute is attached", async () => {
         // Start drifted, then compute is detached: drift is meaningless, so the
-        // stale flag must clear rather than linger.
+        // state must clear back to ready rather than linger as drifted.
         const {deps} = makeDeps();
         const m = new PythonSetupDriftManager(deps);
         await m.evaluate("computeChange");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
 
         (deps as {getComputeDescriptor: unknown}).getComputeDescriptor = () =>
             undefined;
         await m.evaluate("computeChange");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.equal("ready");
         m.dispose();
     });
 
-    it("stays silent and leaves the flag unchanged when a dep rejects", async () => {
+    it("stays silent and leaves the state unchanged when a dep rejects", async () => {
         // A rejecting dep must resolve quietly to "unknown" -- no throw, no
-        // unhandled rejection, and the drift flag is left as-is.
+        // unhandled rejection, and the state is left as-is.
         const {deps, recorded} = makeDeps({
             isVisible: async () => {
                 throw new Error("network down");
@@ -163,22 +176,22 @@ describe("PythonSetupDriftManager", () => {
         });
         const m = new PythonSetupDriftManager(deps);
 
-        // Starts not drifted: a rejection leaves it false.
+        // A rejection does not flag drift.
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.false;
+        expect(m.state).to.equal("ready");
         expect(recorded).to.have.length(0);
 
-        // Now start drifted, then a rejecting dep must not retract the flag.
+        // Now become drifted, then a rejecting dep must not retract it.
         (deps as {isVisible: unknown}).isVisible = async () => true;
         await m.evaluate("computeChange");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
 
         (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
             async () => {
                 throw new Error("dry-run failed");
             };
         await m.evaluate("workspaceOpen");
-        expect(m.drifted).to.be.true;
+        expect(m.state).to.equal("drifted");
         m.dispose();
     });
 });

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -178,6 +178,52 @@ describe("PythonSetupDriftManager", () => {
         m.dispose();
     });
 
+    it("drops the result when the compute switched during the dry-run", async () => {
+        // The selected compute can change while the dry-run is in flight (a new
+        // trigger's debounce hasn't fired, so the generation is unchanged).
+        // Committing would flash a stale badge and log a drift event for a
+        // compute that is no longer selected, so the result must be dropped.
+        let descriptor = "cluster:c1";
+        const {deps, recorded} = makeDeps({
+            getComputeDescriptor: () => descriptor,
+            resolveCurrentEnvKey: async () => {
+                descriptor = "cluster:c2"; // user switched mid-flight
+                return "dbr/15.4.x-scala2.12";
+            },
+        });
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(m.state).to.equal("ready");
+        expect(recorded).to.have.length(0);
+        m.dispose();
+    });
+
+    it("does not mutate state or record telemetry after disposal", async () => {
+        // A resolver that ignores cancellation must not commit a result once the
+        // manager is disposed.
+        let resolveDryRun!: (v: string | undefined) => void;
+        const dryRun = new Promise<string | undefined>((r) => {
+            resolveDryRun = r;
+        });
+        const {deps, recorded} = makeDeps({
+            resolveCurrentEnvKey: () => dryRun,
+        });
+        const m = new PythonSetupDriftManager(deps);
+        let fired = 0;
+        m.onDidChangeState(() => fired++);
+
+        const pending = m.evaluate("computeChange");
+        // Flush microtasks so evaluate progresses past isVisible and is now
+        // suspended awaiting the dry-run.
+        await new Promise((r) => setTimeout(r, 0));
+        m.dispose();
+        resolveDryRun("dbr/15.4.x-scala2.12"); // resolver ignores cancellation
+        await pending;
+
+        expect(fired).to.equal(0);
+        expect(recorded).to.have.length(0);
+    });
+
     it("returns to ready when no comparable compute is attached", async () => {
         // Start drifted, then compute is detached: drift is meaningless, so the
         // state must clear back to ready rather than linger as drifted.

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -1,0 +1,147 @@
+import {expect} from "chai";
+import {CancellationLike} from "../gateways/PythonSetupCliClient";
+import {
+    PythonSetupDriftDeps,
+    PythonSetupDriftManager,
+} from "./PythonSetupDriftManager";
+
+function makeDeps(over: Partial<PythonSetupDriftDeps> = {}): {
+    deps: PythonSetupDriftDeps;
+    recorded: unknown[];
+} {
+    const recorded: unknown[] = [];
+    const deps: PythonSetupDriftDeps = {
+        isVisible: async () => true,
+        getPersistedEnvKey: () => "serverless/serverless-v4",
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        resolveCurrentEnvKey: async (_token: CancellationLike) =>
+            "dbr/15.4.x-scala2.12",
+        recordDrift: (r) => recorded.push(r),
+        ...over,
+    };
+    return {deps, recorded};
+}
+
+describe("PythonSetupDriftManager", () => {
+    it("flags drift and reports telemetry when keys differ", async () => {
+        const {deps, recorded} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        let fired = 0;
+        m.onDidChangeState(() => fired++);
+
+        await m.evaluate("computeChange");
+
+        expect(m.drifted).to.be.true;
+        expect(fired).to.equal(1);
+        expect(recorded).to.deep.equal([
+            {
+                trigger: "computeChange",
+                fromEnvKey: "serverless/serverless-v4",
+                toEnvKey: "dbr/15.4.x-scala2.12",
+            },
+        ]);
+        m.dispose();
+    });
+
+    it("does not flag drift when the keys match", async () => {
+        const {deps, recorded} = makeDeps({
+            resolveCurrentEnvKey: async () => "serverless/serverless-v4",
+        });
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.false;
+        expect(recorded).to.have.length(0);
+        m.dispose();
+    });
+
+    it("is a no-op when not visible", async () => {
+        const {deps, recorded} = makeDeps({isVisible: async () => false});
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.false;
+        expect(recorded).to.have.length(0);
+        m.dispose();
+    });
+
+    it("does not flag drift when there is no persisted state", async () => {
+        const {deps} = makeDeps({getPersistedEnvKey: () => undefined});
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.false;
+        m.dispose();
+    });
+
+    it("leaves the flag unchanged when the current key is unknown", async () => {
+        // Start drifted, then a later check can't resolve the key: stay drifted.
+        const {deps} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(m.drifted).to.be.true;
+
+        (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
+            async () => undefined;
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.true;
+        m.dispose();
+    });
+
+    it("clears drift once the keys match again", async () => {
+        const {deps} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(m.drifted).to.be.true;
+
+        (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
+            async () => "serverless/serverless-v4";
+        await m.evaluate("setupCompleted");
+        expect(m.drifted).to.be.false;
+        m.dispose();
+    });
+
+    it("reports the same mismatch only once until it clears", async () => {
+        const {deps, recorded} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        await m.evaluate("workspaceOpen"); // same mismatch, no new telemetry
+        expect(recorded).to.have.length(1);
+
+        // Clears, then the same mismatch recurs -> reported again.
+        (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
+            async () => "serverless/serverless-v4";
+        await m.evaluate("setupCompleted");
+        (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
+            async () => "dbr/15.4.x-scala2.12";
+        await m.evaluate("computeChange");
+        expect(recorded).to.have.length(2);
+        m.dispose();
+    });
+
+    it("stays silent and leaves the flag unchanged when a dep rejects", async () => {
+        // A rejecting dep must resolve quietly to "unknown" -- no throw, no
+        // unhandled rejection, and the drift flag is left as-is.
+        const {deps, recorded} = makeDeps({
+            isVisible: async () => {
+                throw new Error("network down");
+            },
+        });
+        const m = new PythonSetupDriftManager(deps);
+
+        // Starts not drifted: a rejection leaves it false.
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.false;
+        expect(recorded).to.have.length(0);
+
+        // Now start drifted, then a rejecting dep must not retract the flag.
+        (deps as {isVisible: unknown}).isVisible = async () => true;
+        await m.evaluate("computeChange");
+        expect(m.drifted).to.be.true;
+
+        (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
+            async () => {
+                throw new Error("dry-run failed");
+            };
+        await m.evaluate("workspaceOpen");
+        expect(m.drifted).to.be.true;
+        m.dispose();
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -151,6 +151,33 @@ describe("PythonSetupDriftManager", () => {
         m.dispose();
     });
 
+    it("retries the same compute after a transient resolution failure", async () => {
+        // A dry-run that comes back "unknown" (transient CLI/network failure)
+        // must NOT record the descriptor: otherwise the no-op skip above would
+        // latch this compute and every later same-identity trigger would be
+        // dropped, so a genuine drift would never be detected until the compute
+        // changed or a reload happened. The next same-descriptor check must
+        // re-run the dry-run and pick up the drift.
+        let key: string | undefined = undefined;
+        const {deps, calls} = makeDeps({
+            resolveCurrentEnvKey: async () => {
+                calls.resolve++;
+                return key;
+            },
+        });
+        const m = new PythonSetupDriftManager(deps);
+
+        await m.evaluate("computeChange"); // resolves undefined -> unknown
+        expect(calls.resolve).to.equal(1);
+        expect(m.state).to.equal("ready"); // unchanged, no false drift
+
+        key = "dbr/15.4.x-scala2.12"; // now the dry-run succeeds and shows drift
+        await m.evaluate("computeChange"); // SAME descriptor -> must not be skipped
+        expect(calls.resolve).to.equal(2);
+        expect(m.state).to.equal("drifted");
+        m.dispose();
+    });
+
     it("returns to ready when no comparable compute is attached", async () => {
         // Start drifted, then compute is detached: drift is meaningless, so the
         // state must clear back to ready rather than linger as drifted.

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.test.ts
@@ -8,18 +8,23 @@ import {
 function makeDeps(over: Partial<PythonSetupDriftDeps> = {}): {
     deps: PythonSetupDriftDeps;
     recorded: unknown[];
+    calls: {resolve: number};
 } {
     const recorded: unknown[] = [];
+    const calls = {resolve: 0};
     const deps: PythonSetupDriftDeps = {
         isVisible: async () => true,
         getPersistedEnvKey: () => "serverless/serverless-v4",
+        getComputeDescriptor: () => "cluster:c1",
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        resolveCurrentEnvKey: async (_token: CancellationLike) =>
-            "dbr/15.4.x-scala2.12",
+        resolveCurrentEnvKey: async (_token: CancellationLike) => {
+            calls.resolve++;
+            return "dbr/15.4.x-scala2.12";
+        },
         recordDrift: (r) => recorded.push(r),
         ...over,
     };
-    return {deps, recorded};
+    return {deps, recorded, calls};
 }
 
 describe("PythonSetupDriftManager", () => {
@@ -105,14 +110,46 @@ describe("PythonSetupDriftManager", () => {
         await m.evaluate("workspaceOpen"); // same mismatch, no new telemetry
         expect(recorded).to.have.length(1);
 
-        // Clears, then the same mismatch recurs -> reported again.
+        // Clears, then a mismatch recurs on a DIFFERENT compute -> reported
+        // again (a different descriptor is required, since a compute-change with
+        // the same identity is skipped as a no-op runtime-state transition).
         (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
             async () => "serverless/serverless-v4";
         await m.evaluate("setupCompleted");
+        (deps as {getComputeDescriptor: unknown}).getComputeDescriptor = () =>
+            "cluster:c2";
         (deps as {resolveCurrentEnvKey: unknown}).resolveCurrentEnvKey =
             async () => "dbr/15.4.x-scala2.12";
         await m.evaluate("computeChange");
         expect(recorded).to.have.length(2);
+        m.dispose();
+    });
+
+    it("skips the dry-run when a compute-change leaves the identity unchanged", async () => {
+        // Same descriptor across two compute-change triggers models a cluster
+        // runtime-state transition (RUNNING -> TERMINATED): the env key cannot
+        // have changed, so the CLI dry-run must not run a second time.
+        const {deps, calls} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(calls.resolve).to.equal(1);
+        await m.evaluate("computeChange");
+        expect(calls.resolve).to.equal(1);
+        m.dispose();
+    });
+
+    it("clears drift when no comparable compute is attached", async () => {
+        // Start drifted, then compute is detached: drift is meaningless, so the
+        // stale flag must clear rather than linger.
+        const {deps} = makeDeps();
+        const m = new PythonSetupDriftManager(deps);
+        await m.evaluate("computeChange");
+        expect(m.drifted).to.be.true;
+
+        (deps as {getComputeDescriptor: unknown}).getComputeDescriptor = () =>
+            undefined;
+        await m.evaluate("computeChange");
+        expect(m.drifted).to.be.false;
         m.dispose();
     });
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -70,6 +70,9 @@ export class PythonSetupDriftManager implements Disposable {
 
     /** Debounced entry point for triggers (compute change, open, setup done). */
     check(trigger: PythonSetupDriftTrigger): void {
+        if (this.disposed) {
+            return;
+        }
         if (this.debounceTimer !== undefined) {
             clearTimeout(this.debounceTimer);
         }
@@ -84,6 +87,9 @@ export class PythonSetupDriftManager implements Disposable {
      * code reaches it through the debounced {@link check}.
      */
     async evaluate(trigger: PythonSetupDriftTrigger): Promise<void> {
+        if (this.disposed) {
+            return;
+        }
         const myGeneration = ++this.generation;
 
         // Cancel any dry-run still running for a superseded trigger.
@@ -138,10 +144,16 @@ export class PythonSetupDriftManager implements Disposable {
             if (current === undefined) {
                 return;
             }
-            // Compute may have switched during the dry-run without bumping our
-            // generation (its debounce hasn't fired yet); drop the now-stale
-            // result and let the pending trigger re-evaluate.
-            if (this.deps.getComputeDescriptor() !== descriptor) {
+            // Either input can move during the dry-run without bumping our
+            // generation (a new trigger's debounce hasn't fired yet): the compute
+            // may have switched, or a completed setup may have re-provisioned the
+            // baseline. Committing a mix of stale and fresh values would flash a
+            // wrong badge and log a false drift event, so drop the result and let
+            // the pending trigger re-evaluate.
+            if (
+                this.deps.getComputeDescriptor() !== descriptor ||
+                this.deps.getPersistedEnvKey() !== persisted
+            ) {
                 return;
             }
             // Definitive result: record the descriptor so a later no-op
@@ -151,7 +163,9 @@ export class PythonSetupDriftManager implements Disposable {
             const drifted = isDrifted(persisted, current);
             this.setDrifted(drifted);
 
-            if (drifted) {
+            // `!this.disposed`: a synchronous listener of the state event above
+            // may have disposed us during the fire; don't record telemetry then.
+            if (drifted && !this.disposed) {
                 const mismatch = `${persisted}->${current}`;
                 if (this.lastReported !== mismatch) {
                     this.lastReported = mismatch;
@@ -199,6 +213,7 @@ export class PythonSetupDriftManager implements Disposable {
         }
         this.inFlight?.cancel();
         this.inFlight?.dispose();
+        this.inFlight = undefined;
         this.stateEmitter.dispose();
     }
 }

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -8,14 +8,10 @@ export interface PythonSetupDriftDeps {
     isVisible: () => Promise<boolean>;
     getPersistedEnvKey: () => string | undefined;
     /**
-     * A cheap, synchronous descriptor of the currently selected compute's
-     * IDENTITY (e.g. `"cluster:<id>:<sparkVersion>"`, `"serverless:v5"`), or
-     * `undefined` when no comparable compute is attached (nothing selected, or
-     * serverless with no chosen version). Unlike {@link resolveCurrentEnvKey}
-     * this never spawns the CLI. It lets the manager (a) skip the dry-run when a
-     * compute-change trigger fires but the identity is unchanged -- a cluster
-     * runtime-state transition rather than a switch -- and (b) clear a stale
-     * drift flag when nothing comparable is attached.
+     * Cheap, synchronous identity of the selected compute (e.g.
+     * `"cluster:<id>:<sparkVersion>"`, `"serverless:v5"`), or `undefined` when
+     * nothing comparable is attached. Never spawns the CLI. Used to skip the
+     * dry-run on a no-op compute change and to clear drift when detached.
      */
     getComputeDescriptor: () => string | undefined;
     resolveCurrentEnvKey: (
@@ -25,29 +21,22 @@ export interface PythonSetupDriftDeps {
 }
 
 /**
- * The config-view row's derived state, from the persisted setup record vs. the
- * selected compute:
- *  - `unset`   — no successful setup on record (show the initial CTA);
- *  - `ready`   — a setup is on record and the compute still matches (or drift
- *    can't be assessed — the fail-safe direction);
+ * The config-view row's derived state:
+ *  - `unset`   — no setup on record (initial CTA);
+ *  - `ready`   — a setup is on record and matches (or drift can't be assessed);
  *  - `drifted` — a setup is on record but the selected compute no longer matches.
  */
 export type PythonSetupDriftState = "unset" | "ready" | "drifted";
 
 /**
- * Watches for compute drift: when the selected compute's environment key no
- * longer matches the one recorded by the last successful setup, exposes a
- * {@link PythonSetupDriftState} (and fires `onDidChangeState`) that the
- * config-view row renders — `drifted` becomes an "out of date -- re-run setup"
- * affordance.
+ * Watches for compute drift: when the selected compute's env key no longer
+ * matches the last successful setup's, exposes a {@link PythonSetupDriftState}
+ * the config-view row renders as an "out of date — re-run setup" affordance.
  *
- * The check is deliberately passive: it runs a silent CLI `--dry-run` (no
- * progress UI, no prompt, no error surface), is gated by `isVisible` and the
- * presence of a persisted state, is debounced against rapid compute switches,
- * and treats any inability to resolve the current key as "unknown" -- never a
- * false alarm. To avoid needless dry-runs it skips a compute-change check whose
- * compute identity is unchanged (a runtime-state transition, not a switch), and
- * it clears drift outright when no comparable compute is attached.
+ * Deliberately passive and fail-safe: a silent CLI `--dry-run` (no UI), gated by
+ * `isVisible` and a persisted state, debounced against rapid switches, and any
+ * inability to resolve the current key is treated as "unknown" — never a false
+ * alarm.
  */
 export class PythonSetupDriftManager implements Disposable {
     private _drifted = false;
@@ -56,6 +45,7 @@ export class PythonSetupDriftManager implements Disposable {
     /** Compute descriptor evaluated last, to skip no-op compute-change checks. */
     private lastComputeDescriptor: string | undefined;
     private generation = 0;
+    private disposed = false;
     private debounceTimer: ReturnType<typeof setTimeout> | undefined;
     private inFlight: CancellationTokenSource | undefined;
 
@@ -68,11 +58,8 @@ export class PythonSetupDriftManager implements Disposable {
     ) {}
 
     /**
-     * The row's derived state. Persisted state is read live so it reflects the
-     * current project across window reloads: with a setup on record the row
-     * stays `ready` (or `drifted` once a mismatch is detected) instead of
-     * reverting to the initial CTA; with none it is `unset`. The mismatch flag
-     * is only ever set while a setup is on record, so ordering here is moot.
+     * The row's derived state, read live so it survives a window reload: with a
+     * setup on record the row stays `ready`/`drifted`; with none it is `unset`.
      */
     get state(): PythonSetupDriftState {
         if (this.deps.getPersistedEnvKey() === undefined) {
@@ -108,8 +95,7 @@ export class PythonSetupDriftManager implements Disposable {
         try {
             const visible = await this.deps.isVisible();
 
-            // A newer trigger started while we awaited: drop this stale result
-            // so an out-of-order early return cannot retract a fresher flag.
+            // A newer trigger (or disposal) superseded us: drop this stale result.
             if (myGeneration !== this.generation) {
                 return;
             }
@@ -123,20 +109,17 @@ export class PythonSetupDriftManager implements Disposable {
                 return;
             }
             const descriptor = this.deps.getComputeDescriptor();
-            // No comparable compute attached (detached, or serverless with no
-            // chosen version): drift is meaningless -- you cannot be drifted from
-            // nothing -- so clear any stale flag instead of leaving it set.
+            // Nothing comparable attached (detached, or serverless with no chosen
+            // version): drift is meaningless, so clear any stale flag.
             if (descriptor === undefined) {
                 this.lastComputeDescriptor = undefined;
                 this.setDrifted(false);
                 return;
             }
-            // A compute-change trigger whose resolved identity is unchanged is a
-            // runtime-state transition (e.g. a cluster going RUNNING ->
-            // TERMINATED), not a compute switch. The environment key is derived
-            // from the identity, so it cannot have changed: skip the dry-run.
-            // workspaceOpen / setupCompleted always re-evaluate -- the first
-            // check must run, and a completed setup moves the persisted baseline.
+            // A compute-change whose identity is unchanged is a runtime-state
+            // transition (e.g. RUNNING -> TERMINATED), not a switch; the env key
+            // can't have changed, so skip the dry-run. open/setupCompleted always
+            // re-evaluate.
             if (
                 trigger === "computeChange" &&
                 descriptor === this.lastComputeDescriptor
@@ -145,24 +128,24 @@ export class PythonSetupDriftManager implements Disposable {
             }
             const current = await this.deps.resolveCurrentEnvKey(source.token);
 
-            // A newer trigger started while we awaited: drop this stale result.
+            // A newer trigger (or disposal) superseded us: drop this stale result.
             if (myGeneration !== this.generation) {
                 return;
             }
-            // Could not resolve the current key -> unknown. Leave the flag as-is
-            // rather than clearing (a transient network/auth failure must not
-            // silently retract a real drift warning), and -- crucially -- do NOT
-            // record the descriptor: a transient failure must not latch this
-            // compute into the no-op skip above, or every subsequent same-compute
-            // trigger (cluster RUNNING/PENDING/TERMINATED churn, connection state
-            // events) would be skipped and the drift check would never retry
-            // until the compute actually changes, a setup completes, or a reload.
+            // Unknown current key: leave the flag as-is (a transient failure must
+            // not retract a real warning) and do NOT record the descriptor, or the
+            // no-op skip above would latch this compute and never retry.
             if (current === undefined) {
                 return;
             }
-            // Resolution was definitive, so this descriptor is now a known
-            // quantity: record it, so a later no-op compute-change with the same
-            // identity (a runtime-state transition) is skipped.
+            // Compute may have switched during the dry-run without bumping our
+            // generation (its debounce hasn't fired yet); drop the now-stale
+            // result and let the pending trigger re-evaluate.
+            if (this.deps.getComputeDescriptor() !== descriptor) {
+                return;
+            }
+            // Definitive result: record the descriptor so a later no-op
+            // compute-change with the same identity is skipped.
             this.lastComputeDescriptor = descriptor;
 
             const drifted = isDrifted(persisted, current);
@@ -180,11 +163,9 @@ export class PythonSetupDriftManager implements Disposable {
                 }
             }
         } catch {
-            // Any failure resolving the current state (e.g. isVisible or the
-            // dry-run rejecting) is treated as "unknown": stay silent and leave
-            // the drift flag untouched -- never surface UI, never a false alarm,
-            // never retract a real warning. Same fail-safe direction as the
-            // `current === undefined` branch above.
+            // Any failure (isVisible or the dry-run rejecting) is "unknown": stay
+            // silent and leave the flag untouched — never a false alarm, never
+            // retract a real warning.
         } finally {
             if (this.inFlight === source) {
                 source.dispose();
@@ -194,6 +175,9 @@ export class PythonSetupDriftManager implements Disposable {
     }
 
     private setDrifted(value: boolean): void {
+        if (this.disposed) {
+            return;
+        }
         if (!value) {
             // Reset the telemetry dedupe latch so a recurrence is reported again.
             this.lastReported = undefined;
@@ -206,6 +190,10 @@ export class PythonSetupDriftManager implements Disposable {
     }
 
     dispose(): void {
+        this.disposed = true;
+        // Invalidate any in-flight evaluation so it can't mutate state or record
+        // telemetry after disposal.
+        this.generation++;
         if (this.debounceTimer !== undefined) {
             clearTimeout(this.debounceTimer);
         }

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -7,6 +7,17 @@ import {isDrifted} from "../utils/driftDetection";
 export interface PythonSetupDriftDeps {
     isVisible: () => Promise<boolean>;
     getPersistedEnvKey: () => string | undefined;
+    /**
+     * A cheap, synchronous descriptor of the currently selected compute's
+     * IDENTITY (e.g. `"cluster:<id>:<sparkVersion>"`, `"serverless:v5"`), or
+     * `undefined` when no comparable compute is attached (nothing selected, or
+     * serverless with no chosen version). Unlike {@link resolveCurrentEnvKey}
+     * this never spawns the CLI. It lets the manager (a) skip the dry-run when a
+     * compute-change trigger fires but the identity is unchanged -- a cluster
+     * runtime-state transition rather than a switch -- and (b) clear a stale
+     * drift flag when nothing comparable is attached.
+     */
+    getComputeDescriptor: () => string | undefined;
     resolveCurrentEnvKey: (
         token: CancellationLike
     ) => Promise<string | undefined>;
@@ -23,12 +34,16 @@ export interface PythonSetupDriftDeps {
  * progress UI, no prompt, no error surface), is gated by `isVisible` and the
  * presence of a persisted state, is debounced against rapid compute switches,
  * and treats any inability to resolve the current key as "unknown" -- never a
- * false alarm.
+ * false alarm. To avoid needless dry-runs it skips a compute-change check whose
+ * compute identity is unchanged (a runtime-state transition, not a switch), and
+ * it clears drift outright when no comparable compute is attached.
  */
 export class PythonSetupDriftManager implements Disposable {
     private _drifted = false;
     /** `${from}->${to}` of the last reported mismatch, to dedupe telemetry. */
     private lastReported: string | undefined;
+    /** Compute descriptor evaluated last, to skip no-op compute-change checks. */
+    private lastComputeDescriptor: string | undefined;
     private generation = 0;
     private debounceTimer: ReturnType<typeof setTimeout> | undefined;
     private inFlight: CancellationTokenSource | undefined;
@@ -86,6 +101,28 @@ export class PythonSetupDriftManager implements Disposable {
                 this.setDrifted(false);
                 return;
             }
+            const descriptor = this.deps.getComputeDescriptor();
+            // No comparable compute attached (detached, or serverless with no
+            // chosen version): drift is meaningless -- you cannot be drifted from
+            // nothing -- so clear any stale flag instead of leaving it set.
+            if (descriptor === undefined) {
+                this.lastComputeDescriptor = undefined;
+                this.setDrifted(false);
+                return;
+            }
+            // A compute-change trigger whose resolved identity is unchanged is a
+            // runtime-state transition (e.g. a cluster going RUNNING ->
+            // TERMINATED), not a compute switch. The environment key is derived
+            // from the identity, so it cannot have changed: skip the dry-run.
+            // workspaceOpen / setupCompleted always re-evaluate -- the first
+            // check must run, and a completed setup moves the persisted baseline.
+            if (
+                trigger === "computeChange" &&
+                descriptor === this.lastComputeDescriptor
+            ) {
+                return;
+            }
+            this.lastComputeDescriptor = descriptor;
             const current = await this.deps.resolveCurrentEnvKey(source.token);
 
             // A newer trigger started while we awaited: drop this stale result.

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -143,7 +143,6 @@ export class PythonSetupDriftManager implements Disposable {
             ) {
                 return;
             }
-            this.lastComputeDescriptor = descriptor;
             const current = await this.deps.resolveCurrentEnvKey(source.token);
 
             // A newer trigger started while we awaited: drop this stale result.
@@ -152,10 +151,19 @@ export class PythonSetupDriftManager implements Disposable {
             }
             // Could not resolve the current key -> unknown. Leave the flag as-is
             // rather than clearing (a transient network/auth failure must not
-            // silently retract a real drift warning).
+            // silently retract a real drift warning), and -- crucially -- do NOT
+            // record the descriptor: a transient failure must not latch this
+            // compute into the no-op skip above, or every subsequent same-compute
+            // trigger (cluster RUNNING/PENDING/TERMINATED churn, connection state
+            // events) would be skipped and the drift check would never retry
+            // until the compute actually changes, a setup completes, or a reload.
             if (current === undefined) {
                 return;
             }
+            // Resolution was definitive, so this descriptor is now a known
+            // quantity: record it, so a later no-op compute-change with the same
+            // identity (a runtime-state transition) is skipped.
+            this.lastComputeDescriptor = descriptor;
 
             const drifted = isDrifted(persisted, current);
             this.setDrifted(drifted);

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -25,10 +25,21 @@ export interface PythonSetupDriftDeps {
 }
 
 /**
+ * The config-view row's derived state, from the persisted setup record vs. the
+ * selected compute:
+ *  - `unset`   — no successful setup on record (show the initial CTA);
+ *  - `ready`   — a setup is on record and the compute still matches (or drift
+ *    can't be assessed — the fail-safe direction);
+ *  - `drifted` — a setup is on record but the selected compute no longer matches.
+ */
+export type PythonSetupDriftState = "unset" | "ready" | "drifted";
+
+/**
  * Watches for compute drift: when the selected compute's environment key no
  * longer matches the one recorded by the last successful setup, exposes a
- * `drifted` flag (and fires `onDidChangeState`) that the config-view row renders
- * as an "out of date -- re-run setup" affordance.
+ * {@link PythonSetupDriftState} (and fires `onDidChangeState`) that the
+ * config-view row renders — `drifted` becomes an "out of date -- re-run setup"
+ * affordance.
  *
  * The check is deliberately passive: it runs a silent CLI `--dry-run` (no
  * progress UI, no prompt, no error surface), is gated by `isVisible` and the
@@ -56,8 +67,18 @@ export class PythonSetupDriftManager implements Disposable {
         private readonly debounceMs: number = 500
     ) {}
 
-    get drifted(): boolean {
-        return this._drifted;
+    /**
+     * The row's derived state. Persisted state is read live so it reflects the
+     * current project across window reloads: with a setup on record the row
+     * stays `ready` (or `drifted` once a mismatch is detected) instead of
+     * reverting to the initial CTA; with none it is `unset`. The mismatch flag
+     * is only ever set while a setup is on record, so ordering here is moot.
+     */
+    get state(): PythonSetupDriftState {
+        if (this.deps.getPersistedEnvKey() === undefined) {
+            return "unset";
+        }
+        return this._drifted ? "drifted" : "ready";
     }
 
     /** Debounced entry point for triggers (compute change, open, setup done). */

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupDriftManager.ts
@@ -1,0 +1,150 @@
+import {CancellationTokenSource, Disposable, Event, EventEmitter} from "vscode";
+import {CancellationLike} from "../gateways/PythonSetupCliClient";
+import {PythonSetupDrift} from "../../telemetry/pythonSetupExtensions";
+import {PythonSetupDriftTrigger} from "../../telemetry/constants";
+import {isDrifted} from "../utils/driftDetection";
+
+export interface PythonSetupDriftDeps {
+    isVisible: () => Promise<boolean>;
+    getPersistedEnvKey: () => string | undefined;
+    resolveCurrentEnvKey: (
+        token: CancellationLike
+    ) => Promise<string | undefined>;
+    recordDrift: (report: PythonSetupDrift) => void;
+}
+
+/**
+ * Watches for compute drift: when the selected compute's environment key no
+ * longer matches the one recorded by the last successful setup, exposes a
+ * `drifted` flag (and fires `onDidChangeState`) that the config-view row renders
+ * as an "out of date -- re-run setup" affordance.
+ *
+ * The check is deliberately passive: it runs a silent CLI `--dry-run` (no
+ * progress UI, no prompt, no error surface), is gated by `isVisible` and the
+ * presence of a persisted state, is debounced against rapid compute switches,
+ * and treats any inability to resolve the current key as "unknown" -- never a
+ * false alarm.
+ */
+export class PythonSetupDriftManager implements Disposable {
+    private _drifted = false;
+    /** `${from}->${to}` of the last reported mismatch, to dedupe telemetry. */
+    private lastReported: string | undefined;
+    private generation = 0;
+    private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    private inFlight: CancellationTokenSource | undefined;
+
+    private readonly stateEmitter = new EventEmitter<void>();
+    readonly onDidChangeState: Event<void> = this.stateEmitter.event;
+
+    constructor(
+        private readonly deps: PythonSetupDriftDeps,
+        private readonly debounceMs: number = 500
+    ) {}
+
+    get drifted(): boolean {
+        return this._drifted;
+    }
+
+    /** Debounced entry point for triggers (compute change, open, setup done). */
+    check(trigger: PythonSetupDriftTrigger): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = undefined;
+            void this.evaluate(trigger);
+        }, this.debounceMs);
+    }
+
+    /**
+     * The awaitable core. Public so it is unit-testable directly; production
+     * code reaches it through the debounced {@link check}.
+     */
+    async evaluate(trigger: PythonSetupDriftTrigger): Promise<void> {
+        const myGeneration = ++this.generation;
+
+        // Cancel any dry-run still running for a superseded trigger.
+        this.inFlight?.cancel();
+        this.inFlight?.dispose();
+        const source = new CancellationTokenSource();
+        this.inFlight = source;
+
+        try {
+            const visible = await this.deps.isVisible();
+
+            // A newer trigger started while we awaited: drop this stale result
+            // so an out-of-order early return cannot retract a fresher flag.
+            if (myGeneration !== this.generation) {
+                return;
+            }
+            if (!visible) {
+                this.setDrifted(false);
+                return;
+            }
+            const persisted = this.deps.getPersistedEnvKey();
+            if (persisted === undefined) {
+                this.setDrifted(false);
+                return;
+            }
+            const current = await this.deps.resolveCurrentEnvKey(source.token);
+
+            // A newer trigger started while we awaited: drop this stale result.
+            if (myGeneration !== this.generation) {
+                return;
+            }
+            // Could not resolve the current key -> unknown. Leave the flag as-is
+            // rather than clearing (a transient network/auth failure must not
+            // silently retract a real drift warning).
+            if (current === undefined) {
+                return;
+            }
+
+            const drifted = isDrifted(persisted, current);
+            this.setDrifted(drifted);
+
+            if (drifted) {
+                const mismatch = `${persisted}->${current}`;
+                if (this.lastReported !== mismatch) {
+                    this.lastReported = mismatch;
+                    this.deps.recordDrift({
+                        trigger,
+                        fromEnvKey: persisted,
+                        toEnvKey: current,
+                    });
+                }
+            }
+        } catch {
+            // Any failure resolving the current state (e.g. isVisible or the
+            // dry-run rejecting) is treated as "unknown": stay silent and leave
+            // the drift flag untouched -- never surface UI, never a false alarm,
+            // never retract a real warning. Same fail-safe direction as the
+            // `current === undefined` branch above.
+        } finally {
+            if (this.inFlight === source) {
+                source.dispose();
+                this.inFlight = undefined;
+            }
+        }
+    }
+
+    private setDrifted(value: boolean): void {
+        if (!value) {
+            // Reset the telemetry dedupe latch so a recurrence is reported again.
+            this.lastReported = undefined;
+        }
+        if (value === this._drifted) {
+            return;
+        }
+        this._drifted = value;
+        this.stateEmitter.fire();
+    }
+
+    dispose(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+        }
+        this.inFlight?.cancel();
+        this.inFlight?.dispose();
+        this.stateEmitter.dispose();
+    }
+}

--- a/packages/databricks-vscode/src/python-setup/utils/driftDetection.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/driftDetection.test.ts
@@ -1,0 +1,27 @@
+import {expect} from "chai";
+import {isDrifted} from "./driftDetection";
+
+describe("isDrifted", () => {
+    it("is true when both keys are known and differ", () => {
+        expect(isDrifted("serverless/serverless-v4", "dbr/15.4.x-scala2.12")).to
+            .be.true;
+    });
+
+    it("is false when the keys are equal", () => {
+        expect(
+            isDrifted("serverless/serverless-v5", "serverless/serverless-v5")
+        ).to.be.false;
+    });
+
+    it("is false (fail-safe) when the current key is unknown", () => {
+        expect(isDrifted("serverless/serverless-v5", undefined)).to.be.false;
+    });
+
+    it("is false (fail-safe) when there is no persisted key", () => {
+        expect(isDrifted(undefined, "dbr/15.4.x-scala2.12")).to.be.false;
+    });
+
+    it("is false when both are unknown", () => {
+        expect(isDrifted(undefined, undefined)).to.be.false;
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/driftDetection.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/driftDetection.ts
@@ -1,0 +1,20 @@
+/**
+ * Decide whether the local environment has drifted from the selected compute.
+ *
+ * Drift means we know both the environment key we last provisioned against
+ * (`persistedEnvKey`, from `databricks.pythonSetup.setupState`) and the key the
+ * currently selected compute would resolve to (`currentEnvKey`), and they
+ * differ. Anything unknown — no prior setup, or a compute whose key could not be
+ * resolved — is deliberately NOT drift: absence of a clear signal must never
+ * raise a false alarm (see the design's fail-safe rule).
+ */
+export function isDrifted(
+    persistedEnvKey: string | undefined,
+    currentEnvKey: string | undefined
+): boolean {
+    return (
+        persistedEnvKey !== undefined &&
+        currentEnvKey !== undefined &&
+        persistedEnvKey !== currentEnvKey
+    );
+}

--- a/packages/databricks-vscode/src/python-setup/utils/driftDetection.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/driftDetection.ts
@@ -1,12 +1,7 @@
 /**
- * Decide whether the local environment has drifted from the selected compute.
- *
- * Drift means we know both the environment key we last provisioned against
- * (`persistedEnvKey`, from `databricks.pythonSetup.setupState`) and the key the
- * currently selected compute would resolve to (`currentEnvKey`), and they
- * differ. Anything unknown — no prior setup, or a compute whose key could not be
- * resolved — is deliberately NOT drift: absence of a clear signal must never
- * raise a false alarm (see the design's fail-safe rule).
+ * Whether the local environment has drifted: both the last-provisioned key
+ * (`persistedEnvKey`) and the selected compute's key (`currentEnvKey`) are known
+ * and differ. Anything unknown is deliberately NOT drift — never a false alarm.
  */
 export function isDrifted(
     persistedEnvKey: string | undefined,

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
@@ -75,6 +75,25 @@ describe("buildSetupLocalArgs", () => {
         });
         expect(args.slice(-2)).to.deep.equal(["--output", "json"]);
     });
+
+    it("adds --dry-run when the invocation is a dry run", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "serverless", version: "5"},
+            dryRun: true,
+        });
+        expect(args).to.include("--dry-run");
+        // Still requests machine-readable output last.
+        expect(args.slice(-2)).to.deep.equal(["--output", "json"]);
+    });
+
+    it("omits --dry-run by default", () => {
+        const args = buildSetupLocalArgs({
+            mode: "default",
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.not.include("--dry-run");
+    });
 });
 
 describe("resolveCliPath", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
@@ -13,6 +13,13 @@ import {PythonSetupMode} from "../models/PythonSetupResult";
  */
 export interface SetupLocalInvocation {
     mode: PythonSetupMode;
+    /**
+     * When true, pass `--dry-run`: the CLI resolves compute and reports the
+     * environment key without provisioning or writing to disk. Used by drift
+     * detection to read the authoritative `compute.envKey` for the selected
+     * compute.
+     */
+    dryRun?: boolean;
     compute:
         | {kind: "cluster"; clusterId: string}
         | {kind: "serverless"; version: string};
@@ -40,6 +47,9 @@ export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
 
     if (inv.mode === "constraints-only") {
         args.push("--constraints-only");
+    }
+    if (inv.dryRun) {
+        args.push("--dry-run");
     }
     if (inv.constraintSourceUrl) {
         args.push("--constraint-source-url", inv.constraintSourceUrl);

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -27,6 +27,7 @@ export enum Events {
     PYTHON_ENV_SETUP_DETECTED = "python_env.setup.detected",
     PYTHON_ENV_SETUP_ATTEMPT = "python_env.setup.attempt",
     PYTHON_ENV_SETUP_RESULT = "python_env.setup.result",
+    PYTHON_ENV_DRIFT = "python_env.drift",
     AITOOLS_INSTALL = "aitoolsInstall",
     AITOOLS_UPDATE = "aitoolsUpdate",
     AITOOLS_UNINSTALL = "aitoolsUninstall",
@@ -152,6 +153,12 @@ export type PythonSetupFailurePhase =
     | PythonSetupPhaseName
     | "adopt"
     | "persist";
+
+/** How a drift check was triggered. */
+export type PythonSetupDriftTrigger =
+    | "computeChange"
+    | "workspaceOpen"
+    | "setupCompleted";
 
 /** Documentation about all of the properties and metrics of the event. */
 type EventDescription<T> = {[K in keyof T]?: {comment?: string}};
@@ -553,6 +560,31 @@ export class EventTypes {
         // also the latency the user actually experiences: it includes process
         // spawn and interpreter adoption.
         ...getDurationProperty(),
+    };
+    [Events.PYTHON_ENV_DRIFT]: EventType<{
+        trigger: PythonSetupDriftTrigger;
+        fromEnvKey: string;
+        toEnvKey: string;
+    }> = {
+        comment:
+            "Emitted when the selected compute's environment key no longer matches the one the " +
+            "local .venv was provisioned against (from databricks.pythonSetup.setupState). Reported " +
+            "once per newly-detected distinct mismatch, not on every trigger. Categorical data only.",
+        trigger: {
+            comment:
+                "What prompted the check: computeChange | workspaceOpen | setupCompleted",
+        },
+        fromEnvKey: {
+            comment:
+                'The recorded environment key (e.g. "serverless/serverless-v4", ' +
+                '"dbr/15.4.x-scala2.12"). Constrained to those shapes before emission; anything ' +
+                'else becomes "other". Never a cluster id or name',
+        },
+        toEnvKey: {
+            comment:
+                "The environment key the currently selected compute resolves to, same closed " +
+                'vocabulary as fromEnvKey (else "other")',
+        },
     };
 }
 

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
@@ -402,4 +402,35 @@ describe(__filename, () => {
         expect(() => reportResult({outcome: "ok"})).to.not.throw();
         expect(telemetry.isTelemetryEnabled).to.equal(false);
     });
+
+    describe("recordPythonSetupDrift", () => {
+        it("emits python_env.drift with the trigger and sanitized keys", () => {
+            const {telemetry, events} = makeTelemetry();
+            telemetry.recordPythonSetupDrift({
+                trigger: "computeChange",
+                fromEnvKey: "serverless/serverless-v4",
+                toEnvKey: "dbr/15.4.x-scala2.12",
+            });
+            const drift = events.find((e) => e.name === "python_env.drift");
+            expect(drift, "a drift event was recorded").to.not.be.undefined;
+            expect(drift!.props["event.trigger"]).to.equal("computeChange");
+            expect(drift!.props["event.fromEnvKey"]).to.equal(
+                "serverless/serverless-v4"
+            );
+            expect(drift!.props["event.toEnvKey"]).to.equal(
+                "dbr/15.4.x-scala2.12"
+            );
+        });
+
+        it("collapses an unrecognized env key to 'other'", () => {
+            const {telemetry, events} = makeTelemetry();
+            telemetry.recordPythonSetupDrift({
+                trigger: "workspaceOpen",
+                fromEnvKey: "serverless/serverless-v5",
+                toEnvKey: "0710-secret-cluster-id",
+            });
+            const drift = events.find((e) => e.name === "python_env.drift")!;
+            expect(drift.props["event.toEnvKey"]).to.equal("other");
+        });
+    });
 });

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -286,13 +286,10 @@ Telemetry.prototype.recordPythonSetupDrift = function (
 ): void {
     this.recordEvent(Events.PYTHON_ENV_DRIFT, {
         trigger: report.trigger,
-        // Both keys are copied from CLI/persisted JSON; constrain them to the
-        // closed envKey vocabulary so an unexpected runtime string (or a cluster
-        // id that slipped in) collapses to "other" rather than leaking
-        // high-cardinality / identifying content.
-        // categoricalEnvKey only returns undefined for an undefined input; both
-        // fields are required non-null strings, so the results are always
-        // defined (asserted here to satisfy the string-typed schema).
+        // Constrain both keys to the closed envKey vocabulary so an unexpected
+        // string can't leak high-cardinality / identifying content. The `!` is
+        // safe: categoricalEnvKey only returns undefined for undefined input, and
+        // both fields are required strings.
         fromEnvKey: categoricalEnvKey(report.fromEnvKey)!,
         toEnvKey: categoricalEnvKey(report.toEnvKey)!,
     });

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -2,6 +2,7 @@ import {Events, Telemetry} from ".";
 import {
     ComputeType,
     PrimaryManager,
+    PythonSetupDriftTrigger,
     PythonSetupErrorCode,
     PythonSetupFailurePhase,
     PythonSetupMode,
@@ -33,6 +34,15 @@ export interface PythonSetupAttempt {
      * Same event, one enum dimension.
      */
     trigger: PythonSetupRunTrigger;
+}
+
+/** A detected drift, reduced to the categorical fields we report. */
+export interface PythonSetupDrift {
+    trigger: PythonSetupDriftTrigger;
+    /** The recorded environment key the .venv was provisioned against. */
+    fromEnvKey: string;
+    /** The environment key the currently selected compute resolves to. */
+    toEnvKey: string;
 }
 
 /** How a setup run ended, reduced to the categorical fields we report. */
@@ -181,6 +191,13 @@ declare module "." {
          * legacy checklist and the uv-native entry mutually exclusively.
          */
         recordPythonSetupNoCompute(): void;
+
+        /**
+         * Record a detected compute drift. Emitted once per newly-detected
+         * distinct mismatch by {@link PythonSetupDriftManager}; both keys are
+         * constrained to the categorical envKey vocabulary before emission.
+         */
+        recordPythonSetupDrift(report: PythonSetupDrift): void;
     }
 }
 
@@ -262,4 +279,21 @@ Telemetry.prototype.recordPythonSetupNoCompute = function () {
     // drag the setup-time percentiles down. Recorded directly rather than via
     // start(), which always stamps an elapsed time.
     this.recordEvent(Events.PYTHON_ENV_SETUP_RESULT, {outcome: "no_compute"});
+};
+
+Telemetry.prototype.recordPythonSetupDrift = function (
+    report: PythonSetupDrift
+): void {
+    this.recordEvent(Events.PYTHON_ENV_DRIFT, {
+        trigger: report.trigger,
+        // Both keys are copied from CLI/persisted JSON; constrain them to the
+        // closed envKey vocabulary so an unexpected runtime string (or a cluster
+        // id that slipped in) collapses to "other" rather than leaking
+        // high-cardinality / identifying content.
+        // categoricalEnvKey only returns undefined for an undefined input; both
+        // fields are required non-null strings, so the results are always
+        // defined (asserted here to satisfy the string-typed schema).
+        fromEnvKey: categoricalEnvKey(report.fromEnvKey)!,
+        toEnvKey: categoricalEnvKey(report.toEnvKey)!,
+    });
 };

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
@@ -17,12 +17,12 @@ const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
 function stubPythonSetup(opts: {
     visible: boolean;
     ready: boolean;
-    drifted?: boolean;
+    driftState?: "unset" | "ready" | "drifted";
 }): PythonSetupEntry {
     return {
         isVisible: async () => opts.visible,
         ready: opts.ready,
-        drifted: opts.drifted ?? false,
+        driftState: opts.driftState ?? "unset",
         // Minimal Event: registering a listener returns a no-op Disposable.
         onDidChangeState: () => ({dispose() {}}),
     };

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
@@ -17,10 +17,12 @@ const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
 function stubPythonSetup(opts: {
     visible: boolean;
     ready: boolean;
+    drifted?: boolean;
 }): PythonSetupEntry {
     return {
         isVisible: async () => opts.visible,
         ready: opts.ready,
+        drifted: opts.drifted ?? false,
         // Minimal Event: registering a listener returns a no-op Disposable.
         onDidChangeState: () => ({dispose() {}}),
     };

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -44,7 +44,10 @@ export class EnvironmentComponent extends BaseComponent {
         const pythonSetup = this.pythonSetup;
         if (pythonSetup && (await pythonSetup.isVisible())) {
             return buildPythonSetupEntry(
-                {ready: pythonSetup.ready, drifted: pythonSetup.drifted},
+                {
+                    ready: pythonSetup.ready,
+                    driftState: pythonSetup.driftState,
+                },
                 PYTHON_SETUP_COMMAND,
                 PYTHON_SETUP_RERUN_COMMAND
             );

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -8,6 +8,7 @@ import {buildPythonSetupEntry, PythonSetupEntry} from "./pythonSetupEntry";
 
 const ENVIRONMENT_COMPONENT_ID = "ENVIRONMENT";
 const PYTHON_SETUP_COMMAND = "databricks.environment.setupPythonEnv";
+const PYTHON_SETUP_RERUN_COMMAND = "databricks.environment.rerunPythonEnv";
 const getItemContext = (key: string, available: boolean) =>
     `databricks.environment.${key}.${available ? "success" : "error"}`;
 
@@ -43,8 +44,9 @@ export class EnvironmentComponent extends BaseComponent {
         const pythonSetup = this.pythonSetup;
         if (pythonSetup && (await pythonSetup.isVisible())) {
             return buildPythonSetupEntry(
-                {ready: pythonSetup.ready},
-                PYTHON_SETUP_COMMAND
+                {ready: pythonSetup.ready, drifted: pythonSetup.drifted},
+                PYTHON_SETUP_COMMAND,
+                PYTHON_SETUP_RERUN_COMMAND
             );
         }
         const environmentState = await this.featureManager.isEnabled(

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
@@ -54,7 +54,7 @@ describe("buildPythonSetupEntry", () => {
         );
         expect((item.iconPath as ThemeIcon).id).to.equal("warning");
         expect(item.command?.command).to.equal(RERUN);
-        expect(String(item.label)).to.match(/drifted/i);
+        expect(String(item.label)).to.match(/out of sync/i);
     });
 
     it("drift takes precedence over the ready session flag", () => {

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
@@ -1,35 +1,108 @@
 import {expect} from "chai";
-import {ThemeColor, ThemeIcon} from "vscode";
-import {buildPythonSetupEntry} from "./pythonSetupEntry";
+import {EventEmitter, ThemeColor, ThemeIcon} from "vscode";
+import {
+    buildPythonSetupEntry,
+    composePythonSetupEntry,
+} from "./pythonSetupEntry";
 
 describe("buildPythonSetupEntry", () => {
     const COMMAND = "databricks.environment.setupPythonEnv";
+    const RERUN = "databricks.environment.rerunPythonEnv";
 
     it("renders a run CTA when setup is not yet ready", () => {
-        const [item] = buildPythonSetupEntry({ready: false}, COMMAND);
-
+        const [item] = buildPythonSetupEntry(
+            {ready: false, drifted: false},
+            COMMAND,
+            RERUN
+        );
         expect(item.command?.command).to.equal(COMMAND);
         expect((item.iconPath as ThemeIcon).id).to.equal("rocket");
-        // Not-done reads as an error (red), consistent with the sibling
-        // checklist entries, rather than the green debug-start color.
         expect((item.iconPath as ThemeIcon).color).to.deep.equal(
             new ThemeColor("errorForeground")
         );
-        // The label invites the user to run setup.
         expect(String(item.label)).to.match(/set up/i);
     });
 
     it("renders a ready status line (check icon) once setup succeeded", () => {
-        const [item] = buildPythonSetupEntry({ready: true}, COMMAND);
-
+        const [item] = buildPythonSetupEntry(
+            {ready: true, drifted: false},
+            COMMAND,
+            RERUN
+        );
         expect((item.iconPath as ThemeIcon).id).to.equal("check");
-        // Still actionable (re-run), but presented as done.
         expect(item.command?.command).to.equal(COMMAND);
     });
 
-    it("returns exactly one entry (mutually exclusive with the checklist)", () => {
-        expect(buildPythonSetupEntry({ready: false}, COMMAND)).to.have.length(
-            1
+    it("renders an out-of-date state that re-runs setup when drifted", () => {
+        const [item] = buildPythonSetupEntry(
+            {ready: true, drifted: true},
+            COMMAND,
+            RERUN
         );
+        expect((item.iconPath as ThemeIcon).id).to.equal("warning");
+        expect(item.command?.command).to.equal(RERUN);
+        expect(String(item.label)).to.match(/out of date/i);
+    });
+
+    it("drift takes precedence even when not ready this session", () => {
+        const [item] = buildPythonSetupEntry(
+            {ready: false, drifted: true},
+            COMMAND,
+            RERUN
+        );
+        expect((item.iconPath as ThemeIcon).id).to.equal("warning");
+        expect(item.command?.command).to.equal(RERUN);
+    });
+
+    it("returns exactly one entry (mutually exclusive with the checklist)", () => {
+        expect(
+            buildPythonSetupEntry(
+                {ready: false, drifted: false},
+                COMMAND,
+                RERUN
+            )
+        ).to.have.length(1);
+    });
+});
+
+describe("composePythonSetupEntry", () => {
+    function fakeSetup() {
+        const e = new EventEmitter<void>();
+        return {
+            _e: e,
+            ready: false,
+            isVisible: async () => true,
+            onDidChangeState: e.event,
+        };
+    }
+    function fakeDrift() {
+        const e = new EventEmitter<void>();
+        return {_e: e, drifted: false, onDidChangeState: e.event};
+    }
+
+    it("forwards ready, drifted and isVisible from the sources", async () => {
+        const setup = fakeSetup();
+        const drift = fakeDrift();
+        const entry = composePythonSetupEntry(setup, drift);
+
+        setup.ready = true;
+        drift.drifted = true;
+        expect(entry.ready).to.be.true;
+        expect(entry.drifted).to.be.true;
+        expect(await entry.isVisible()).to.be.true;
+        entry.dispose();
+    });
+
+    it("fires onDidChangeState when either source changes", () => {
+        const setup = fakeSetup();
+        const drift = fakeDrift();
+        const entry = composePythonSetupEntry(setup, drift);
+        let fired = 0;
+        entry.onDidChangeState(() => fired++);
+
+        setup._e.fire();
+        drift._e.fire();
+        expect(fired).to.equal(2);
+        entry.dispose();
     });
 });

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
@@ -41,7 +41,7 @@ describe("buildPythonSetupEntry", () => {
         );
         expect((item.iconPath as ThemeIcon).id).to.equal("warning");
         expect(item.command?.command).to.equal(RERUN);
-        expect(String(item.label)).to.match(/out of date/i);
+        expect(String(item.label)).to.match(/drifted/i);
     });
 
     it("drift takes precedence even when not ready this session", () => {
@@ -52,6 +52,23 @@ describe("buildPythonSetupEntry", () => {
         );
         expect((item.iconPath as ThemeIcon).id).to.equal("warning");
         expect(item.command?.command).to.equal(RERUN);
+    });
+
+    it("gives the drifted row a distinct id so VS Code rebinds its command", () => {
+        // The drifted state points at a different command than ready/set-up; if
+        // it reused the same tree-item id, VS Code would not reliably rebind the
+        // command on refresh and the re-run click would be inert.
+        const [drifted] = buildPythonSetupEntry(
+            {ready: true, drifted: true},
+            COMMAND,
+            RERUN
+        );
+        const [ready] = buildPythonSetupEntry(
+            {ready: true, drifted: false},
+            COMMAND,
+            RERUN
+        );
+        expect(drifted.id).to.not.equal(ready.id);
     });
 
     it("returns exactly one entry (mutually exclusive with the checklist)", () => {

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.test.ts
@@ -9,9 +9,9 @@ describe("buildPythonSetupEntry", () => {
     const COMMAND = "databricks.environment.setupPythonEnv";
     const RERUN = "databricks.environment.rerunPythonEnv";
 
-    it("renders a run CTA when setup is not yet ready", () => {
+    it("renders a run CTA when setup has never completed", () => {
         const [item] = buildPythonSetupEntry(
-            {ready: false, drifted: false},
+            {ready: false, driftState: "unset"},
             COMMAND,
             RERUN
         );
@@ -25,7 +25,7 @@ describe("buildPythonSetupEntry", () => {
 
     it("renders a ready status line (check icon) once setup succeeded", () => {
         const [item] = buildPythonSetupEntry(
-            {ready: true, drifted: false},
+            {ready: true, driftState: "unset"},
             COMMAND,
             RERUN
         );
@@ -33,9 +33,22 @@ describe("buildPythonSetupEntry", () => {
         expect(item.command?.command).to.equal(COMMAND);
     });
 
+    it("stays ready across a reload when a prior setup is persisted", () => {
+        // The session `ready` flag is false after a reload, but a persisted
+        // `ready` drift state (a setup on record that still matches) must keep the
+        // row on the "ready" status line instead of reverting to the rocket CTA.
+        const [item] = buildPythonSetupEntry(
+            {ready: false, driftState: "ready"},
+            COMMAND,
+            RERUN
+        );
+        expect((item.iconPath as ThemeIcon).id).to.equal("check");
+        expect(String(item.label)).to.match(/ready/i);
+    });
+
     it("renders an out-of-date state that re-runs setup when drifted", () => {
         const [item] = buildPythonSetupEntry(
-            {ready: true, drifted: true},
+            {ready: true, driftState: "drifted"},
             COMMAND,
             RERUN
         );
@@ -44,9 +57,9 @@ describe("buildPythonSetupEntry", () => {
         expect(String(item.label)).to.match(/drifted/i);
     });
 
-    it("drift takes precedence even when not ready this session", () => {
+    it("drift takes precedence over the ready session flag", () => {
         const [item] = buildPythonSetupEntry(
-            {ready: false, drifted: true},
+            {ready: true, driftState: "drifted"},
             COMMAND,
             RERUN
         );
@@ -59,12 +72,12 @@ describe("buildPythonSetupEntry", () => {
         // it reused the same tree-item id, VS Code would not reliably rebind the
         // command on refresh and the re-run click would be inert.
         const [drifted] = buildPythonSetupEntry(
-            {ready: true, drifted: true},
+            {ready: true, driftState: "drifted"},
             COMMAND,
             RERUN
         );
         const [ready] = buildPythonSetupEntry(
-            {ready: true, drifted: false},
+            {ready: true, driftState: "ready"},
             COMMAND,
             RERUN
         );
@@ -74,7 +87,7 @@ describe("buildPythonSetupEntry", () => {
     it("returns exactly one entry (mutually exclusive with the checklist)", () => {
         expect(
             buildPythonSetupEntry(
-                {ready: false, drifted: false},
+                {ready: false, driftState: "unset"},
                 COMMAND,
                 RERUN
             )
@@ -94,18 +107,22 @@ describe("composePythonSetupEntry", () => {
     }
     function fakeDrift() {
         const e = new EventEmitter<void>();
-        return {_e: e, drifted: false, onDidChangeState: e.event};
+        return {
+            _e: e,
+            state: "unset" as "unset" | "ready" | "drifted",
+            onDidChangeState: e.event,
+        };
     }
 
-    it("forwards ready, drifted and isVisible from the sources", async () => {
+    it("forwards ready, driftState and isVisible from the sources", async () => {
         const setup = fakeSetup();
         const drift = fakeDrift();
         const entry = composePythonSetupEntry(setup, drift);
 
         setup.ready = true;
-        drift.drifted = true;
+        drift.state = "drifted";
         expect(entry.ready).to.be.true;
-        expect(entry.drifted).to.be.true;
+        expect(entry.driftState).to.equal("drifted");
         expect(await entry.isVisible()).to.be.true;
         entry.dispose();
     });

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
@@ -1,4 +1,5 @@
 import {Disposable, Event, EventEmitter, ThemeColor, ThemeIcon} from "vscode";
+import type {PythonSetupDriftState} from "../../python-setup/controllers/PythonSetupDriftManager";
 import {ConfigurationTreeItem} from "./types";
 
 const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
@@ -24,11 +25,13 @@ export interface PythonSetupEntry {
     /** True once a setup has completed successfully this session. */
     readonly ready: boolean;
     /**
-     * True when the selected compute no longer matches the recorded setup state
-     * (see {@link PythonSetupDriftManager}); renders the "out of date" state.
+     * The persisted setup/drift state (see {@link PythonSetupDriftState}): a
+     * single signal derived from the recorded setup vs. the selected compute. It
+     * survives a window reload — `ready`/`drifted` mean a prior setup is on
+     * record — so the row does not revert to the initial CTA across sessions.
      */
-    readonly drifted: boolean;
-    /** Fires when {@link ready} or {@link drifted} changes, so the view refreshes. */
+    readonly driftState: PythonSetupDriftState;
+    /** Fires when readiness or drift state changes, so the view refreshes. */
     readonly onDidChangeState: Event<void>;
 }
 
@@ -36,18 +39,20 @@ export interface PythonSetupEntry {
  * Build the single Python Environment child row for the uv-native setup.
  *
  * Three states, in precedence order:
- *   - drifted  -> an "out of date" warning that re-runs setup (rerunCommandId);
- *   - ready    -> a done status line (check) that can still be re-run;
- *   - neither  -> a run call-to-action (rocket).
- * Drift wins over ready: a stale environment is the more urgent thing to show,
- * and its action (re-run) is what resolves it.
+ *   - drifted      -> an "out of date" warning that re-runs setup (rerunCommandId);
+ *   - done         -> a done status line (check) that can still be re-run;
+ *   - neither      -> a run call-to-action (rocket).
+ * Drift wins: a stale environment is the more urgent thing to show, and its
+ * action (re-run) is what resolves it. "Done" is the session `ready` flag OR a
+ * persisted `driftState` of `ready` (a prior setup on record that still matches),
+ * so the row stays "ready" across a window reload rather than reverting to the CTA.
  */
 export function buildPythonSetupEntry(
-    state: {ready: boolean; drifted: boolean},
+    state: {ready: boolean; driftState: PythonSetupDriftState},
     commandId: string,
     rerunCommandId: string
 ): ConfigurationTreeItem[] {
-    if (state.drifted) {
+    if (state.driftState === "drifted") {
         return [
             {
                 id: PYTHON_SETUP_DRIFTED_ENTRY_ID,
@@ -67,16 +72,17 @@ export function buildPythonSetupEntry(
             },
         ];
     }
+    const done = state.ready || state.driftState === "ready";
     return [
         {
             id: PYTHON_SETUP_ENTRY_ID,
-            label: state.ready
+            label: done
                 ? "Python environment ready"
                 : "Set up Python environment",
             contextValue: `databricks.environment.pythonSetup.${
-                state.ready ? "success" : "error"
+                done ? "success" : "error"
             }`,
-            iconPath: state.ready
+            iconPath: done
                 ? new ThemeIcon("check")
                 : new ThemeIcon("rocket", new ThemeColor("errorForeground")),
             command: {
@@ -88,8 +94,8 @@ export function buildPythonSetupEntry(
 }
 
 /**
- * Combine the setup controller's `ready` state and the drift manager's
- * `drifted` state into the single {@link PythonSetupEntry} the config view
+ * Combine the setup controller's session `ready` flag with the drift manager's
+ * derived `state` into the single {@link PythonSetupEntry} the config view
  * consumes, merging both change events so a change in either refreshes the row.
  * Returns a Disposable that tears down the merged emitter and its subscriptions.
  */
@@ -100,7 +106,7 @@ export function composePythonSetupEntry(
         readonly onDidChangeState: Event<void>;
     },
     drift: {
-        readonly drifted: boolean;
+        readonly state: PythonSetupDriftState;
         readonly onDidChangeState: Event<void>;
     }
 ): PythonSetupEntry & Disposable {
@@ -114,8 +120,8 @@ export function composePythonSetupEntry(
         get ready() {
             return setup.ready;
         },
-        get drifted() {
-            return drift.drifted;
+        get driftState() {
+            return drift.state;
         },
         onDidChangeState: emitter.event,
         dispose() {

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
@@ -3,21 +3,16 @@ import type {PythonSetupDriftState} from "../../python-setup/controllers/PythonS
 import {ConfigurationTreeItem} from "./types";
 
 const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
-// The drifted row deliberately uses a DISTINCT tree-item id from the ready/set-up
-// row. VS Code does not reliably rebind a tree node's `command` when an item
-// keeps the same `id` but swaps to a different command across a refresh: the
-// label/icon update but clicks still fire (or fail to fire) the old binding. The
-// ready and set-up states share one command (setupPythonEnv), but the drifted
-// state points at a different command (rerunPythonEnv, for its own telemetry), so
-// it must be a separate node — otherwise the "re-run" click is silently inert.
+// Distinct tree-item id: VS Code doesn't reliably rebind a node's `command` when
+// the id stays the same but the command changes across a refresh. The drifted
+// row points at a different command (rerunPythonEnv) than the ready/set-up row
+// (setupPythonEnv), so it must be a separate node or the re-run click is inert.
 const PYTHON_SETUP_DRIFTED_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP_DRIFTED";
 
 /**
- * The slice of the setup orchestrator the config view needs to render its
- * entry. Kept as a narrow interface (not the concrete
- * `PythonSetupEnvironmentSetup`) so {@link EnvironmentComponent} carries no
- * dependency on the controller/gateway layers and the entry builder stays
- * unit-testable.
+ * The slice of the setup orchestrator the config view needs, as a narrow
+ * interface so {@link EnvironmentComponent} carries no dependency on the
+ * controller/gateway layers and the entry builder stays unit-testable.
  */
 export interface PythonSetupEntry {
     /** Whether the uv-native entry should be shown instead of the checklist. */
@@ -25,10 +20,8 @@ export interface PythonSetupEntry {
     /** True once a setup has completed successfully this session. */
     readonly ready: boolean;
     /**
-     * The persisted setup/drift state (see {@link PythonSetupDriftState}): a
-     * single signal derived from the recorded setup vs. the selected compute. It
-     * survives a window reload — `ready`/`drifted` mean a prior setup is on
-     * record — so the row does not revert to the initial CTA across sessions.
+     * Persisted setup/drift state (see {@link PythonSetupDriftState}). Survives a
+     * window reload, so the row does not revert to the initial CTA across sessions.
      */
     readonly driftState: PythonSetupDriftState;
     /** Fires when readiness or drift state changes, so the view refreshes. */
@@ -36,16 +29,10 @@ export interface PythonSetupEntry {
 }
 
 /**
- * Build the single Python Environment child row for the uv-native setup.
- *
- * Three states, in precedence order:
- *   - drifted      -> an "out of date" warning that re-runs setup (rerunCommandId);
- *   - done         -> a done status line (check) that can still be re-run;
- *   - neither      -> a run call-to-action (rocket).
- * Drift wins: a stale environment is the more urgent thing to show, and its
- * action (re-run) is what resolves it. "Done" is the session `ready` flag OR a
- * persisted `driftState` of `ready` (a prior setup on record that still matches),
- * so the row stays "ready" across a window reload rather than reverting to the CTA.
+ * Build the single Python Environment child row for the uv-native setup, in
+ * precedence order: drifted -> an out-of-sync warning that re-runs setup;
+ * done -> a check that can still be re-run; neither -> a run CTA (rocket).
+ * "Done" is the session `ready` flag OR a persisted `driftState` of `ready`.
  */
 export function buildPythonSetupEntry(
     state: {ready: boolean; driftState: PythonSetupDriftState},
@@ -56,7 +43,7 @@ export function buildPythonSetupEntry(
         return [
             {
                 id: PYTHON_SETUP_DRIFTED_ENTRY_ID,
-                label: "Python environment is drifted",
+                label: "Python environment is out of sync",
                 tooltip:
                     "The selected compute no longer matches your Python " +
                     "environment. Re-run setup to align it.",
@@ -95,9 +82,9 @@ export function buildPythonSetupEntry(
 
 /**
  * Combine the setup controller's session `ready` flag with the drift manager's
- * derived `state` into the single {@link PythonSetupEntry} the config view
- * consumes, merging both change events so a change in either refreshes the row.
- * Returns a Disposable that tears down the merged emitter and its subscriptions.
+ * `state` into the single {@link PythonSetupEntry} the config view consumes,
+ * merging both change events. The returned Disposable tears down the emitter
+ * and its subscriptions.
  */
 export function composePythonSetupEntry(
     setup: {

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
@@ -2,6 +2,14 @@ import {Disposable, Event, EventEmitter, ThemeColor, ThemeIcon} from "vscode";
 import {ConfigurationTreeItem} from "./types";
 
 const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
+// The drifted row deliberately uses a DISTINCT tree-item id from the ready/set-up
+// row. VS Code does not reliably rebind a tree node's `command` when an item
+// keeps the same `id` but swaps to a different command across a refresh: the
+// label/icon update but clicks still fire (or fail to fire) the old binding. The
+// ready and set-up states share one command (setupPythonEnv), but the drifted
+// state points at a different command (rerunPythonEnv, for its own telemetry), so
+// it must be a separate node — otherwise the "re-run" click is silently inert.
+const PYTHON_SETUP_DRIFTED_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP_DRIFTED";
 
 /**
  * The slice of the setup orchestrator the config view needs to render its
@@ -42,8 +50,8 @@ export function buildPythonSetupEntry(
     if (state.drifted) {
         return [
             {
-                id: PYTHON_SETUP_ENTRY_ID,
-                label: "Python environment out of date",
+                id: PYTHON_SETUP_DRIFTED_ENTRY_ID,
+                label: "Python environment is drifted",
                 tooltip:
                     "The selected compute no longer matches your Python " +
                     "environment. Re-run setup to align it.",

--- a/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/pythonSetupEntry.ts
@@ -1,4 +1,4 @@
-import {Event, ThemeColor, ThemeIcon} from "vscode";
+import {Disposable, Event, EventEmitter, ThemeColor, ThemeIcon} from "vscode";
 import {ConfigurationTreeItem} from "./types";
 
 const PYTHON_SETUP_ENTRY_ID = "ENVIRONMENT_PYTHON_SETUP";
@@ -15,23 +15,50 @@ export interface PythonSetupEntry {
     isVisible(): Promise<boolean>;
     /** True once a setup has completed successfully this session. */
     readonly ready: boolean;
-    /** Fires when {@link ready} changes, so the view can refresh. */
+    /**
+     * True when the selected compute no longer matches the recorded setup state
+     * (see {@link PythonSetupDriftManager}); renders the "out of date" state.
+     */
+    readonly drifted: boolean;
+    /** Fires when {@link ready} or {@link drifted} changes, so the view refreshes. */
     readonly onDidChangeState: Event<void>;
 }
 
 /**
  * Build the single Python Environment child row for the uv-native setup.
  *
- * Pure over its inputs so the label/icon/command wiring is unit-testable. Not
- * ready → a run call-to-action (rocket); ready → a done status line (check).
- * Either way the row runs `commandId`, so a ready environment can be re-run.
- * Returns a one-element array to slot directly into `getChildren`, underscoring
- * that this entry is mutually exclusive with the legacy checklist.
+ * Three states, in precedence order:
+ *   - drifted  -> an "out of date" warning that re-runs setup (rerunCommandId);
+ *   - ready    -> a done status line (check) that can still be re-run;
+ *   - neither  -> a run call-to-action (rocket).
+ * Drift wins over ready: a stale environment is the more urgent thing to show,
+ * and its action (re-run) is what resolves it.
  */
 export function buildPythonSetupEntry(
-    state: {ready: boolean},
-    commandId: string
+    state: {ready: boolean; drifted: boolean},
+    commandId: string,
+    rerunCommandId: string
 ): ConfigurationTreeItem[] {
+    if (state.drifted) {
+        return [
+            {
+                id: PYTHON_SETUP_ENTRY_ID,
+                label: "Python environment out of date",
+                tooltip:
+                    "The selected compute no longer matches your Python " +
+                    "environment. Re-run setup to align it.",
+                contextValue: "databricks.environment.pythonSetup.drifted",
+                iconPath: new ThemeIcon(
+                    "warning",
+                    new ThemeColor("errorForeground")
+                ),
+                command: {
+                    title: "Re-run Python setup",
+                    command: rerunCommandId,
+                },
+            },
+        ];
+    }
     return [
         {
             id: PYTHON_SETUP_ENTRY_ID,
@@ -50,4 +77,42 @@ export function buildPythonSetupEntry(
             },
         },
     ];
+}
+
+/**
+ * Combine the setup controller's `ready` state and the drift manager's
+ * `drifted` state into the single {@link PythonSetupEntry} the config view
+ * consumes, merging both change events so a change in either refreshes the row.
+ * Returns a Disposable that tears down the merged emitter and its subscriptions.
+ */
+export function composePythonSetupEntry(
+    setup: {
+        isVisible(): Promise<boolean>;
+        readonly ready: boolean;
+        readonly onDidChangeState: Event<void>;
+    },
+    drift: {
+        readonly drifted: boolean;
+        readonly onDidChangeState: Event<void>;
+    }
+): PythonSetupEntry & Disposable {
+    const emitter = new EventEmitter<void>();
+    const subs = [
+        setup.onDidChangeState(() => emitter.fire()),
+        drift.onDidChangeState(() => emitter.fire()),
+    ];
+    return {
+        isVisible: () => setup.isVisible(),
+        get ready() {
+            return setup.ready;
+        },
+        get drifted() {
+            return drift.drifted;
+        },
+        onDidChangeState: emitter.event,
+        dispose() {
+            subs.forEach((s) => s.dispose());
+            emitter.dispose();
+        },
+    };
 }


### PR DESCRIPTION
## Changes

Closes the loop on the persisted Python-setup state, which the extension has been writing (`databricks.pythonSetup.setupState` = `{envKey, pythonVersion, timestamp}`) but never reading. When a user switches compute, the local `.venv` can silently remain provisioned against the *previous* compute's environment — a mismatch that today only surfaces much later as an opaque UDF-pickling failure at runtime.

This adds passive compute-drift detection:

- When the currently selected compute would resolve to a **different environment key** than the one recorded on disk, the "Python environment" row in the Configuration view flips to a passive **"Python environment is out of sync"** state (warning icon) wired to a re-run action. No toast, no nag — the row *is* the affordance, and drift takes precedence over the ready/set-up states.
- The current compute's env key is obtained **authoritatively** via a silent CLI `--dry-run` (no disk mutation, no UI), gated behind the feature + a prior successful setup, debounced against rapid compute switches, cancellable, and fail-safe: a transient failure to resolve the key (network/auth/parse error) leaves the flag unchanged and never raises a false alarm.
- **Triggers:** compute-target change, serverless-version change, workspace open, and setup completion (so a re-run clears the badge promptly).
- To avoid needless work, a compute-change whose resolved **identity is unchanged** (a cluster runtime-state transition like RUNNING→TERMINATED) skips the dry-run, and drift is **cleared outright when no comparable compute is attached** (you cannot be drifted from nothing).
- Emits a categorical `python_env.drift` telemetry event once per newly-detected distinct mismatch (trigger + from/to env-key shapes, sanitized through the existing `categoricalEnvKey`).

Additive: no new persisted state and no migration — it only reads the existing `setupState` key, so sessions without a prior setup simply never drift.

The drift row re-runs via the existing `databricks.environment.rerunPythonEnv` command (already registered for the "ready" row's re-run, and hidden from the Command Palette), which gives re-runs their own `COMMAND_EXECUTION` telemetry. The drifted row uses a **distinct tree-item id** from the ready/set-up row: VS Code does not reliably rebind a node's `command` when the same id swaps to a different command on refresh, so a shared id left the "re-run" click inert.

Architecture: a pure `isDrifted` comparator → a `PythonSetupDriftManager` orchestrator (gated/debounced/cancellable/fail-safe, dependency-injected for testing) → a `composePythonSetupEntry` adapter that merges the setup controller's `ready` with the manager's `drifted` into the single config-view entry → wiring in `extension.ts`.

## Tests

- New co-located unit tests for each unit: `isDrifted` (fail-safe cases), `--dry-run` arg building, the `python_env.drift` emitter (incl. unrecognized-key → `other` collapse), the full `PythonSetupDriftManager` state machine (drift/clear, telemetry dedupe-with-reset, fail-safe on unknown key, a rejecting-dep regression, the identity-unchanged skip, and the no-compute clear), the drifted row state + precedence + distinct id, and `composePythonSetupEntry` event-merging/disposal.
- Full unit suite green: **763 passing, 0 failing, 10 pending**; `build` and `lint` clean.
- `extension.ts` is the composition root (no unit tests) — verified by build + lint + full suite.
- **Manually verified** in the Extension Development Host: switching compute (cluster or serverless version) flips the row to "is out of sync" with no toast, and the re-run affordance starts setup.

## Follow-ups (not in this PR)

- **Multi-root:** `setupState` is stored workspace-wide (one key), and there is no active-project-change trigger, so in a multi-root workspace one project's baseline could be compared against another's compute. A correct fix is a per-project storage-schema change; deferred as a follow-up.
- Manual testing surfaced a separate **constraints-repo** bug (unrelated to this change): the published `dbr/16.4.x-scala2.12` environment pins `databricks-sdk~=0.30.0`, which is incompatible with its `databricks-connect~=16.4.0` (needs `>=0.46`), so `uv sync` cannot resolve it. Tracked in databricks/environments#16.

This pull request and its description were written by Isaac.

