### PR TITLE
docs(conventions): add a section on concise, useful comments

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -264,7 +264,7 @@ code cannot, then stop.
   before it starts to lie.
 - **Doc-comments state the contract and caveats, not a re-spec.** A class/function
   doc-comment should give a caller what they need and any surprising behavior (e.g.
-  `@onError(throw:false)` semantics) in a sentence or two — not restate every branch.
+  `@onError({throw: false})` semantics) in a sentence or two — not restate every branch.
   Anything visible in the signature doesn't need repeating.
 
 Generated comments trend long and explanatory, so when working AI-assisted this matters

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -241,6 +241,37 @@ per-event markdown ([`telemetry.instructions.md`][vsctel]). Our `EventTypes`
 
 ---
 
+## 4b. Comments — concise and useful
+
+Comments are written for a human who is skimming, and humans skip walls of text.
+Every comment competes with the code for attention — earn it: say the one thing the
+code cannot, then stop.
+
+- **If the code is self-explanatory, don't comment it.** The best comment is often the
+  one you didn't write. Reach for a comment only when the code genuinely can't speak for
+  itself; a comment on obvious code is pure maintenance cost with no reader payoff.
+- **Explain _why_, never _what_.** The code already states what it does; a comment that
+  narrates the next line (`// increment i`) is noise. One that records a non-obvious
+  reason, constraint, or hazard is worth reading. (Same rule as 4a, applied inline.)
+- **Shorter than the code it guards.** If explaining one line takes a paragraph, the
+  reader gave up before your point. Trim to the load-bearing sentence.
+- **A comment is not a fix for a bad name.** If a variable or function needs several
+  lines to explain, rename or restructure it. A good name carries the explanation for
+  free and can't drift out of sync with the code.
+- **Comments rot — minimize the surface.** They aren't compiled or tested, so they go
+  stale silently as code changes. The fewer you keep, and the more they describe durable
+  _intent_ rather than current mechanics, the longer they stay true. Delete a comment
+  before it starts to lie.
+- **Doc-comments state the contract and caveats, not a re-spec.** A class/function
+  doc-comment should give a caller what they need and any surprising behavior (e.g.
+  `@onError(throw:false)` semantics) in a sentence or two — not restate every branch.
+  Anything visible in the signature doesn't need repeating.
+
+Generated comments trend long and explanatory, so when working AI-assisted this matters
+more, not less: trim to what a busy reviewer actually needs before committing.
+
+---
+
 ## 5. Go through the adapter layer (`vscode-objs/`)
 
 Don't call raw VS Code globals for state, config, or context. Use these seams so


### PR DESCRIPTION
## Why

AI-assisted changes trend toward long, explanatory comments that restate the code and go stale quickly. A recent PR needed a dedicated commit to halve the comments a feature had accumulated. `CODE_CONVENTIONS.md` had no guidance on inline or doc comments to point contributors (and agents) at.

## What

Adds section **4b. Comments — concise and useful** to `CODE_CONVENTIONS.md`. It sits right after 4a (module documentation), which already establishes "document the _why_, not the _what_"; 4b applies the same spirit to inline and doc comments:

- If the code is self-explanatory, don't comment it.
- Explain _why_, never _what_.
- Keep a comment shorter than the code it guards.
- A comment is not a fix for a bad name — rename or restructure instead.
- Comments rot; minimize them and prefer durable intent over current mechanics.
- Doc-comments state the contract and caveats, not a re-spec of every branch.

Closes with a note that this matters more, not less, when working AI-assisted.

## Verification

Docs-only change; reviewed the rendered Markdown. No code or build affected.

This pull request and its description were written by Isaac.