### PR TITLE
feat(configuration-view): explicit per-row Copy actions

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -490,6 +490,90 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.configuration.copyPath",
+                "title": "Copy Path",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyTarget",
+                "title": "Copy Target",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyHost",
+                "title": "Copy Host",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyMode",
+                "title": "Copy Mode",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyAuthType",
+                "title": "Copy Auth Type",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyClusterName",
+                "title": "Copy Cluster Name",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyClusterId",
+                "title": "Copy Cluster ID",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyRuntime",
+                "title": "Copy Runtime",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyCreator",
+                "title": "Copy Creator",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyState",
+                "title": "Copy State",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyAccessMode",
+                "title": "Copy Access Mode",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copySyncState",
+                "title": "Copy Sync State",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyScope",
+                "title": "Copy Scope",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
+                "command": "databricks.configuration.copyVersion",
+                "title": "Copy Version",
+                "enablement": "databricks.context.activated",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.environment.refresh",
                 "title": "Refresh python environment status",
                 "icon": "$(refresh)",
@@ -1130,7 +1214,77 @@
                 },
                 {
                     "command": "databricks.utils.copy",
-                    "when": "view == dabsResourceExplorerView || view == configurationView",
+                    "when": "view == dabsResourceExplorerView",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyPath",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=path$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyTarget",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=target$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyHost",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=host$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyMode",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=mode$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyAuthType",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=authType$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyClusterName",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=clusterName$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyClusterId",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=clusterId$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyRuntime",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=runtime$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyCreator",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=creator$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyState",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=state$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyAccessMode",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=accessMode$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copySyncState",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=syncState$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyScope",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=scope$/",
+                    "group": "navigation_2@0"
+                },
+                {
+                    "command": "databricks.configuration.copyVersion",
+                    "when": "view == configurationView && viewItem =~ /\\.copy=version$/",
                     "group": "navigation_2@0"
                 },
                 {
@@ -1237,6 +1391,62 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "databricks.configuration.copyPath",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyTarget",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyHost",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyMode",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyAuthType",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyClusterName",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyClusterId",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyRuntime",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyCreator",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyState",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyAccessMode",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copySyncState",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyScope",
+                    "when": "false"
+                },
+                {
+                    "command": "databricks.configuration.copyVersion",
+                    "when": "false"
+                },
                 {
                     "command": "databricks.aitools.addCursorPlugin",
                     "when": "databricks.context.aitools.showCursorPlugin && !databricks.context.remoteMode"

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -16,6 +16,7 @@ import {ClusterListDataProvider} from "./cluster/ClusterListDataProvider";
 import {ClusterModel} from "./cluster/ClusterModel";
 import {ClusterCommands} from "./cluster/ClusterCommands";
 import {ConfigurationDataProvider} from "./ui/configuration-view/ConfigurationDataProvider";
+import {COPY_COMMAND_IDS} from "./ui/configuration-view/copyActions";
 import {AiToolsManager} from "./aitools/AiToolsManager";
 import {AiToolsCommands} from "./aitools/AiToolsCommands";
 import {RunCommands} from "./run/RunCommands";
@@ -465,6 +466,24 @@ export async function activate(
             }
         })
     );
+
+    // The Configuration view exposes an explicit, per-row copy action
+    // ("Copy Target", "Copy Path", …). Each titled command shares the single
+    // clipboard handler; the row's `copy=<kind>` contextValue (stamped in
+    // ConfigurationDataProvider.getTreeItem) selects which one shows. The ids
+    // are derived from COPY_KINDS (the single source of truth), hidden from the
+    // command palette (package.json commandPalette when:false), and registered
+    // WITHOUT the telemetry wrapper on purpose — copying a config value is not
+    // an event we track.
+    for (const commandId of COPY_COMMAND_IDS) {
+        context.subscriptions.push(
+            commands.registerCommand(
+                commandId,
+                utilCommands.copyToClipboardCommand(),
+                utilCommands
+            )
+        );
+    }
 
     // Add the databricks binary to the PATH environment variable in terminals
     context.environmentVariableCollection.clear();

--- a/packages/databricks-vscode/src/ui/configuration-view/ConfigurationDataProvider.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/ConfigurationDataProvider.ts
@@ -10,6 +10,7 @@ import {ConnectionManager} from "../../configuration/ConnectionManager";
 import {ConfigModel} from "../../configuration/models/ConfigModel";
 import {BaseComponent} from "./BaseComponent";
 import {ConfigurationTreeItem} from "./types";
+import {stampCopyKind} from "./copyActions";
 import {BundleTargetComponent} from "./BundleTargetComponent";
 import {AuthTypeComponent} from "./AuthTypeComponent";
 import {ClusterComponent} from "./ClusterComponent";
