### PR TITLE
fix(python-setup): don't let an open notification wedge the setup entry

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -560,6 +560,29 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         expect(setup.ready).to.equal(true);
     });
 
+    it("clears the guard after the work even if the notification stays open", async () => {
+        // Model a user who leaves the success toast up (never dismisses it):
+        // showSuccess never resolves. The re-entrancy guard must release when the
+        // mutating work (CLI run + adopt + state) finishes, NOT when the toast is
+        // dismissed -- otherwise the entry stays wedged (every later click returns
+        // the still-pending promise) until the window is reloaded.
+        const cli = makeCli({resolve: SUCCESS_REAL_RUN});
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                showSuccess: () => new Promise<void>(() => {}),
+            })
+        );
+
+        // Resolves once the work is done, despite the still-open notification.
+        await setup.setup();
+        expect(cli.calls).to.have.length(1);
+
+        // A later click starts a fresh run rather than returning the wedged one.
+        await setup.setup();
+        expect(cli.calls).to.have.length(2);
+    });
+
     it("surfaces an error and stays not-ready when interpreter adoption fails", async () => {
         const shownErrors: string[] = [];
         const saved: unknown[] = [];

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -1,4 +1,6 @@
 import {Disposable, Event, EventEmitter} from "vscode";
+import {logging} from "@databricks/sdk-experimental";
+import {Loggers} from "../../logger";
 import {
     CancellationLike,
     PythonSetupCancelledError,
@@ -254,7 +256,10 @@ export class PythonSetupEnvironmentSetup implements Disposable {
 
     setup(): Promise<void> {
         // Re-entrancy guard: coalesce concurrent callers onto the running run
-        // rather than spawning a second project-mutating CLI process.
+        // rather than spawning a second project-mutating CLI process. The guard
+        // releases when the run's *work* settles; the terminal notification is
+        // presented via {@link present} (fire-and-forget), so a toast left open
+        // never wedges the entry -- see that method.
         if (this.inFlight) {
             return this.inFlight;
         }
@@ -263,6 +268,29 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         });
         this.inFlight = run;
         return run;
+    }
+
+    /**
+     * Present a terminal user notification without blocking the run. The
+     * re-entrancy guard in {@link setup} must release when the mutating work
+     * (CLI run, interpreter adoption, state write) finishes -- NOT when the user
+     * dismisses the toast. `showError`/`showSuccess`/`notify` each await
+     * `window.show*Message`, which stays pending until the toast is acted on, so
+     * awaiting them inside the guarded run wedged the entry: every later click
+     * returned the still-pending promise until the window was reloaded.
+     * A rejection must not become an unhandled rejection or fail the (already
+     * finished) setup, but it is not silently discarded: `showSuccess`/
+     * `showError` do real work before the toast (reading the venv project name,
+     * formatting the log, writing the output channel), so a throw there is a
+     * genuine bug worth a debug-level trace.
+     */
+    private present(notification: Promise<void>): void {
+        void notification.catch((e) =>
+            logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
+                "Failed to present python-setup notification",
+                e
+            )
+        );
     }
 
     private async runSetup(): Promise<void> {
@@ -298,7 +326,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             } catch {
                 // Measurement must never break the flow it measures.
             }
-            await this.deps.notify(NO_COMPUTE_TARGET_MESSAGE);
+            this.present(this.deps.notify(NO_COMPUTE_TARGET_MESSAGE));
             return;
         }
         const compute = resolved.compute;
@@ -331,7 +359,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             // result object exists, hence `not_started` rather than `failed`:
             // there is no phase or error code to attribute the break to.
             reportResult({outcome: "not_started"});
-            await this.deps.showError((e as Error).message);
+            this.present(this.deps.showError((e as Error).message));
             return;
         }
 
@@ -344,9 +372,11 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 diskMutated: result.error?.diskMutated,
                 warnings: result.warnings,
             });
-            await this.deps.showError(
-                getPythonSetupErrorMessage(result),
-                formatSetupFailureDetail(result)
+            this.present(
+                this.deps.showError(
+                    getPythonSetupErrorMessage(result),
+                    formatSetupFailureDetail(result)
+                )
             );
             return;
         }
@@ -369,7 +399,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 envKey: result.compute.envKey,
                 warnings: result.warnings,
             });
-            await this.deps.showError((e as Error).message);
+            this.present(this.deps.showError((e as Error).message));
             return;
         }
 
@@ -395,16 +425,17 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             throw e;
         }
 
-        // Reported before `showSuccess` on purpose: that awaits the user
-        // dismissing the notification, and folding think-time into `duration`
-        // would wreck the setup-time metric this event exists to measure.
+        // Report before presenting success: `duration` should measure the
+        // setup work, not the time the toast sits on screen. `present` is
+        // fire-and-forget, so the run settles here and the re-entrancy guard
+        // releases regardless of whether the user dismisses the notification.
         reportResult({
             outcome: "ok",
             envKey: result.compute.envKey,
             warnings: result.warnings,
         });
 
-        await this.deps.showSuccess(result);
+        this.present(this.deps.showSuccess(result));
     }
 
     /**


### PR DESCRIPTION
## Changes

Fixes a re-entrancy bug in the uv-native Python-setup orchestrator where the config-view row (**"Set up Python environment"** / **"Python environment ready"** / the new **"Python environment is drifted"** re-run) would stop responding to clicks until the window was reloaded.

Root cause: `setup()` wraps the run in an `inFlight` re-entrancy guard (to coalesce concurrent clicks onto a single project-mutating run), but `runSetup()` **`await`ed its terminal notification** — `showError` / `showSuccess` / `notify`, each of which awaits `window.show*Message(...)`, and that promise stays pending until the user acts on the toast. So once a run finished, if the user left the notification open (e.g. dismissed the log panel but not the toast, or after a failed first-time setup), `inFlight` never cleared and every subsequent click returned the same still-pending promise — nothing happened.

Fix: present terminal notifications **fire-and-forget** through a small `present()` helper (`void notification.catch(() => {})`), so the guarded run settles when the *work* (CLI run + interpreter adoption + state write) completes, not when the toast is dismissed. Telemetry (`reportResult`) is still recorded **before** presenting, so the setup-time `duration` metric is unchanged; a rejection from the notification is logged at debug (not silently swallowed, not surfaced) — `showSuccess`/`showError` do real work before the toast.

## Tests

- New unit test in `PythonSetupEnvironmentSetup.test.ts`: a second `setup()` starts a fresh CLI run even while the prior run's notification is still open. It **times out on the old code** (the guard never releases) and passes with the fix.
- Existing re-entrancy tests (coalesce concurrent calls; clear the guard on rejection) still pass.
- Full unit suite: **733 passing, 0 failing, 10 pending**; `test:lint` clean.

This pull request and its description were written by Isaac.
