### PR TITLE
feat(python-setup): route the setup command to the uv flow when active

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -17,6 +17,7 @@ import {ClusterModel} from "./cluster/ClusterModel";
 import {ClusterCommands} from "./cluster/ClusterCommands";
 import {ConfigurationDataProvider} from "./ui/configuration-view/ConfigurationDataProvider";
 import {composePythonSetupEntry} from "./ui/configuration-view/pythonSetupEntry";
+import {routeEnvironmentSetup} from "./language/pythonSetupRouting";
 import {COPY_COMMAND_IDS} from "./ui/configuration-view/copyActions";
 import {AiToolsManager} from "./aitools/AiToolsManager";
 import {AiToolsCommands} from "./aitools/AiToolsCommands";
@@ -910,7 +911,10 @@ export async function activate(
                 pythonExtensionWrapper,
                 environmentDependenciesInstaller,
                 configureAutocomplete,
-                packageManagerTelemetry
+                packageManagerTelemetry,
+                // Constructed lazily (first isEnabled call is well after
+                // pythonSetupEnvironment is wired), so this reference is safe.
+                () => pythonSetupEnvironment.isVisible()
             )
     );
     // uv-native Python environment setup (python-setup). Constructed always,
@@ -1148,8 +1152,16 @@ export async function activate(
     context.subscriptions.push(
         telemetry.registerCommand(
             "databricks.environment.setup",
-            environmentCommands.setup,
-            environmentCommands
+            // Route to the uv-native flow when it is the active surface for the
+            // project, else the legacy checklist. Every trigger surface (status
+            // bar, config-view rows, palette, the run/debug gate) funnels
+            // through this command, so they all dispatch here.
+            (stepId?: string) =>
+                routeEnvironmentSetup(
+                    pythonSetupEnvironment,
+                    environmentCommands,
+                    stepId
+                )
         ),
         telemetry.registerCommand(
             "databricks.environment.refresh",

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.test.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.test.ts
@@ -1,0 +1,86 @@
+import * as assert from "assert";
+import type {Disposable} from "vscode";
+import {EnvironmentDependenciesVerifier} from "./EnvironmentDependenciesVerifier";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
+import {EnvironmentDependenciesInstaller} from "./EnvironmentDependenciesInstaller";
+import {ConfigureAutocomplete} from "./ConfigureAutocomplete";
+import {PackageManagerTelemetry} from "./PackageManagerTelemetry";
+
+// ConnectionManager/MsPythonExtensionWrapper expose their VS Code Events as
+// instance properties (`emitter.event`), which ts-mockito can't stub — calling
+// them throws "not a function" during construction. Hand-rolled stubs give the
+// constructor real no-op event subscriptions and let us drive the one handler
+// under test directly.
+const noopEvent = () => ({dispose() {}}) as Disposable;
+
+describe(__filename, () => {
+    let showCalls: unknown[];
+
+    function makeVerifier(isUvActive: () => Promise<boolean>) {
+        const connectionManager = {
+            serverless: false,
+            cluster: undefined,
+            onDidChangeCluster: noopEvent,
+            onDidChangeState: noopEvent,
+        } as unknown as ConnectionManager;
+
+        const pythonExtension = {
+            pythonEnvironment: Promise.resolve({
+                version: {major: 3, minor: 10, micro: 0},
+                environment: {name: ".venv"},
+                executable: {uri: {fsPath: "/project/.venv/bin/python"}},
+            }),
+            getPythonExecutable: async () => "/project/.venv/bin/python",
+            // databricks-connect missing: the legacy path would offer to install
+            // it on an interpreter change.
+            getPackageDetailsFromEnvironment: async () => undefined,
+            onDidChangePythonExecutable: noopEvent,
+        } as unknown as MsPythonExtensionWrapper;
+
+        const installer = {
+            show: (advertisement?: boolean) => {
+                showCalls.push(advertisement);
+                return Promise.resolve();
+            },
+            onDidTryInstallation: noopEvent,
+        } as unknown as EnvironmentDependenciesInstaller;
+
+        const configureAutocomplete = {
+            shouldSetupBuiltins: async () => false,
+            onDidUpdate: noopEvent,
+        } as unknown as ConfigureAutocomplete;
+
+        const packageManagerTelemetry =
+            {} as unknown as PackageManagerTelemetry;
+
+        return new EnvironmentDependenciesVerifier(
+            connectionManager,
+            pythonExtension,
+            installer,
+            configureAutocomplete,
+            packageManagerTelemetry,
+            isUvActive
+        );
+    }
+
+    beforeEach(() => {
+        showCalls = [];
+    });
+
+    it("offers the legacy install prompt on interpreter change when uv is not active", async () => {
+        const verifier = makeVerifier(async () => false);
+
+        await verifier["onInterpreterChanged"]();
+
+        assert.deepStrictEqual(showCalls, [true]);
+    });
+
+    it("suppresses the legacy install prompt on interpreter change when uv is active", async () => {
+        const verifier = makeVerifier(async () => true);
+
+        await verifier["onInterpreterChanged"]();
+
+        assert.deepStrictEqual(showCalls, []);
+    });
+});

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesVerifier.ts
@@ -20,7 +20,12 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
         private readonly pythonExtension: MsPythonExtensionWrapper,
         private readonly installer: EnvironmentDependenciesInstaller,
         private readonly configureAutocomplete: ConfigureAutocomplete,
-        private readonly packageManagerTelemetry: PackageManagerTelemetry
+        private readonly packageManagerTelemetry: PackageManagerTelemetry,
+        // Whether the uv-native flow is the active surface for this project. When
+        // it is, this legacy checklist stays evaluated (other consumers read its
+        // state) but must not auto-prompt, or the user gets both flows' prompts.
+        // Defaults to "never active" so the legacy construction is unchanged.
+        private readonly isUvActive: () => Promise<boolean> = async () => false
     ) {
         super([
             "checkCluster",
@@ -43,14 +48,10 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
                     await this.checkWorkspaceHasUc();
                 }
             }, this),
-            this.pythonExtension.onDidChangePythonExecutable(async () => {
-                await this.checkPythonEnvironment();
-                const depsCheck = await this.checkEnvironmentDependencies();
-                if (!depsCheck.available && depsCheck.action) {
-                    await depsCheck.action(true);
-                }
-                await this.checkBuiltins();
-            }, this),
+            this.pythonExtension.onDidChangePythonExecutable(
+                () => this.onInterpreterChanged(),
+                this
+            ),
             this.installer.onDidTryInstallation(async () => {
                 await this.checkEnvironmentDependencies();
                 await this.checkBuiltins();
@@ -59,6 +60,22 @@ export class EnvironmentDependenciesVerifier extends MultiStepAccessVerifier {
                 await this.checkBuiltins();
             })
         );
+    }
+
+    private async onInterpreterChanged() {
+        await this.checkPythonEnvironment();
+        const depsCheck = await this.checkEnvironmentDependencies();
+        // Suppress the legacy auto-install prompt when the uv-native flow owns
+        // this project — it drives its own setup, so a second prompt here is a
+        // duplicate.
+        if (
+            !depsCheck.available &&
+            depsCheck.action &&
+            !(await this.isUvActive())
+        ) {
+            await depsCheck.action(true);
+        }
+        await this.checkBuiltins();
     }
 
     promptForAttachingCluster(msg: string) {

--- a/packages/databricks-vscode/src/language/pythonSetupRouting.test.ts
+++ b/packages/databricks-vscode/src/language/pythonSetupRouting.test.ts
@@ -1,0 +1,47 @@
+import * as assert from "assert";
+import {routeEnvironmentSetup} from "./pythonSetupRouting";
+
+describe(__filename, () => {
+    function makeUv(visible: boolean) {
+        const calls = {setup: 0};
+        return {
+            uv: {
+                isVisible: () => Promise.resolve(visible),
+                setup: async () => {
+                    calls.setup++;
+                },
+            },
+            calls,
+        };
+    }
+
+    it("routes to the uv flow when it is the active surface", async () => {
+        const {uv, calls} = makeUv(true);
+        const legacyCalls: (string | undefined)[] = [];
+        const legacy = {
+            setup: async (stepId?: string) => {
+                legacyCalls.push(stepId);
+            },
+        };
+
+        await routeEnvironmentSetup(uv, legacy, "checkPythonEnvironment");
+
+        assert.strictEqual(calls.setup, 1);
+        assert.deepStrictEqual(legacyCalls, []);
+    });
+
+    it("routes to the legacy checklist (with the step id) when uv is not active", async () => {
+        const {uv, calls} = makeUv(false);
+        const legacyCalls: (string | undefined)[] = [];
+        const legacy = {
+            setup: async (stepId?: string) => {
+                legacyCalls.push(stepId);
+            },
+        };
+
+        await routeEnvironmentSetup(uv, legacy, "checkPythonEnvironment");
+
+        assert.strictEqual(calls.setup, 0);
+        assert.deepStrictEqual(legacyCalls, ["checkPythonEnvironment"]);
+    });
+});

--- a/packages/databricks-vscode/src/language/pythonSetupRouting.ts
+++ b/packages/databricks-vscode/src/language/pythonSetupRouting.ts
@@ -1,0 +1,38 @@
+/**
+ * The slice of the uv-native setup flow ({@link
+ * ../python-setup/controllers/PythonSetupEnvironmentSetup}) that the setup
+ * command router needs. Kept as a narrow structural interface so the router
+ * carries no dependency on the controller/gateway layers and stays
+ * unit-testable.
+ */
+export interface UvPythonSetup {
+    /** Whether the uv-native flow is the active surface for the current project. */
+    isVisible(): Promise<boolean>;
+    /** Run the uv-native setup (re-entrancy-guarded); resolves when it settles. */
+    setup(): Promise<void>;
+}
+
+/** The legacy checklist setup, as the router invokes it. */
+export interface LegacyEnvironmentSetup {
+    setup(stepId?: string): Promise<void>;
+}
+
+/**
+ * Back the `databricks.environment.setup` command: run the uv-native flow when
+ * it is the active surface for the current project, otherwise the legacy
+ * checklist. Routing here means every surface that funnels through that command
+ * (status bar, config-view rows, palette, the run/debug gate) reaches the right
+ * flow without per-surface branching. `stepId` is a legacy-only affordance and
+ * is ignored by the uv flow, which has no per-step entry points.
+ */
+export async function routeEnvironmentSetup(
+    uv: UvPythonSetup,
+    legacy: LegacyEnvironmentSetup,
+    stepId?: string
+): Promise<void> {
+    if (await uv.isVisible()) {
+        await uv.setup();
+        return;
+    }
+    await legacy.setup(stepId);
+}

--- a/packages/databricks-vscode/src/run/RunCommands.test.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import {commands, ExtensionContext, Uri} from "vscode";
-import {anything, instance, mock, verify, when} from "ts-mockito";
+import {instance, mock, verify, when} from "ts-mockito";
 import {RunCommands} from "./RunCommands";
 import {ConnectionManager} from "../configuration/ConnectionManager";
 import {MsPythonExtensionWrapper} from "../language/MsPythonExtensionWrapper";
@@ -119,10 +119,16 @@ describe(__filename, () => {
             ).never();
         });
 
-        it("should not re-verify when the feature is unavailable", async () => {
-            when(featureManagerMock.isEnabled(anything())).thenResolve(
-                featureState(false, undefined)
-            );
+        it("should not run the staleness re-check when the feature is unavailable", async () => {
+            // Unavailable on the first (cached) check, so the staleness re-check
+            // is skipped; setup runs and the forced post-setup check still
+            // reports unavailable, so the launch aborts.
+            when(
+                featureManagerMock.isEnabled("environment.dependencies")
+            ).thenResolve(featureState(false, undefined));
+            when(
+                featureManagerMock.isEnabled("environment.dependencies", true)
+            ).thenResolve(featureState(false, undefined));
             when(pythonExtensionMock.getPythonExecutable()).thenResolve(
                 undefined
             );
@@ -134,12 +140,6 @@ describe(__filename, () => {
             try {
                 const result = await runCommands["checkDbconnectEnabled"]();
                 assert.strictEqual(result, false);
-                verify(
-                    featureManagerMock.isEnabled(
-                        "environment.dependencies",
-                        true
-                    )
-                ).never();
             } finally {
                 registration.dispose();
             }
@@ -147,13 +147,14 @@ describe(__filename, () => {
 
         it("should proceed after a successful in-flow setup", async () => {
             // Unavailable on the first check; the setup flow fixes it, so the
-            // re-check after setup reports available and the launch proceeds.
+            // forced re-check after setup reports available and the launch
+            // proceeds.
             when(
                 featureManagerMock.isEnabled("environment.dependencies")
-            ).thenResolve(
-                featureState(false, undefined),
-                featureState(true, "/project/.venv/bin/python")
-            );
+            ).thenResolve(featureState(false, undefined));
+            when(
+                featureManagerMock.isEnabled("environment.dependencies", true)
+            ).thenResolve(featureState(true, "/project/.venv/bin/python"));
             const registration = commands.registerCommand(
                 "databricks.environment.setup",
                 () => undefined

--- a/packages/databricks-vscode/src/run/RunCommands.ts
+++ b/packages/databricks-vscode/src/run/RunCommands.ts
@@ -138,9 +138,17 @@ export class RunCommands {
         }
         // Run the setup flow, then re-check: a successful setup should let the
         // launch proceed instead of aborting and making the user re-trigger.
+        // Force a fresh check rather than reading the cache: when the setup
+        // command routes to the uv flow, it adopts the interpreter and the
+        // legacy state refreshes only on the (async) interpreter-change event,
+        // which may not have landed yet.
         await commands.executeCommand("databricks.environment.setup");
-        return (await this.featureManager.isEnabled("environment.dependencies"))
-            .available;
+        return (
+            await this.featureManager.isEnabled(
+                "environment.dependencies",
+                true
+            )
+        ).available;
     }
 
     private async isPythonEnvironmentStale(featureState: FeatureState) {


### PR DESCRIPTION
## Why

When the uv-native Python setup is the active surface for a project — the `environment.pythonSetup` opt-in plus a uv-suitable project, the same gate the **configuration view** already dispatches on — the `databricks.environment.setup` command still ran the **legacy checklist**. Every "set up my Python env" trigger funnels through that command:

- the **Databricks Connect status bar** button,
- the **config-view legacy rows**,
- the **command palette** entry,
- the **Run/Debug current file** gate's own `executeCommand("databricks.environment.setup")`.

So all of them drove the wrong flow for uv projects. Separately, the legacy interpreter-change listener would pop a **second** install prompt on top of the uv flow.

## What

- **`pythonSetupRouting.ts`** — a narrow `UvPythonSetup` seam plus `routeEnvironmentSetup`, which sends `databricks.environment.setup` to the uv flow when it is visible, else the legacy checklist. One change reroutes **every** trigger surface (the palette command is **not** hidden — it routes).
- **Interpreter-change guard** (`EnvironmentDependenciesVerifier`) — suppress the legacy auto-install prompt when uv is active, so the two flows don't both prompt.
- **`extension.ts`** — wire both.

### On readiness (deliberate design choice)

The **run/debug gate** and the **status bar** keep reading the legacy `environment.dependencies` check for *readiness*. That check reads **real installed state** (interpreter version + `databricks-connect` presence/version), so it is **reload-safe** and **interpreter-safe** — unlike the uv flow's session-only `ready` flag, which is empty after a window reload and is never invalidated when the user switches interpreters. Routing only the setup **trigger** (not the readiness signal) drives the uv setup from every surface while avoiding a reload / interpreter-staleness regression. **No cross-fallback**: when uv is active it is the only setup path.

All new dependencies are optional and default to legacy behavior, so nothing changes for users who have not opted in (the uv gate returns `false` → every surface behaves exactly as before). No new settings, persisted state, telemetry events, or when-clause flags.

## Verification

- Unit tests for the command routing and the interpreter-change guard.
- `yarn test:unit`: **790 passing, 0 failing** (10 pre-existing pending).
- `eslint` + `prettier -c` clean on all touched files.
- Reviewed with Isaac Review (0 findings), Codex, a Claude code-review agent, a devil's-advocate pass, and a CODE_CONVENTIONS.md compliance pass; this design incorporates their feedback (the earlier readiness-routing approach was dropped after review flagged the reload/interpreter regressions).

This pull request and its description were written by Isaac.