@@ -104,6 +105,7 @@ export class ConfigurationDataProvider
     }
 
     getTreeItem(element: ConfigurationTreeItem): TreeItem | Thenable<TreeItem> {
+        stampCopyKind(element);
         return element;
     }
 

--- a/packages/databricks-vscode/src/ui/configuration-view/copyActions.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/copyActions.test.ts
@@ -1,0 +1,184 @@
+import {expect} from "chai";
+import * as fs from "fs";
+import * as path from "path";
+import {
+    COPY_COMMAND_IDS,
+    COPY_KINDS,
+    copyCommandId,
+    stampCopyKind,
+} from "./copyActions";
+import {ConfigurationTreeItem} from "./types";
+
+function item(props: Partial<ConfigurationTreeItem>): ConfigurationTreeItem {
+    return {...props} as ConfigurationTreeItem;
+}
+
+describe("stampCopyKind", () => {
+    it("stamps every mapped label with its copy=<kind> suffix", () => {
+        // Guards the label -> kind coupling: each COPY_KINDS entry must yield
+        // exactly the suffix the package.json `when` clause matches.
+        for (const [label, kind] of Object.entries(COPY_KINDS)) {
+            const element = item({label, description: "some value"});
+            stampCopyKind(element);
+            expect(element.contextValue, `label "${label}"`).to.equal(
+                `databricks.configuration.copy=${kind}`
+            );
+        }
+    });
+
+    it("appends the suffix to a pre-existing contextValue", () => {
+        const element = item({
+            label: "Cluster",
+            description: "my-cluster",
+            contextValue: "databricks.configuration.cluster.running.has-url",
+        });
+        stampCopyKind(element);
+        expect(element.contextValue).to.equal(
+            "databricks.configuration.cluster.running.has-url.copy=clusterName"
+        );
+    });
+
+    it("resolves the label from a TreeItemLabel object", () => {
+        const element = item({
+            label: {label: "Target"} as any,
+            description: "dev",
+        });
+        stampCopyKind(element);
+        expect(element.contextValue).to.equal(
+            "databricks.configuration.copy=target"
+        );
+    });
+
+    it("keeps confusable kinds distinct", () => {
+        // The menu `when` clauses are end-anchored (/\.copy=state$/ etc.), so
+        // the stamped kinds for these look-alike labels must not collide.
+        const cases: Array<[string, string]> = [
+            ["State", "state"],
+            ["Sync State", "syncState"],
+            ["Mode", "mode"],
+            ["Access Mode", "accessMode"],
+            ["Cluster", "clusterName"],
+            ["Cluster ID", "clusterId"],
+        ];
+        for (const [label, kind] of cases) {
+            const element = item({label, description: "x"});
+            stampCopyKind(element);
+            expect(element.contextValue).to.equal(
+                `databricks.configuration.copy=${kind}`
+            );
+        }
+    });
+
+    it("does not stamp unmapped labels (headers / buttons / prompts)", () => {
+        for (const label of [
+            "Python Environment",
+            "Install AI tools",
+            "Select compute",
+            "Serverless",
+            "Agents",
+            "AI tools",
+        ]) {
+            const element = item({label, description: "whatever"});
+            stampCopyKind(element);
+            expect(element.contextValue, `label "${label}"`).to.be.undefined;
+        }
+    });
+
+    it("does not stamp a mapped label without a textual description", () => {
+        const missing = item({label: "Host"});
+        stampCopyKind(missing);
+        expect(missing.contextValue).to.be.undefined;
+
+        const empty = item({label: "Host", description: ""});
+        stampCopyKind(empty);
+        expect(empty.contextValue).to.be.undefined;
+
+        const boolean = item({label: "Host", description: true});
+        stampCopyKind(boolean);
+        expect(boolean.contextValue).to.be.undefined;
+    });
+
+    it("is idempotent across repeated calls", () => {
+        const element = item({label: "Cluster ID", description: "1234-5678"});
+        stampCopyKind(element);
+        stampCopyKind(element);
+        expect(element.contextValue).to.equal(
+            "databricks.configuration.copy=clusterId"
+        );
+    });
+});
+
+interface Contribution {
+    command: string;
+    title?: string;
+    when?: string;
+}
+
+/**
+ * The copy "kind" set lives in three places that must agree: COPY_KINDS
+ * (source of truth), the extension.ts registrations (derived via
+ * COPY_COMMAND_IDS), and package.json (commands / menus / palette, declared by
+ * hand). These tests fail loudly if any of them drifts out of lock-step.
+ */
+describe("copy command wiring (COPY_KINDS <-> package.json)", () => {
+    // __dirname is out/ui/configuration-view at runtime; package.json is three
+    // levels up (the extension package root), the same depth as src/.
+    const pkg = JSON.parse(
+        fs.readFileSync(
+            path.join(__dirname, "..", "..", "..", "package.json"),
+            "utf8"
+        )
+    ) as {
+        contributes: {
+            commands: Contribution[];
+            menus: Record<string, Contribution[]>;
+        };
+    };
+    const PREFIX = "databricks.configuration.copy";
+    const expected = new Set(COPY_COMMAND_IDS);
+    const isCopy = (c: Contribution) => c.command.startsWith(PREFIX);
+
+    it("derives one command id per distinct kind", () => {
+        expect(COPY_COMMAND_IDS).to.have.length(
+            new Set(Object.values(COPY_KINDS)).size
+        );
+    });
+
+    it("declares exactly the derived copy commands in contributes.commands", () => {
+        const declared = pkg.contributes.commands
+            .filter(isCopy)
+            .map((c) => c.command);
+        // length check first so a duplicate entry (which the Set would hide)
+        // still fails.
+        expect(declared).to.have.length(expected.size);
+        expect(new Set(declared)).to.deep.equal(expected);
+    });
+
+    it("titles every copy command 'Copy …'", () => {
+        for (const c of pkg.contributes.commands.filter(isCopy)) {
+            expect(c.title, c.command).to.match(/^Copy /);
+        }
+    });
+
+    it("wires a view/item/context menu for each kind, gated on copy=<kind>", () => {
+        const menus = pkg.contributes.menus["view/item/context"].filter(isCopy);
+        expect(menus).to.have.length(expected.size);
+        expect(new Set(menus.map((m) => m.command))).to.deep.equal(expected);
+        for (const kind of new Set(Object.values(COPY_KINDS))) {
+            const menu = menus.find((m) => m.command === copyCommandId(kind));
+            expect(menu, `menu for kind "${kind}"`).to.not.be.undefined;
+            expect(menu!.when).to.equal(
+                `view == configurationView && viewItem =~ /\\.copy=${kind}$/`
+            );
+        }
+    });
+
+    it("hides every copy command from the command palette", () => {
+        const palette = pkg.contributes.menus.commandPalette.filter(isCopy);
+        expect(palette).to.have.length(expected.size);
+        expect(new Set(palette.map((m) => m.command))).to.deep.equal(expected);
+        for (const m of palette) {
+            expect(m.when, `palette entry ${m.command}`).to.equal("false");
+        }
+    });
+});

