### PR TITLE
feat(ssh): pre-check the host CLI before starting the SSH tunnel

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1900,6 +1900,7 @@
         "lodash": "^4.17.21",
         "markdown-it": "^14.2.0",
         "minimatch": "^10.0.1",
+        "shell-env": "^4.0.3",
         "shell-quote": "^1.8.4",
         "triple-beam": "^1.4.1",
         "winston": "^3.11.0",

--- a/packages/databricks-vscode/src/ssh/SshCommands.test.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.test.ts
@@ -54,10 +54,7 @@ describe(__filename, () => {
         originalIsCursor = HostUtils.isCursor;
         originalShowWarningMessage = window.showWarningMessage;
         originalExecuteCommand = commands.executeCommand;
-        originalPlatform = Object.getOwnPropertyDescriptor(
-            process,
-            "platform"
-        );
+        originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
         (window as any).showWarningMessage = (
             message: string,

--- a/packages/databricks-vscode/src/ssh/SshCommands.test.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.test.ts
@@ -1,0 +1,176 @@
+import assert from "assert";
+import {commands, Uri, window} from "vscode";
+import {instance, mock} from "ts-mockito";
+import {CliWrapper} from "../cli/CliWrapper";
+import {SshCommands} from "./SshCommands";
+import {HostUtils} from "../utils";
+
+/**
+ * Exercises the advisory host-CLI PATH warning in isolation. The prompt is
+ * fired-and-forgotten from startTunnelCommand, so tests reach the private
+ * warnIfHostCliMissing directly and flush the detached prompt chain it kicks
+ * off before asserting on the message and any follow-up command.
+ */
+describe(__filename, () => {
+    let originalIsHostCliOnPath: typeof HostUtils.isHostCliOnPath;
+    let originalGetHostCliCommand: typeof HostUtils.getHostCliCommand;
+    let originalIsCursor: typeof HostUtils.isCursor;
+    let originalShowWarningMessage: typeof window.showWarningMessage;
+    let originalExecuteCommand: typeof commands.executeCommand;
+    let originalPlatform: PropertyDescriptor | undefined;
+
+    // Messages shown and their offered actions, plus the executed commands, so
+    // each test can assert what the user was prompted with and what ran.
+    let shownWarnings: {message: string; items: string[]}[];
+    let executedCommands: {command: string; args: unknown[]}[];
+    // The action the stubbed warning resolves with (what the user "clicks").
+    let warningResponse: string | undefined;
+
+    function stubPlatform(value: NodeJS.Platform) {
+        Object.defineProperty(process, "platform", {
+            value,
+            configurable: true,
+        });
+    }
+
+    function newSshCommands(): SshCommands {
+        return new SshCommands(instance(mock(CliWrapper)));
+    }
+
+    // Runs the fire-and-forget warning, then drains the microtask queue so the
+    // detached prompt chain (warning → follow-up command) has fully settled.
+    async function warn(sshCommands: SshCommands) {
+        await (sshCommands as any).warnIfHostCliMissing();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    beforeEach(() => {
+        shownWarnings = [];
+        executedCommands = [];
+        warningResponse = undefined;
+
+        originalIsHostCliOnPath = HostUtils.isHostCliOnPath;
+        originalGetHostCliCommand = HostUtils.getHostCliCommand;
+        originalIsCursor = HostUtils.isCursor;
+        originalShowWarningMessage = window.showWarningMessage;
+        originalExecuteCommand = commands.executeCommand;
+        originalPlatform = Object.getOwnPropertyDescriptor(
+            process,
+            "platform"
+        );
+
+        (window as any).showWarningMessage = (
+            message: string,
+            ...items: string[]
+        ) => {
+            shownWarnings.push({message, items});
+            return Promise.resolve(warningResponse);
+        };
+        (commands as any).executeCommand = (
+            command: string,
+            ...args: unknown[]
+        ) => {
+            executedCommands.push({command, args});
+            return Promise.resolve();
+        };
+    });
+
+    afterEach(() => {
+        (HostUtils as any).isHostCliOnPath = originalIsHostCliOnPath;
+        (HostUtils as any).getHostCliCommand = originalGetHostCliCommand;
+        (HostUtils as any).isCursor = originalIsCursor;
+        (window as any).showWarningMessage = originalShowWarningMessage;
+        (commands as any).executeCommand = originalExecuteCommand;
+        if (originalPlatform) {
+            Object.defineProperty(process, "platform", originalPlatform);
+        }
+    });
+
+    it("shows no warning when the host CLI is on PATH", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => true;
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(shownWarnings.length, 0);
+        assert.strictEqual(executedCommands.length, 0);
+    });
+
+    it("offers the shell-command installer on macOS", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => false;
+        (HostUtils as any).getHostCliCommand = () => "code";
+        stubPlatform("darwin");
+        warningResponse = "Install shell command";
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(shownWarnings.length, 1);
+        assert.ok(shownWarnings[0].message.includes('"code"'));
+        assert.deepStrictEqual(shownWarnings[0].items, [
+            "Install shell command",
+        ]);
+        assert.deepStrictEqual(executedCommands, [
+            {command: "workbench.action.installCommandLine", args: []},
+        ]);
+    });
+
+    it("does not run the installer on macOS when the prompt is dismissed", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => false;
+        (HostUtils as any).getHostCliCommand = () => "code";
+        stubPlatform("darwin");
+        warningResponse = undefined;
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(shownWarnings.length, 1);
+        assert.strictEqual(executedCommands.length, 0);
+    });
+
+    it("points at the VS Code PATH docs off macOS", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => false;
+        (HostUtils as any).getHostCliCommand = () => "code";
+        (HostUtils as any).isCursor = () => false;
+        stubPlatform("linux");
+        warningResponse = "Setup instructions";
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(shownWarnings.length, 1);
+        assert.deepStrictEqual(shownWarnings[0].items, ["Setup instructions"]);
+        assert.strictEqual(executedCommands.length, 1);
+        assert.strictEqual(executedCommands[0].command, "vscode.open");
+        assert.strictEqual(
+            (executedCommands[0].args[0] as Uri).toString(),
+            Uri.parse(
+                "https://code.visualstudio.com/docs/setup/setup-overview"
+            ).toString()
+        );
+    });
+
+    it("points at the Cursor PATH docs off macOS in Cursor", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => false;
+        (HostUtils as any).getHostCliCommand = () => "cursor";
+        (HostUtils as any).isCursor = () => true;
+        stubPlatform("linux");
+        warningResponse = "Setup instructions";
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(
+            (executedCommands[0].args[0] as Uri).toString(),
+            Uri.parse("https://docs.cursor.com/en/cli/installation").toString()
+        );
+    });
+
+    it("does not open docs off macOS when the prompt is dismissed", async () => {
+        (HostUtils as any).isHostCliOnPath = async () => false;
+        (HostUtils as any).getHostCliCommand = () => "code";
+        (HostUtils as any).isCursor = () => false;
+        stubPlatform("linux");
+        warningResponse = undefined;
+
+        await warn(newSshCommands());
+
+        assert.strictEqual(shownWarnings.length, 1);
+        assert.strictEqual(executedCommands.length, 0);
+    });
+});

