### PR TITLE
fix(dbconnect-run): surface Databricks Connect import failures

### DIFF
--- a/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
+++ b/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
@@ -45,17 +45,35 @@ db_globals = {}
 from databricks.sdk.runtime import dbutils  # noqa: E402
 db_globals['dbutils'] = dbutils
 
-# "table", "sc", "sqlContext" are missing
+# "table", "sc", "sqlContext" are missing.
+#
+# The import and the session build are handled separately on purpose. A failure to
+# import Databricks Connect (or pyspark) means the Python environment itself is
+# broken and the user's own script will hit the same error, so it is surfaced. The
+# most common cause is a standalone "pyspark" package installed alongside
+# databricks-connect: the two share the pyspark namespace and overwrite each other,
+# and the resulting Java/protobuf error otherwise gives no hint at the cause. A
+# failure to *build* the session (no configured compute, auth) is left quiet — many
+# scripts create their own session and never touch the injected one.
 try:
     from pyspark.sql import functions as udf, SparkSession
     from databricks.connect import DatabricksSession
-    spark: SparkSession = DatabricksSession.builder.getOrCreate()
-    sql = spark.sql
-    db_globals['spark'] = spark
-    db_globals['sql'] = sql
-    db_globals['udf'] = udf
 except Exception as e:
-    logging.debug(f"Failed to create DatabricksSession: {e}")
+    logging.error(
+        "Failed to import Databricks Connect: %s. This usually means the Python "
+        "environment is misconfigured — a common cause is a standalone 'pyspark' "
+        "package installed alongside databricks-connect, which share the pyspark "
+        "package and overwrite each other. Remove the standalone pyspark dependency "
+        "and re-run 'Set up Python environment'.", e)
+else:
+    try:
+        spark: SparkSession = DatabricksSession.builder.getOrCreate()
+        sql = spark.sql
+        db_globals['spark'] = spark
+        db_globals['sql'] = sql
+        db_globals['udf'] = udf
+    except Exception as e:
+        logging.debug(f"Failed to create DatabricksSession: {e}")
 
 # We do this to prevent importing widgets implementation prematurely
 # The widget import should prompt users to use the implementation

--- a/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
+++ b/packages/databricks-vscode/resources/python/dbconnect-bootstrap.py
@@ -61,10 +61,10 @@ try:
 except Exception as e:
     logging.error(
         "Failed to import Databricks Connect: %s. This usually means the Python "
-        "environment is misconfigured — a common cause is a standalone 'pyspark' "
-        "package installed alongside databricks-connect, which share the pyspark "
-        "package and overwrite each other. Remove the standalone pyspark dependency "
-        "and re-run 'Set up Python environment'.", e)
+        "environment is misconfigured. A common cause is a standalone 'pyspark' "
+        "package installed alongside databricks-connect: they share the pyspark "
+        "package and overwrite each other, so if your project depends on a "
+        "standalone pyspark, remove it and re-run 'Set up Python environment'.", e)
 else:
     try:
         spark: SparkSession = DatabricksSession.builder.getOrCreate()


### PR DESCRIPTION
## Problem

The run bootstrap wrapped the Databricks Connect import and the session build in one
broad `try/except` that logged any failure at `debug` level, so a broken environment
produced no visible signal. The most common break is a standalone `pyspark` installed
alongside `databricks-connect`: they share the `pyspark` package and overwrite each
other, and the user only sees an opaque Java or protobuf gencode error from their own
script, with no hint at the cause.

## What

- Split the import from the session build. An **import** failure now logs at error
  level with actionable guidance naming the standalone-`pyspark` conflict, because the
  user's own script hits the same import.
- A failure to *build* the session (no configured compute, auth) stays quiet at `debug`
  as before — many scripts create their own session and never use the injected one, so
  that path must not become noisy.

## Testing

- `python3 -m py_compile` on the bootstrap script.

This pull request and its description were written by Isaac.