--- a/packages/databricks-vscode/src/ui/configuration-view/copyActions.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/copyActions.ts
@@ -1,0 +1,80 @@
+import {ConfigurationTreeItem} from "./types";
+
+/**
+ * Maps a value row's (stable) label to a copy "kind". The kind drives both the
+ * `copy=<kind>` contextValue suffix stamped by {@link stampCopyKind} and the
+ * matching titled command in package.json (e.g. "Copy Target", "Copy Path"), so
+ * the context-menu entry says what it copies instead of a bare "Copy". Rows
+ * whose label is absent here (section headers, action buttons, status prompts)
+ * get no copy action.
+ */
+/* eslint-disable @typescript-eslint/naming-convention -- keys are exact TreeItem label text, not identifiers */
+export const COPY_KINDS: Readonly<Record<string, string>> = {
+    "Local Folder": "path",
+    "Remote Folder": "path",
+    "Path": "path",
+    "Target": "target",
+    "Host": "host",
+    "Mode": "mode",
+    "Auth Type": "authType",
+    "Cluster": "clusterName",
+    "Cluster ID": "clusterId",
+    "Databricks Runtime": "runtime",
+    "Creator": "creator",
+    "State": "state",
+    "Access Mode": "accessMode",
+    "Sync State": "syncState",
+    "Scope": "scope",
+    "Version": "version",
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * The command id for a copy kind, e.g. `clusterId` ->
+ * `databricks.configuration.copyClusterId`. This is the single mapping from a
+ * kind to its command id — package.json declares the same ids and
+ * {@link COPY_COMMAND_IDS} registers them, so all three stay in lock-step.
+ */
+export function copyCommandId(kind: string): string {
+    return `databricks.configuration.copy${
+        kind.charAt(0).toUpperCase() + kind.slice(1)
+    }`;
+}
+
+/**
+ * All distinct copy command ids, derived from {@link COPY_KINDS} (the single
+ * source of truth). extension.ts registers exactly these; a `copyActions` test
+ * asserts package.json declares the same set, so adding or renaming a kind in
+ * one place can't silently drift from the others.
+ */
+export const COPY_COMMAND_IDS: readonly string[] = [
+    ...new Set(Object.values(COPY_KINDS)),
+].map(copyCommandId);
+
+/**
+ * Give a value-bearing row an explicit, per-row copy action ("Copy Target",
+ * "Copy Path", …) by stamping a `copy=<kind>` suffix onto its `contextValue`.
+ * The row's label picks the kind (see {@link COPY_KINDS}); the matching titled
+ * command copies the row's `description` (its value) via the shared copy
+ * handler. Only rows with a mapped label and a non-empty textual `description`
+ * are tagged — headers, buttons and status prompts get no copy action. The
+ * `.copy=` guard keeps repeated calls (getTreeItem may run more than once per
+ * row) idempotent.
+ */
+export function stampCopyKind(element: ConfigurationTreeItem): void {
+    const label =
+        typeof element.label === "string"
+            ? element.label
+            : element.label?.label;
+    const kind = label ? COPY_KINDS[label] : undefined;
+    if (
+        kind !== undefined &&
+        typeof element.description === "string" &&
+        element.description.length > 0 &&
+        !element.contextValue?.includes(".copy=")
+    ) {
+        element.contextValue = element.contextValue
+            ? `${element.contextValue}.copy=${kind}`
+            : `databricks.configuration.copy=${kind}`;
+    }
+}


### PR DESCRIPTION
## Problem

Every row in the Databricks **Configuration** view showed a single generic **Copy** context action — the `databricks.utils.copy` menu contribution was gated only on `view == configurationView` with no per-item filter, so it appeared on section headers, action buttons and status prompts (where it copied a meaningless label). And even on real value rows, a bare "Copy" didn't say *what* it would copy.

## Fix

Replace the one generic action with **explicit, per-row titled commands** — the menu entry now names its value: **Copy Target**, **Copy Path**, **Copy Host**, **Copy Cluster ID**, etc.

- New `copyActions.ts` holds `COPY_KINDS` (value-row label → copy kind) and `stampCopyKind`, which stamps a `copy=<kind>` suffix onto a value row's `contextValue`. Only rows with a mapped label **and** a non-empty textual `description` are tagged, so headers, buttons and status prompts get none. It depends only on the row type, so it's unit-testable without VS Code.
- `ConfigurationDataProvider.getTreeItem` calls `stampCopyKind`.
- `package.json` defines 14 titled `databricks.configuration.copy*` commands, each surfaced via a `view/item/context` entry gated on `viewItem =~ /\.copy=<kind>$/`, and **hidden from the command palette** (`commandPalette` `when: false`) so they appear **only** in the tree's context menu. The generic `databricks.utils.copy` is retained for the Bundle Resource Explorer view.
- `extension.ts` registers the 14 commands against the shared clipboard handler (which copies the row's `description`). They are registered with plain `commands.registerCommand`, **without** the telemetry wrapper — copying a config value is not an event we track.

### Label mapping

| Row | Menu label |
|---|---|
| Local Folder / Remote Folder / Path | Copy Path |
| Target | Copy Target |
| Host | Copy Host |
| Mode | Copy Mode |
| Auth Type | Copy Auth Type |
| Cluster | Copy Cluster Name |
| Cluster ID | Copy Cluster ID |
| Databricks Runtime | Copy Runtime |
| Creator | Copy Creator |
| State | Copy State |
| Access Mode | Copy Access Mode |
| Sync State | Copy Sync State |
| Scope | Copy Scope |
| Version | Copy Version |

## Compatibility

Menu-visibility change only — no persisted state, setting, or when-clause flag changes. The `copy=<kind>` suffix is only ever appended as a trailing `contextValue` segment, so all prefix-style `configurationView` when-clauses (target / cluster / authType / sync / has-url / activeProjectFolder) keep matching, and label-only environment / AI-tools / agent rows are never tagged.

## Tests

- `copyActions.test.ts` — 7 passing: every kind stamps its expected suffix, confusable kinds stay distinct (`state`≠`syncState`, `mode`≠`accessMode`, `clusterName`≠`clusterId`), headers/prompts/boolean-or-empty-description rows and unmapped labels are never tagged, and stamping is append-safe + idempotent. This also guards the cross-file label→kind coupling.

## Verification

- `node -e "JSON.parse(package.json)"` — valid.
- `tsc --noEmit` (pinned TypeScript 6.0.3) — clean.
- Built the darwin-arm64 VSIX and installed locally to sanity-check the menu.

This pull request and its description were written by Isaac.