--- a/packages/databricks-vscode/src/ssh/SshCommands.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.ts
@@ -1,10 +1,12 @@
 import {
+    commands,
     Disposable,
     Event,
     EventEmitter,
     QuickPick,
     QuickPickItem,
     QuickPickItemKind,
+    Uri,
     window,
 } from "vscode";
 import {WorkspaceClient} from "@databricks/sdk-experimental";
@@ -24,6 +26,7 @@ import {AuthProvider} from "../configuration/auth/AuthProvider";
 import {LoginWizard} from "../configuration/LoginWizard";
 import {Cluster} from "../sdk-extensions";
 import {onError} from "../utils/onErrorDecorator";
+import {HostUtils} from "../utils";
 import {logging} from "@databricks/sdk-experimental";
 import {Loggers} from "../logger";
 
@@ -170,6 +173,14 @@ export class SshCommands implements Disposable {
 
     @onError({popup: {prefix: "Error starting SSH tunnel."}})
     async startTunnelCommand() {
+        // Fail fast on a missing host CLI before touching auth, compute, or a
+        // terminal. `databricks ssh connect` shells out to the host command to
+        // open the remote window; when it is off PATH the connect only fails
+        // deep inside the terminal after a long wait, so pre-check it here and
+        // surface an actionable in-editor prompt instead.
+        if (!(await this.ensureHostCliOnPath())) {
+            return;
+        }
         const context = await this.resolveTunnelContext();
         if (context === undefined) {
             return;
@@ -409,6 +420,50 @@ export class SshCommands implements Disposable {
                 return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * Ensures the host editor's shell command (`code`/`cursor`) is on PATH,
+     * which `databricks ssh connect` needs to open the remote window. Returns
+     * true to proceed; on a miss, shows an actionable prompt whose button
+     * installs the shell command (falling back to the download page if the host
+     * does not expose the built-in installer) and returns false.
+     */
+    private async ensureHostCliOnPath(): Promise<boolean> {
+        if (await HostUtils.isHostCliOnPath()) {
+            return true;
+        }
+        const cmd = HostUtils.getHostCliCommand();
+        const install = "Install shell command";
+        window
+            .showErrorMessage(
+                `The "${cmd}" command isn't on your PATH, which the Databricks ` +
+                    `SSH tunnel needs to open the remote window. Install it, ` +
+                    `then start the tunnel again.`,
+                install
+            )
+            .then(async (choice) => {
+                if (choice !== install) {
+                    return;
+                }
+                try {
+                    // Built-in "Shell Command: Install '<cmd>' command in PATH".
+                    await commands.executeCommand(
+                        "workbench.action.installCommandLine"
+                    );
+                } catch {
+                    // Older hosts (or forks) may not register the installer;
+                    // fall back to the editor's download page.
+                    const url = HostUtils.isCursor()
+                        ? "https://cursor.com/"
+                        : "https://code.visualstudio.com/";
+                    await commands.executeCommand(
+                        "vscode.open",
+                        Uri.parse(url)
+                    );
+                }
+            });
         return false;
     }
 

--- a/packages/databricks-vscode/src/ssh/SshCommands.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.ts
@@ -173,14 +173,15 @@ export class SshCommands implements Disposable {
 
     @onError({popup: {prefix: "Error starting SSH tunnel."}})
     async startTunnelCommand() {
-        // Fail fast on a missing host CLI before touching auth, compute, or a
-        // terminal. `databricks ssh connect` shells out to the host command to
-        // open the remote window; when it is off PATH the connect only fails
-        // deep inside the terminal after a long wait, so pre-check it here and
-        // surface an actionable in-editor prompt instead.
-        if (!(await this.ensureHostCliOnPath())) {
-            return;
-        }
+        // `databricks ssh connect` shells out to the host command (`code`/
+        // `cursor`) to open the remote window; when it is off PATH the connect
+        // only fails deep inside the terminal after a long wait. Surface an
+        // actionable in-editor hint up front when the command looks missing.
+        // This is advisory only — the probe runs a non-interactive shell whose
+        // PATH can differ from the terminal's, so we still proceed and let the
+        // terminal report the real error rather than blocking a tunnel that
+        // would have worked.
+        await this.warnIfHostCliMissing();
         const context = await this.resolveTunnelContext();
         if (context === undefined) {
             return;
@@ -424,47 +425,61 @@ export class SshCommands implements Disposable {
     }
 
     /**
-     * Ensures the host editor's shell command (`code`/`cursor`) is on PATH,
-     * which `databricks ssh connect` needs to open the remote window. Returns
-     * true to proceed; on a miss, shows an actionable prompt whose button
-     * installs the shell command (falling back to the download page if the host
-     * does not expose the built-in installer) and returns false.
+     * When the host editor's shell command (`code`/`cursor`) looks missing from
+     * PATH — which `databricks ssh connect` needs to open the remote window —
+     * shows a non-blocking hint. The probe is advisory (its PATH can differ from
+     * the terminal's), so this never gates the tunnel; the prompt is fired and
+     * forgotten while the caller proceeds.
+     *
+     * On macOS the prompt offers the built-in "Install shell command" installer.
+     * `workbench.action.installCommandLine` is registered only on macOS, so
+     * elsewhere we point at the editor's PATH-setup docs instead of telling the
+     * user to reinstall an editor they already have.
      */
-    private async ensureHostCliOnPath(): Promise<boolean> {
+    private async warnIfHostCliMissing(): Promise<void> {
         if (await HostUtils.isHostCliOnPath()) {
-            return true;
+            return;
         }
         const cmd = HostUtils.getHostCliCommand();
+        const message =
+            `The "${cmd}" command may not be on your PATH, which the ` +
+            `Databricks SSH tunnel needs to open the remote window. If the ` +
+            `tunnel fails to open a window, add it to your PATH and try again.`;
+
+        const promptChain =
+            process.platform === "darwin"
+                ? this.promptInstallShellCommand(message)
+                : this.promptPathSetupDocs(message);
+        // The prompt outlives this call by design; make sure a rejection in the
+        // detached chain can't surface as an unhandled rejection.
+        promptChain.catch((e) => {
+            logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                "Failed to handle host CLI PATH prompt",
+                e
+            );
+        });
+    }
+
+    private async promptInstallShellCommand(message: string): Promise<void> {
         const install = "Install shell command";
-        window
-            .showErrorMessage(
-                `The "${cmd}" command isn't on your PATH, which the Databricks ` +
-                    `SSH tunnel needs to open the remote window. Install it, ` +
-                    `then start the tunnel again.`,
-                install
-            )
-            .then(async (choice) => {
-                if (choice !== install) {
-                    return;
-                }
-                try {
-                    // Built-in "Shell Command: Install '<cmd>' command in PATH".
-                    await commands.executeCommand(
-                        "workbench.action.installCommandLine"
-                    );
-                } catch {
-                    // Older hosts (or forks) may not register the installer;
-                    // fall back to the editor's download page.
-                    const url = HostUtils.isCursor()
-                        ? "https://cursor.com/"
-                        : "https://code.visualstudio.com/";
-                    await commands.executeCommand(
-                        "vscode.open",
-                        Uri.parse(url)
-                    );
-                }
-            });
-        return false;
+        const choice = await window.showWarningMessage(message, install);
+        if (choice !== install) {
+            return;
+        }
+        // Built-in "Shell Command: Install '<cmd>' command in PATH" (macOS only).
+        await commands.executeCommand("workbench.action.installCommandLine");
+    }
+
+    private async promptPathSetupDocs(message: string): Promise<void> {
+        const setup = "Setup instructions";
+        const choice = await window.showWarningMessage(message, setup);
+        if (choice !== setup) {
+            return;
+        }
+        const url = HostUtils.isCursor()
+            ? "https://docs.cursor.com/en/cli/installation"
+            : "https://code.visualstudio.com/docs/setup/setup-overview";
+        await commands.executeCommand("vscode.open", Uri.parse(url));
     }
 
     private async launchSshTunnel(

--- a/packages/databricks-vscode/src/utils/hostUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.test.ts
@@ -49,12 +49,16 @@ describe(__filename, () => {
     });
 
     describe("isHostCliOnPath", () => {
+        // A resolved profile env; the probe passes this to `execFile` as PATH.
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const loadShellEnv = async () => async () => ({PATH: "/usr/bin"});
+
         it("is true when the probe succeeds", async () => {
             const exec = (async () => ({
                 stdout: "1.0.0",
                 stderr: "",
             })) as unknown as typeof cancellableExecFile;
-            assert.strictEqual(await isHostCliOnPath(exec), true);
+            assert.strictEqual(await isHostCliOnPath(exec, loadShellEnv), true);
         });
 
         it("is false only when the command is definitively not found", async () => {
@@ -64,7 +68,10 @@ describe(__filename, () => {
             const exec = (async () => {
                 throw notFound;
             }) as unknown as typeof cancellableExecFile;
-            assert.strictEqual(await isHostCliOnPath(exec), false);
+            assert.strictEqual(
+                await isHostCliOnPath(exec, loadShellEnv),
+                false
+            );
         });
 
         it("is true (advisory) when the probe fails for another reason", async () => {
@@ -73,7 +80,42 @@ describe(__filename, () => {
                     code: "EACCES",
                 });
             }) as unknown as typeof cancellableExecFile;
-            assert.strictEqual(await isHostCliOnPath(exec), true);
+            assert.strictEqual(await isHostCliOnPath(exec, loadShellEnv), true);
+        });
+
+        it("probes with the profile PATH on POSIX", async function () {
+            if (process.platform === "win32") {
+                this.skip();
+            }
+            let seenEnv: Record<string, string> | undefined;
+            const exec = (async (
+                _cmd: string,
+                _args: string[],
+                opts: {env?: Record<string, string>}
+            ) => {
+                seenEnv = opts.env;
+                return {stdout: "1.0.0", stderr: ""};
+            }) as unknown as typeof cancellableExecFile;
+            assert.strictEqual(await isHostCliOnPath(exec, loadShellEnv), true);
+            assert.strictEqual(seenEnv?.PATH, "/usr/bin");
+        });
+
+        it("is true (advisory) when the shell profile fails to resolve", async function () {
+            // Windows never loads shell-env, so this branch is POSIX-only.
+            if (process.platform === "win32") {
+                this.skip();
+            }
+            const exec = (async () => ({
+                stdout: "1.0.0",
+                stderr: "",
+            })) as unknown as typeof cancellableExecFile;
+            const failingShellEnv = async () => async () => {
+                throw new Error("profile blew up");
+            };
+            assert.strictEqual(
+                await isHostCliOnPath(exec, failingShellEnv),
+                true
+            );
         });
     });
 });

--- a/packages/databricks-vscode/src/utils/hostUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.test.ts
@@ -43,9 +43,9 @@ describe(__filename, () => {
         assert.strictEqual(getHostCliCommand(), "code");
     });
 
-    it("resolves the host CLI command to code-insiders in Insiders", () => {
+    it("resolves the host CLI command to code in Insiders (the CLI has no Insiders descriptor)", () => {
         stubUriScheme("vscode-insiders");
-        assert.strictEqual(getHostCliCommand(), "code-insiders");
+        assert.strictEqual(getHostCliCommand(), "code");
     });
 
     describe("isHostCliOnPath", () => {

--- a/packages/databricks-vscode/src/utils/hostUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.test.ts
@@ -1,6 +1,6 @@
 import {env} from "vscode";
 import assert from "assert";
-import {isCursor} from "./hostUtils";
+import {getHostCliCommand, isCursor} from "./hostUtils";
 
 describe(__filename, () => {
     let originalAppName: PropertyDescriptor | undefined;
@@ -30,5 +30,15 @@ describe(__filename, () => {
     it("is false for VS Code", () => {
         stubUriScheme("vscode");
         assert.strictEqual(isCursor(), false);
+    });
+
+    it("resolves the host CLI command to cursor in Cursor", () => {
+        stubUriScheme("cursor");
+        assert.strictEqual(getHostCliCommand(), "cursor");
+    });
+
+    it("resolves the host CLI command to code in VS Code", () => {
+        stubUriScheme("vscode");
+        assert.strictEqual(getHostCliCommand(), "code");
     });
 });

--- a/packages/databricks-vscode/src/utils/hostUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.test.ts
@@ -1,6 +1,7 @@
 import {env} from "vscode";
 import assert from "assert";
-import {getHostCliCommand, isCursor} from "./hostUtils";
+import {getHostCliCommand, isCursor, isHostCliOnPath} from "./hostUtils";
+import {cancellableExecFile} from "../cli/CliWrapper";
 
 describe(__filename, () => {
     let originalAppName: PropertyDescriptor | undefined;
@@ -40,5 +41,39 @@ describe(__filename, () => {
     it("resolves the host CLI command to code in VS Code", () => {
         stubUriScheme("vscode");
         assert.strictEqual(getHostCliCommand(), "code");
+    });
+
+    it("resolves the host CLI command to code-insiders in Insiders", () => {
+        stubUriScheme("vscode-insiders");
+        assert.strictEqual(getHostCliCommand(), "code-insiders");
+    });
+
+    describe("isHostCliOnPath", () => {
+        it("is true when the probe succeeds", async () => {
+            const exec = (async () => ({
+                stdout: "1.0.0",
+                stderr: "",
+            })) as unknown as typeof cancellableExecFile;
+            assert.strictEqual(await isHostCliOnPath(exec), true);
+        });
+
+        it("is false only when the command is definitively not found", async () => {
+            const notFound = Object.assign(new Error("spawn ENOENT"), {
+                code: "ENOENT",
+            });
+            const exec = (async () => {
+                throw notFound;
+            }) as unknown as typeof cancellableExecFile;
+            assert.strictEqual(await isHostCliOnPath(exec), false);
+        });
+
+        it("is true (advisory) when the probe fails for another reason", async () => {
+            const exec = (async () => {
+                throw Object.assign(new Error("permission denied"), {
+                    code: "EACCES",
+                });
+            }) as unknown as typeof cancellableExecFile;
+            assert.strictEqual(await isHostCliOnPath(exec), true);
+        });
     });
 });

--- a/packages/databricks-vscode/src/utils/hostUtils.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.ts
@@ -1,4 +1,5 @@
 import {env} from "vscode";
+import {cancellableExecFile} from "../cli/CliWrapper";
 
 /**
  * Cursor identifies itself via env.uriScheme === "cursor",
@@ -6,4 +7,31 @@ import {env} from "vscode";
  */
 export function isCursor(): boolean {
     return env.uriScheme === "cursor";
+}
+
+/**
+ * The name of the host editor's shell command on PATH: `cursor` in Cursor,
+ * `code` in VS Code. This is the command the `databricks ssh connect` CLI
+ * shells out to when opening the remote window (see the CLI's ideDescriptor),
+ * and is distinct from the `--ide=vscode|cursor` value passed to that command.
+ */
+export function getHostCliCommand(): "code" | "cursor" {
+    return isCursor() ? "cursor" : "code";
+}
+
+/**
+ * Whether the host editor's shell command (see getHostCliCommand) is available
+ * on PATH. `databricks ssh connect` needs it to open the remote window, so this
+ * lets us fail fast with an actionable prompt before spawning a terminal.
+ * Runs through a shell so PATH is resolved the same way the terminal would.
+ */
+export async function isHostCliOnPath(): Promise<boolean> {
+    try {
+        await cancellableExecFile(getHostCliCommand(), ["--version"], {
+            shell: true,
+        });
+        return true;
+    } catch {
+        return false;
+    }
 }

--- a/packages/databricks-vscode/src/utils/hostUtils.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.ts
@@ -1,6 +1,5 @@
 import {env} from "vscode";
-import {logging} from "@databricks/sdk-experimental";
-import {isFileNotFound} from "@databricks/sdk-experimental/dist/config/execUtils";
+import {ExecUtils, logging} from "@databricks/sdk-experimental";
 import {cancellableExecFile} from "../cli/CliWrapper";
 import {Loggers} from "../logger";
 
@@ -14,21 +13,17 @@ export function isCursor(): boolean {
 
 /**
  * The name of the host editor's shell command on PATH: `cursor` in Cursor,
- * `code-insiders` in VS Code Insiders, `code` in stable VS Code. This is the
- * command the `databricks ssh connect` CLI shells out to when opening the remote
- * window (see the CLI's ideDescriptor), and is distinct from the
- * `--ide=vscode|cursor` value passed to that command.
+ * `code` otherwise. This is the command the `databricks ssh connect` CLI shells
+ * out to when opening the remote window, and it mirrors how the CLI resolves
+ * `--ide` (see getSshConnectCommand): everything non-Cursor maps to `code`.
+ *
+ * VS Code Insiders ships its shell command as `code-insiders`, but the CLI has
+ * no Insiders descriptor and always invokes `code`, so we deliberately probe
+ * `code` there too — probing `code-insiders` would check a command the CLI
+ * never calls. Real Insiders support belongs upstream in the CLI.
  */
-export function getHostCliCommand(): "code" | "code-insiders" | "cursor" {
-    if (isCursor()) {
-        return "cursor";
-    }
-    // Insiders ships its shell command as `code-insiders`, not `code`; an
-    // Insiders-only install has that on PATH.
-    if (env.uriScheme === "vscode-insiders") {
-        return "code-insiders";
-    }
-    return "code";
+export function getHostCliCommand(): "code" | "cursor" {
+    return isCursor() ? "cursor" : "code";
 }
 
 /**
@@ -52,7 +47,7 @@ export async function isHostCliOnPath(
         await exec(getHostCliCommand(), ["--version"], {shell: true});
         return true;
     } catch (e) {
-        if (isFileNotFound(e)) {
+        if (ExecUtils.isFileNotFound(e)) {
             return false;
         }
         logging.NamedLogger.getOrCreate(Loggers.Extension).error(

--- a/packages/databricks-vscode/src/utils/hostUtils.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.ts
@@ -26,25 +26,53 @@ export function getHostCliCommand(): "code" | "cursor" {
     return isCursor() ? "cursor" : "code";
 }
 
+/** The subset of `shell-env`'s `shellEnv` we depend on. */
+type ShellEnv = (shell?: string) => Promise<Readonly<Record<string, string>>>;
+
+/**
+ * Loads `shell-env` lazily. It is a pure-ESM module, so a static `import`
+ * compiles to `require()` under our CommonJS target and would throw; a dynamic
+ * `import()` (which Node 22+ honours for ESM without top-level await) loads it
+ * in both the esbuild bundle and the tsc-compiled tests.
+ */
+async function defaultShellEnv(): Promise<ShellEnv> {
+    return (await import("shell-env")).shellEnv;
+}
+
 /**
  * Whether the host editor's shell command (see getHostCliCommand) is definitely
  * missing from PATH. `databricks ssh connect` needs it to open the remote
  * window, so this lets us surface an actionable hint before spawning a terminal.
  *
- * This probe runs a non-interactive shell with the extension-host environment,
- * which does not source the user's profile the way the terminal that runs the
- * connect does, so it can differ from the terminal's PATH. Treat a `false` here
- * as advisory, not authoritative: only a definitive file-not-found reports
- * `false`; any other failure (permissions, a transient spawn error) is logged
- * and reported as `true` so we don't wrongly claim the command is missing.
+ * The terminal that runs the connect sources the user's shell profile
+ * (~/.zshrc, ~/.zprofile, …), but the extension host does not, so a `code` /
+ * `cursor` that only lives on a profile-augmented PATH is invisible to a naive
+ * probe. On POSIX we therefore resolve the login+interactive shell's env via
+ * `shell-env` and hand that PATH to `execFile` so the probe sees what the
+ * terminal will. On Windows there is no profile to source and the command is a
+ * `.cmd` that needs a shell to launch, so we keep spawning through one.
  *
- * `exec` is injectable so the probe's branches can be tested.
+ * Because `execFile` resolves the executable against the PATH we pass (no
+ * intervening shell on POSIX), a genuinely absent command yields a definitive
+ * file-not-found and reports `false`. Any other failure — a slow or broken
+ * profile, a spawn error — is advisory: it is logged and reported as `true` so
+ * we don't wrongly claim the command is missing.
+ *
+ * `exec` and `loadShellEnv` are injectable so the probe's branches can be
+ * tested without spawning a real login shell.
  */
 export async function isHostCliOnPath(
-    exec: typeof cancellableExecFile = cancellableExecFile
+    exec: typeof cancellableExecFile = cancellableExecFile,
+    loadShellEnv: () => Promise<ShellEnv> = defaultShellEnv
 ): Promise<boolean> {
+    const command = getHostCliCommand();
     try {
-        await exec(getHostCliCommand(), ["--version"], {shell: true});
+        if (process.platform === "win32") {
+            await exec(command, ["--version"], {shell: true});
+        } else {
+            const shellEnv = await loadShellEnv();
+            await exec(command, ["--version"], {env: await shellEnv()});
+        }
         return true;
     } catch (e) {
         if (ExecUtils.isFileNotFound(e)) {

--- a/packages/databricks-vscode/src/utils/hostUtils.ts
+++ b/packages/databricks-vscode/src/utils/hostUtils.ts
@@ -1,5 +1,8 @@
 import {env} from "vscode";
+import {logging} from "@databricks/sdk-experimental";
+import {isFileNotFound} from "@databricks/sdk-experimental/dist/config/execUtils";
 import {cancellableExecFile} from "../cli/CliWrapper";
+import {Loggers} from "../logger";
 
 /**
  * Cursor identifies itself via env.uriScheme === "cursor",
@@ -11,27 +14,51 @@ export function isCursor(): boolean {
 
 /**
  * The name of the host editor's shell command on PATH: `cursor` in Cursor,
- * `code` in VS Code. This is the command the `databricks ssh connect` CLI
- * shells out to when opening the remote window (see the CLI's ideDescriptor),
- * and is distinct from the `--ide=vscode|cursor` value passed to that command.
+ * `code-insiders` in VS Code Insiders, `code` in stable VS Code. This is the
+ * command the `databricks ssh connect` CLI shells out to when opening the remote
+ * window (see the CLI's ideDescriptor), and is distinct from the
+ * `--ide=vscode|cursor` value passed to that command.
  */
-export function getHostCliCommand(): "code" | "cursor" {
-    return isCursor() ? "cursor" : "code";
+export function getHostCliCommand(): "code" | "code-insiders" | "cursor" {
+    if (isCursor()) {
+        return "cursor";
+    }
+    // Insiders ships its shell command as `code-insiders`, not `code`; an
+    // Insiders-only install has that on PATH.
+    if (env.uriScheme === "vscode-insiders") {
+        return "code-insiders";
+    }
+    return "code";
 }
 
 /**
- * Whether the host editor's shell command (see getHostCliCommand) is available
- * on PATH. `databricks ssh connect` needs it to open the remote window, so this
- * lets us fail fast with an actionable prompt before spawning a terminal.
- * Runs through a shell so PATH is resolved the same way the terminal would.
+ * Whether the host editor's shell command (see getHostCliCommand) is definitely
+ * missing from PATH. `databricks ssh connect` needs it to open the remote
+ * window, so this lets us surface an actionable hint before spawning a terminal.
+ *
+ * This probe runs a non-interactive shell with the extension-host environment,
+ * which does not source the user's profile the way the terminal that runs the
+ * connect does, so it can differ from the terminal's PATH. Treat a `false` here
+ * as advisory, not authoritative: only a definitive file-not-found reports
+ * `false`; any other failure (permissions, a transient spawn error) is logged
+ * and reported as `true` so we don't wrongly claim the command is missing.
+ *
+ * `exec` is injectable so the probe's branches can be tested.
  */
-export async function isHostCliOnPath(): Promise<boolean> {
+export async function isHostCliOnPath(
+    exec: typeof cancellableExecFile = cancellableExecFile
+): Promise<boolean> {
     try {
-        await cancellableExecFile(getHostCliCommand(), ["--version"], {
-            shell: true,
-        });
+        await exec(getHostCliCommand(), ["--version"], {shell: true});
         return true;
-    } catch {
-        return false;
+    } catch (e) {
+        if (isFileNotFound(e)) {
+            return false;
+        }
+        logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+            "Failed to probe the host CLI on PATH",
+            e
+        );
+        return true;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,6 +4033,7 @@ __metadata:
     nyc: ^18.0.0
     prettier: ^3.1.1
     quicktype-core: ^23.0.0
+    shell-env: ^4.0.3
     shell-quote: ^1.8.4
     tmp-promise: ^3.0.3
     triple-beam: ^1.4.1
@@ -4153,6 +4154,13 @@ __metadata:
   dependencies:
     strip-bom: ^4.0.0
   checksum: 45882fc971dd157faf6716ced04c15cf252c0a2d6f5c5844b66ca49f46ed03396a26cd940771aa569927aee22923a961bab789e74b25aabc94d90742c9dd1217
+  languageName: node
+  linkType: hard
+
+"default-shell@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "default-shell@npm:2.2.0"
+  checksum: 64e4f03bcf3bd8daacce3212535b6c3a8a28b3cc718db26446c5839c74098eea986446252f4a68714bfcea887155f3b523cf25792069ed7d735abe38faa2c778
   languageName: node
   linkType: hard
 
@@ -4852,6 +4860,23 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
+  languageName: node
+  linkType: hard
+
+"execa@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "execa@npm:5.1.1"
+  dependencies:
+    cross-spawn: ^7.0.3
+    get-stream: ^6.0.0
+    human-signals: ^2.1.0
+    is-stream: ^2.0.0
+    merge-stream: ^2.0.0
+    npm-run-path: ^4.0.1
+    onetime: ^5.1.2
+    signal-exit: ^3.0.3
+    strip-final-newline: ^2.0.0
+  checksum: fba9022c8c8c15ed862847e94c252b3d946036d7547af310e344a527e59021fd8b6bb0723883ea87044dc4f0201f949046993124a42ccb0855cae5bf8c786343
   languageName: node
   linkType: hard
 
@@ -5631,7 +5656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^6.0.1":
+"get-stream@npm:^6.0.0, get-stream@npm:^6.0.1":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: e04ecece32c92eebf5b8c940f51468cd53554dcbb0ea725b2748be583c9523d00128137966afce410b9b051eb2ef16d657cd2b120ca8edafcf5a65e81af63cad
@@ -6160,6 +6185,13 @@ __metadata:
     agent-base: ^7.1.2
     debug: 4
   checksum: b882377a120aa0544846172e5db021fa8afbf83fea2a897d397bd2ddd8095ab268c24bc462f40a15f2a8c600bf4aa05ce52927f70038d4014e68aefecfa94e8d
+  languageName: node
+  linkType: hard
+
+"human-signals@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "human-signals@npm:2.1.0"
+  checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
   languageName: node
   linkType: hard
 
@@ -7367,6 +7399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-stream@npm:2.0.0"
+  checksum: 6fa4dcc8d86629705cea944a4b88ef4cb0e07656ebf223fa287443256414283dd25d91c1cd84c77987f2aec5927af1a9db6085757cb43d90eb170ebf4b47f4f4
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:^1.28.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
@@ -7389,6 +7428,13 @@ __metadata:
   bin:
     mime: cli.js
   checksum: f43f9b7bfa64534e6b05bd6062961681aeb406a5b53673b53b683f27fcc4e739989941836a355eef831f4478923651ecc739f4a5f6e20a76487b432bfd4db928
+  languageName: node
+  linkType: hard
+
+"mimic-fn@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "mimic-fn@npm:2.1.0"
+  checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
   languageName: node
   linkType: hard
 
@@ -7903,6 +7949,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "npm-run-path@npm:4.0.1"
+  dependencies:
+    path-key: ^3.0.0
+  checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^6.0.0":
   version: 6.0.0
   resolution: "npm-run-path@npm:6.0.0"
@@ -8014,6 +8069,15 @@ __metadata:
   dependencies:
     fn.name: 1.x.x
   checksum: fd008d7e992bdec1c67f53a2f9b46381ee12a9b8c309f88b21f0223546003fb47e8ad7c1fd5843751920a8d276c63bd4b45670ef80c61fb3e07dbccc962b5c7d
+  languageName: node
+  linkType: hard
+
+"onetime@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "onetime@npm:5.1.2"
+  dependencies:
+    mimic-fn: ^2.1.0
+  checksum: 2478859ef817fc5d4e9c2f9e5728512ddd1dbc9fb7829ad263765bb6d3b91ce699d6e2332eef6b7dff183c2f490bd3349f1666427eaba4469fba0ac38dfd0d34
   languageName: node
   linkType: hard
 
@@ -8306,7 +8370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-key@npm:^3.1.0":
+"path-key@npm:^3.0.0, path-key@npm:^3.1.0":
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
@@ -9178,6 +9242,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"shell-env@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "shell-env@npm:4.0.3"
+  dependencies:
+    default-shell: ^2.0.0
+    execa: ^5.1.1
+    strip-ansi: ^7.0.1
+  checksum: dc74ce6feebe630ad0a10561603fa795703912411c7d51ea7263172b94c49483256bf3a8028a5dde64c891473f1f564e75148369ff4cc059e71a516e3b440512
+  languageName: node
+  linkType: hard
+
 "shell-quote@npm:^1.8.4":
   version: 1.8.4
   resolution: "shell-quote@npm:1.8.4"
@@ -9233,7 +9308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.7":
+"signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
@@ -9607,6 +9682,13 @@ __metadata:
     inspect-with-kind: ^1.0.5
     is-plain-obj: ^1.1.0
   checksum: 630c16035f4e8638bcb55523a3a016668b82b526fbde818b45cfd15c2fed506e2784153932c9d4a6d9758cc2c07a69a9533c7faffad2594dd601378d613e1b67
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strip-final-newline@npm:2.0.0"
+  checksum: 69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

`databricks ssh connect` shells out to the host editor's shell command (`code`/`cursor`) to open the remote window. When that command is off PATH, the connect only failed deep inside the terminal after a long wait. Fail fast instead: pre-check the command before touching auth, compute, or a terminal, and surface an actionable prompt whose button installs the shell command (falling back to the editor's download page on hosts without the built-in installer).

Adds HostUtils.getHostCliCommand/isHostCliOnPath to resolve and probe the command through a shell so PATH resolves as the terminal would.

## Tests

[hostUtils.ts](https://github.com/databricks/databricks-vscode/compare/fix/ssh-tunnel-host-cli-precheck?expand=1#diff-c1b4d8aeff4272f092f04f6ffbccb9c3d97f0f96c549d129b915dc1f9d2aba57)
