### PR TITLE
test(e2e): smoke-test the uv setup entry visibility gate

### DIFF
--- a/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
@@ -1,0 +1,136 @@
+import * as fs from "fs/promises";
+import path from "node:path";
+import assert from "node:assert";
+import {CustomTreeSection} from "wdio-vscode-service";
+import {
+    dismissNotifications,
+    getViewSection,
+    waitForLogin,
+} from "./utils/commonUtils.ts";
+import {
+    getBasicBundleConfig,
+    writeRootBundleConfig,
+} from "./utils/dabsFixtures.ts";
+
+/**
+ * Smoke test for the uv-native setup entry's VISIBILITY — not its provisioning
+ * (the full uv sync is covered by `setup_local.ucws.e2e.ts`, the CLI's own
+ * acceptance suite, and manual dogfood). There is no feature flag post-GA: the
+ * entry is shown purely when the active project is uv-suitable, i.e. no competing
+ * manager (pip/poetry/conda) is driving it. See `isUvSetupSuitable` /
+ * `makePythonSetupVisibility` / `EnvironmentComponent.getRoot`.
+ *
+ * This spec asserts the POSITIVE direction — a uv-suitable (clean) project
+ * surfaces the top-level "Set up Python environment" row and NOT the legacy
+ * "Python Environment" checklist group. That is the behaviour GA turned on and
+ * that no other e2e exercises. The negative direction (a pip project stays on the
+ * legacy checklist) is already covered end-to-end by `run_dbconnect.ucws.e2e.ts`
+ * — it writes a `requirements.txt` and asserts the "Python Environment" group —
+ * and at the unit level by `pythonSetupGate.test.ts` / `EnvironmentComponent.test.ts`.
+ *
+ * Kept deterministic on purpose: the fixture is uv-suitable on disk before login,
+ * so the very first render of the config view (driven by the login/connection
+ * refresh) evaluates the gate against the intended state — no mid-window fixture
+ * flip, which `databricks.environment.refresh` would NOT reliably re-render (it
+ * recomputes the legacy dependencies feature, whose emitter is change-gated, and
+ * does not re-run the uv visibility gate). No compute, CLI, or uv install is
+ * needed, so this runs on the cheap (non-serverless) shard.
+ *
+ * Note on the CI interpreter: uv-suitability also requires the active interpreter
+ * not to be a plain venv (`interpreter.venv` is a substantive pip signal). That
+ * holds on the e2e runner — `setup_local.ucws` reaches the uv flow on a clean
+ * project, and `runSetup` bails on `!isVisible()` — so a clean project is
+ * uv-suitable here. If this ever regresses to the legacy group, the runner's
+ * active interpreter source is the first thing to check.
+ */
+
+// Exact top-level row labels the two mutually exclusive surfaces render.
+const LEGACY_GROUP_LABEL = "Python Environment";
+const UV_SETUP_LABEL = "Set up Python environment";
+
+/**
+ * Wait until the CONFIGURATION section shows `expected` as a top-level row and
+ * does NOT show `forbidden`. Both surfaces are top-level rows (the uv entry is
+ * promoted out of the group wrapper — see `EnvironmentComponent.getRoot`), so
+ * scan the section's visible items directly rather than opening a group. Match
+ * labels exactly: "Set up Python environment" and "Python Environment" would
+ * otherwise overlap on a substring test.
+ */
+async function waitForConfigSurface(
+    expected: string,
+    forbidden: string,
+    timeoutMs = 60_000
+) {
+    await browser.waitUntil(
+        async () => {
+            const section = (await getViewSection("CONFIGURATION")) as
+                | CustomTreeSection
+                | undefined;
+            if (!section) {
+                return false;
+            }
+            let sawExpected = false;
+            for (const item of await section.getVisibleItems()) {
+                const label = await item.getLabel();
+                if (label === forbidden) {
+                    return false;
+                }
+                if (label === expected) {
+                    sawExpected = true;
+                }
+            }
+            return sawExpected;
+        },
+        {
+            timeout: timeoutMs,
+            interval: 1000,
+            timeoutMsg: `CONFIGURATION never showed "${expected}" without "${forbidden}"`,
+        }
+    );
+}
+
+describe("Python setup entry visibility", async function () {
+    let projectDir: string;
+    this.timeout(6 * 60 * 1000);
+
+    before(async () => {
+        assert(process.env.WORKSPACE_PATH, "WORKSPACE_PATH doesn't exist");
+        projectDir = process.env.WORKSPACE_PATH;
+
+        // A uv-suitable project: a development-mode bundle target and no
+        // competing-manager markers (no requirements.txt / poetry / conda), so
+        // the gate routes it to the uv-native entry. The bundle target also makes
+        // the config view render the Environment section (it renders only when
+        // connected + development mode). No compute is attached (topLevelComputeId
+        // = false) — visibility does not depend on it, and it keeps the fixture to
+        // exactly what the section-render precondition needs.
+        await writeRootBundleConfig(
+            getBasicBundleConfig({}, false),
+            projectDir
+        );
+        await waitForLogin("DEFAULT");
+        await dismissNotifications();
+        const workbench = await driver.getWorkbench();
+        await workbench.getEditorView().closeAllEditors();
+    });
+
+    it("surfaces the uv setup entry for a uv-suitable project", async () => {
+        // Sanity-check the fixture stayed uv-suitable: a stray requirements.txt
+        // would silently route the project to the legacy checklist and make the
+        // assertion below misleading rather than a real gate check.
+        assert(
+            !(await fileExists(path.join(projectDir, "requirements.txt"))),
+            "fixture unexpectedly has a requirements.txt (would force the legacy flow)"
+        );
+        await waitForConfigSurface(UV_SETUP_LABEL, LEGACY_GROUP_LABEL);
+    });
+});
+
+async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
@@ -12,33 +12,16 @@ import {
 } from "./utils/dabsFixtures.ts";
 
 /**
- * Smoke test for the uv-native setup entry's VISIBILITY — not its provisioning
- * (the full uv sync is covered by `setup_local.ucws.e2e.ts`, the CLI's own
- * acceptance suite, and manual dogfood). There is no feature flag post-GA: the
- * entry is shown purely when the active project is uv-suitable, i.e. no competing
- * manager (pip/poetry/conda) is driving it. See `isUvSetupSuitable` /
- * `makePythonSetupVisibility` / `EnvironmentComponent.getRoot`.
+ * Visibility smoke for the uv-native setup entry: a uv-suitable project shows the
+ * "Set up Python environment" row, not the legacy "Python Environment" checklist.
+ * Post-GA the gate is uv-suitability alone, no flag (see `isUvSetupSuitable`). The
+ * pip → legacy direction is the sibling `python_setup_visibility_legacy.e2e.ts`;
+ * provisioning is covered by `setup_local.ucws.e2e.ts`.
  *
- * This spec covers the POSITIVE direction — a uv-suitable (clean) project surfaces
- * the top-level "Set up Python environment" row and NOT the legacy "Python
- * Environment" checklist group. The NEGATIVE direction (a pip project stays on the
- * legacy checklist) is the sibling `python_setup_visibility_legacy.e2e.ts`. They
- * are separate specs on purpose: each asserts on the FIRST config-view render of
- * its own fixture, which is deterministic; the two states cannot share one window,
- * because nothing re-runs the visibility gate on an in-window fixture change
- * (`databricks.environment.refresh` recomputes only the legacy dependencies
- * feature, whose emitter is change-gated). No compute, CLI, or uv install is
- * needed, so both run on the cheap (non-serverless) shard.
- *
- * Note on the CI interpreter: uv-suitability also requires the active interpreter
- * not to be a plain venv (`interpreter.venv` is a substantive pip signal). That
- * holds on the e2e runner — `setup_local.ucws` reaches the uv flow on a clean
- * project, and `runSetup` bails on `!isVisible()` — so a clean project is
- * uv-suitable here. If this ever regresses to the legacy group, the runner's
- * active interpreter source is the first thing to check.
+ * Hazard: assumes the runner's active interpreter is not a plain venv
+ * (`interpreter.venv` is a pip signal); check that first if this flips to legacy.
  */
 
-// Exact top-level row labels the two mutually exclusive surfaces render.
 const LEGACY_GROUP_LABEL = "Python Environment";
 const UV_SETUP_LABEL = "Set up Python environment";
 
@@ -50,13 +33,9 @@ describe("Python setup entry visibility (uv-suitable project)", async function (
         assert(process.env.WORKSPACE_PATH, "WORKSPACE_PATH doesn't exist");
         projectDir = process.env.WORKSPACE_PATH;
 
-        // A uv-suitable project: a development-mode bundle target and no
-        // competing-manager markers (no requirements.txt / poetry / conda), so
-        // the gate routes it to the uv-native entry. The bundle target also makes
-        // the config view render the Environment section (it renders only when
-        // connected + development mode). No compute is attached (topLevelComputeId
-        // = false) — visibility does not depend on it, and it keeps the fixture to
-        // exactly what the section-render precondition needs.
+        // No competing-manager markers → uv-suitable. The dev-mode bundle target
+        // (no compute) is only there to render the Environment section, which
+        // needs connected + development mode.
         await writeRootBundleConfig(
             getBasicBundleConfig({}, false),
             projectDir
@@ -68,9 +47,8 @@ describe("Python setup entry visibility (uv-suitable project)", async function (
     });
 
     it("surfaces the uv setup entry, not the legacy checklist", async () => {
-        // Sanity-check the fixture stayed uv-suitable: a stray requirements.txt
-        // would silently route the project to the legacy checklist and make the
-        // assertion below misleading rather than a real gate check.
+        // A stray requirements.txt would force the legacy flow, making this pass
+        // for the wrong reason — fail fast instead.
         assert(
             !(await fileExists(path.join(projectDir, "requirements.txt"))),
             "fixture unexpectedly has a requirements.txt (would force the legacy flow)"

--- a/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/python_setup_visibility.e2e.ts
@@ -1,10 +1,9 @@
 import * as fs from "fs/promises";
 import path from "node:path";
 import assert from "node:assert";
-import {CustomTreeSection} from "wdio-vscode-service";
 import {
     dismissNotifications,
-    getViewSection,
+    waitForConfigSurface,
     waitForLogin,
 } from "./utils/commonUtils.ts";
 import {
@@ -20,21 +19,16 @@ import {
  * manager (pip/poetry/conda) is driving it. See `isUvSetupSuitable` /
  * `makePythonSetupVisibility` / `EnvironmentComponent.getRoot`.
  *
- * This spec asserts the POSITIVE direction — a uv-suitable (clean) project
- * surfaces the top-level "Set up Python environment" row and NOT the legacy
- * "Python Environment" checklist group. That is the behaviour GA turned on and
- * that no other e2e exercises. The negative direction (a pip project stays on the
- * legacy checklist) is already covered end-to-end by `run_dbconnect.ucws.e2e.ts`
- * — it writes a `requirements.txt` and asserts the "Python Environment" group —
- * and at the unit level by `pythonSetupGate.test.ts` / `EnvironmentComponent.test.ts`.
- *
- * Kept deterministic on purpose: the fixture is uv-suitable on disk before login,
- * so the very first render of the config view (driven by the login/connection
- * refresh) evaluates the gate against the intended state — no mid-window fixture
- * flip, which `databricks.environment.refresh` would NOT reliably re-render (it
- * recomputes the legacy dependencies feature, whose emitter is change-gated, and
- * does not re-run the uv visibility gate). No compute, CLI, or uv install is
- * needed, so this runs on the cheap (non-serverless) shard.
+ * This spec covers the POSITIVE direction — a uv-suitable (clean) project surfaces
+ * the top-level "Set up Python environment" row and NOT the legacy "Python
+ * Environment" checklist group. The NEGATIVE direction (a pip project stays on the
+ * legacy checklist) is the sibling `python_setup_visibility_legacy.e2e.ts`. They
+ * are separate specs on purpose: each asserts on the FIRST config-view render of
+ * its own fixture, which is deterministic; the two states cannot share one window,
+ * because nothing re-runs the visibility gate on an in-window fixture change
+ * (`databricks.environment.refresh` recomputes only the legacy dependencies
+ * feature, whose emitter is change-gated). No compute, CLI, or uv install is
+ * needed, so both run on the cheap (non-serverless) shard.
  *
  * Note on the CI interpreter: uv-suitability also requires the active interpreter
  * not to be a plain venv (`interpreter.venv` is a substantive pip signal). That
@@ -48,48 +42,7 @@ import {
 const LEGACY_GROUP_LABEL = "Python Environment";
 const UV_SETUP_LABEL = "Set up Python environment";
 
-/**
- * Wait until the CONFIGURATION section shows `expected` as a top-level row and
- * does NOT show `forbidden`. Both surfaces are top-level rows (the uv entry is
- * promoted out of the group wrapper — see `EnvironmentComponent.getRoot`), so
- * scan the section's visible items directly rather than opening a group. Match
- * labels exactly: "Set up Python environment" and "Python Environment" would
- * otherwise overlap on a substring test.
- */
-async function waitForConfigSurface(
-    expected: string,
-    forbidden: string,
-    timeoutMs = 60_000
-) {
-    await browser.waitUntil(
-        async () => {
-            const section = (await getViewSection("CONFIGURATION")) as
-                | CustomTreeSection
-                | undefined;
-            if (!section) {
-                return false;
-            }
-            let sawExpected = false;
-            for (const item of await section.getVisibleItems()) {
-                const label = await item.getLabel();
-                if (label === forbidden) {
-                    return false;
-                }
-                if (label === expected) {
-                    sawExpected = true;
-                }
-            }
-            return sawExpected;
-        },
-        {
-            timeout: timeoutMs,
-            interval: 1000,
-            timeoutMsg: `CONFIGURATION never showed "${expected}" without "${forbidden}"`,
-        }
-    );
-}
-
-describe("Python setup entry visibility", async function () {
+describe("Python setup entry visibility (uv-suitable project)", async function () {
     let projectDir: string;
     this.timeout(6 * 60 * 1000);
 
@@ -114,7 +67,7 @@ describe("Python setup entry visibility", async function () {
         await workbench.getEditorView().closeAllEditors();
     });
 
-    it("surfaces the uv setup entry for a uv-suitable project", async () => {
+    it("surfaces the uv setup entry, not the legacy checklist", async () => {
         // Sanity-check the fixture stayed uv-suitable: a stray requirements.txt
         // would silently route the project to the legacy checklist and make the
         // assertion below misleading rather than a real gate check.

--- a/packages/databricks-vscode/src/test/e2e/python_setup_visibility_legacy.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/python_setup_visibility_legacy.e2e.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import * as fs from "fs/promises";
+import assert from "node:assert";
+import {
+    dismissNotifications,
+    waitForConfigSurface,
+    waitForLogin,
+} from "./utils/commonUtils.ts";
+import {
+    getBasicBundleConfig,
+    writeRootBundleConfig,
+} from "./utils/dabsFixtures.ts";
+
+/**
+ * The NEGATIVE half of the uv-native setup entry's visibility gate — the sibling
+ * of `python_setup_visibility.e2e.ts` (which covers the uv-suitable → uv-entry
+ * direction). Here a pip-driven project (a `requirements.txt` is a substantive pip
+ * signal) is NOT uv-suitable, so the gate must route it to the legacy "Python
+ * Environment" checklist group and NOT show the uv-native "Set up Python
+ * environment" row. See `isUvSetupSuitable` / `EnvironmentComponent.getRoot`.
+ *
+ * A separate spec (own window/workspace) rather than a second phase of the
+ * positive spec: nothing re-runs the visibility gate on an in-window fixture
+ * change (`databricks.environment.refresh` recomputes only the legacy dependencies
+ * feature, whose emitter is change-gated), so each direction must be asserted on
+ * the first render of its own fixture. No compute, CLI, or uv install is needed,
+ * so this runs on the cheap (non-serverless) shard.
+ */
+
+// Exact top-level row labels the two mutually exclusive surfaces render.
+const LEGACY_GROUP_LABEL = "Python Environment";
+const UV_SETUP_LABEL = "Set up Python environment";
+
+describe("Python setup entry visibility (pip project)", async function () {
+    let projectDir: string;
+    this.timeout(6 * 60 * 1000);
+
+    before(async () => {
+        assert(process.env.WORKSPACE_PATH, "WORKSPACE_PATH doesn't exist");
+        projectDir = process.env.WORKSPACE_PATH;
+
+        // A pip-driven project: a `requirements.txt` is a substantive pip signal,
+        // so the gate treats pip as a competing manager and stays on the legacy
+        // checklist. The development-mode bundle target (no compute attached) is
+        // what makes the config view render the Environment section at all (it
+        // renders only when connected + development mode).
+        await fs.writeFile(
+            path.join(projectDir, "requirements.txt"),
+            "requests\n"
+        );
+        await writeRootBundleConfig(
+            getBasicBundleConfig({}, false),
+            projectDir
+        );
+        await waitForLogin("DEFAULT");
+        await dismissNotifications();
+        const workbench = await driver.getWorkbench();
+        await workbench.getEditorView().closeAllEditors();
+    });
+
+    it("shows the legacy checklist, not the uv setup entry", async () => {
+        // Sanity-check the fixture stayed pip-driven: without requirements.txt
+        // the project would be uv-suitable, and the assertion below would time
+        // out on the uv row instead of clearly reporting a bad fixture.
+        assert(
+            await fileExists(path.join(projectDir, "requirements.txt")),
+            "fixture is missing requirements.txt (would not exercise the legacy flow)"
+        );
+        await waitForConfigSurface(LEGACY_GROUP_LABEL, UV_SETUP_LABEL);
+    });
+});
+
+async function fileExists(p: string): Promise<boolean> {
+    try {
+        await fs.access(p);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/packages/databricks-vscode/src/test/e2e/python_setup_visibility_legacy.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/python_setup_visibility_legacy.e2e.ts
@@ -12,22 +12,14 @@ import {
 } from "./utils/dabsFixtures.ts";
 
 /**
- * The NEGATIVE half of the uv-native setup entry's visibility gate — the sibling
- * of `python_setup_visibility.e2e.ts` (which covers the uv-suitable → uv-entry
- * direction). Here a pip-driven project (a `requirements.txt` is a substantive pip
- * signal) is NOT uv-suitable, so the gate must route it to the legacy "Python
- * Environment" checklist group and NOT show the uv-native "Set up Python
- * environment" row. See `isUvSetupSuitable` / `EnvironmentComponent.getRoot`.
- *
- * A separate spec (own window/workspace) rather than a second phase of the
- * positive spec: nothing re-runs the visibility gate on an in-window fixture
- * change (`databricks.environment.refresh` recomputes only the legacy dependencies
- * feature, whose emitter is change-gated), so each direction must be asserted on
- * the first render of its own fixture. No compute, CLI, or uv install is needed,
- * so this runs on the cheap (non-serverless) shard.
+ * Negative half of the visibility gate (sibling of `python_setup_visibility.e2e.ts`):
+ * a pip project (`requirements.txt` is a pip signal) stays on the legacy "Python
+ * Environment" checklist and must NOT show the uv setup row. A separate spec, not a
+ * second phase, because nothing re-runs the gate on an in-window fixture change
+ * (`environment.refresh` recomputes only the change-gated legacy dependencies
+ * feature) — so each direction is asserted on its own fixture's first render.
  */
 
-// Exact top-level row labels the two mutually exclusive surfaces render.
 const LEGACY_GROUP_LABEL = "Python Environment";
 const UV_SETUP_LABEL = "Set up Python environment";
 
@@ -39,11 +31,9 @@ describe("Python setup entry visibility (pip project)", async function () {
         assert(process.env.WORKSPACE_PATH, "WORKSPACE_PATH doesn't exist");
         projectDir = process.env.WORKSPACE_PATH;
 
-        // A pip-driven project: a `requirements.txt` is a substantive pip signal,
-        // so the gate treats pip as a competing manager and stays on the legacy
-        // checklist. The development-mode bundle target (no compute attached) is
-        // what makes the config view render the Environment section at all (it
-        // renders only when connected + development mode).
+        // requirements.txt makes the project pip-driven (competing) → legacy. The
+        // dev-mode bundle target (no compute) is only there to render the
+        // Environment section, which needs connected + development mode.
         await fs.writeFile(
             path.join(projectDir, "requirements.txt"),
             "requests\n"
@@ -59,9 +49,8 @@ describe("Python setup entry visibility (pip project)", async function () {
     });
 
     it("shows the legacy checklist, not the uv setup entry", async () => {
-        // Sanity-check the fixture stayed pip-driven: without requirements.txt
-        // the project would be uv-suitable, and the assertion below would time
-        // out on the uv row instead of clearly reporting a bad fixture.
+        // Without requirements.txt the project is uv-suitable; fail fast rather
+        // than time out on the uv row.
         assert(
             await fileExists(path.join(projectDir, "requirements.txt")),
             "fixture is missing requirements.txt (would not exercise the legacy flow)"

--- a/packages/databricks-vscode/src/test/e2e/setup_local.ucws.e2e.ts
+++ b/packages/databricks-vscode/src/test/e2e/setup_local.ucws.e2e.ts
@@ -15,12 +15,6 @@ import {
     writeRootBundleConfig,
 } from "./utils/dabsFixtures.ts";
 
-// The uv-native setup entry is opt-in: it unlocks only when this feature id is
-// present in `databricks.experiments.optInto` (PYTHON_SETUP_FEATURE_ID). We set
-// it at Workspace scope from the test so it stays contained to this project's
-// folder and never reroutes another spec's "Setup python environment" command.
-const PYTHON_SETUP_FEATURE_ID = "environment.pythonSetup";
-
 // Ground-truth text the flow surfaces on success — the config-view row label
 // (persistent) and the completion toast (transient). We assert on the row.
 const READY_LABEL = "Python environment ready";
@@ -185,20 +179,7 @@ describe("Set up local Python environment (uv) on serverless", async function ()
         await workbench.getEditorView().closeAllEditors();
     });
 
-    it("should opt into uv setup and select a serverless version", async () => {
-        // Opt in at Workspace scope. `isPythonSetupEnabled()` reads this config
-        // live, so the setup command routes to the uv flow on the next click
-        // without a window reload.
-        await browser.executeWorkbench(async (vscode, featureId) => {
-            await vscode.workspace
-                .getConfiguration("databricks.experiments")
-                .update(
-                    "optInto",
-                    [featureId],
-                    vscode.ConfigurationTarget.Workspace
-                );
-        }, PYTHON_SETUP_FEATURE_ID);
-
+    it("should attach serverless and select an environment version", async () => {
         // setup-local requires uv, and the CI runners do not ship it, so preflight
         // would fail fast with E_UV_MISSING. Set the CLI's documented auto-install
         // opt-in in the extension host's env — the extension spawns setup-local
@@ -208,9 +189,9 @@ describe("Set up local Python environment (uv) on serverless", async function ()
             process.env.DATABRICKS_LOCALENV_AUTO_INSTALL_UV = "1";
         });
 
-        // Attach serverless. With the feature opted in, selecting serverless
-        // prompts for (and persists) the environment version up front, so the
-        // subsequent setup run resolves compute without re-prompting.
+        // Attach serverless. Selecting serverless prompts for (and persists) the
+        // environment version up front, so the subsequent setup run resolves
+        // compute without re-prompting.
         await executeCommandWhenAvailable("Databricks: Configure compute");
         const computeInput = await waitForQuickInput();
         await computeInput.selectQuickPick("Serverless");
@@ -223,9 +204,9 @@ describe("Set up local Python environment (uv) on serverless", async function ()
     });
 
     it("should set up the environment with uv (setup-local)", async () => {
-        // The router command; opted in + a clean (uv-suitable) project routes it
-        // to the uv flow, which shells out to `databricks environments
-        // setup-local`. Compute + version are already resolved, so no prompt.
+        // The router command; a clean (uv-suitable) project routes it to the uv
+        // flow, which shells out to `databricks environments setup-local`.
+        // Compute + version are already resolved, so no prompt.
         await executeCommandWhenAvailable(
             "Databricks: Setup python environment"
         );

--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -270,6 +270,48 @@ export async function waitForLogin(profileName: string) {
     );
 }
 
+/**
+ * Wait until the CONFIGURATION section shows `expected` as a top-level row and
+ * does NOT show `forbidden`. Scans the section's visible items directly (like
+ * {@link waitForLogin}), so it only sees top-level rows without expanding groups.
+ * Matches labels EXACTLY — pass full labels, since substrings can overlap (e.g.
+ * "Set up Python environment" contains "Python environment"). Treating `forbidden`
+ * as "keep polling" (not a hard failure) tolerates transient startup renders; only
+ * a persistent wrong surface fails at the timeout.
+ */
+export async function waitForConfigSurface(
+    expected: string,
+    forbidden: string,
+    timeoutMs = 60_000
+) {
+    await browser.waitUntil(
+        async () => {
+            const section = (await getViewSection("CONFIGURATION")) as
+                | CustomTreeSection
+                | undefined;
+            if (!section) {
+                return false;
+            }
+            let sawExpected = false;
+            for (const item of await section.getVisibleItems()) {
+                const label = await item.getLabel();
+                if (label === forbidden) {
+                    return false;
+                }
+                if (label === expected) {
+                    sawExpected = true;
+                }
+            }
+            return sawExpected;
+        },
+        {
+            timeout: timeoutMs,
+            interval: 1000,
+            timeoutMsg: `CONFIGURATION never showed "${expected}" without "${forbidden}"`,
+        }
+    );
+}
+
 export function getStaticResourceName(name: string) {
     return `vscode_integration_test_${name}`;
 }

--- a/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
+++ b/packages/databricks-vscode/src/test/e2e/utils/commonUtils.ts
@@ -271,13 +271,10 @@ export async function waitForLogin(profileName: string) {
 }
 
 /**
- * Wait until the CONFIGURATION section shows `expected` as a top-level row and
- * does NOT show `forbidden`. Scans the section's visible items directly (like
- * {@link waitForLogin}), so it only sees top-level rows without expanding groups.
- * Matches labels EXACTLY — pass full labels, since substrings can overlap (e.g.
- * "Set up Python environment" contains "Python environment"). Treating `forbidden`
- * as "keep polling" (not a hard failure) tolerates transient startup renders; only
- * a persistent wrong surface fails at the timeout.
+ * Wait until the CONFIGURATION section shows `expected` as a top-level row and not
+ * `forbidden`. Labels match exactly (substrings overlap, e.g. "Set up Python
+ * environment" contains "Python environment"). A `forbidden` hit keeps polling, so
+ * transient startup renders self-heal — only a persistent wrong surface times out.
  */
 export async function waitForConfigSurface(
     expected: string,


### PR DESCRIPTION
## Why

The uv-native Python setup entry is shown purely when the active project is **uv-suitable** — there is no feature flag post-GA. A competing package manager (pip via `requirements.txt`/`constraints.txt`/a plain venv, or poetry, or conda) routes the project to the legacy "Python Environment" checklist instead; otherwise the top-level "Set up Python environment" row appears. This visibility gate is what GA turned on, and it had no dedicated e2e guard for either direction.

## What

- **New** `python_setup_visibility.e2e.ts` (non-serverless shard) — POSITIVE: a uv-suitable (clean) project surfaces the top-level "Set up Python environment" row and **not** the legacy group.
- **New** `python_setup_visibility_legacy.e2e.ts` (non-serverless shard) — NEGATIVE: a pip project (`requirements.txt` present) shows the legacy "Python Environment" group and **not** the uv row.
  - Each direction is its own spec, asserted on the **first** config-view render of its own fixture (deterministic). They can't share one window: nothing re-runs the visibility gate on an in-window fixture change — `databricks.environment.refresh` recomputes only the legacy dependencies feature, whose emitter is change-gated.
  - Shared generic helper `waitForConfigSurface` extracted into `commonUtils` (assert a top-level CONFIGURATION row present and another absent).
  - No compute, CLI, or uv install — both run on the cheap shard.
- **Cleanup** in `setup_local.ucws.e2e.ts`: removed the now-dead `databricks.experiments.optInto` opt-in write and its stale comments (post-GA that setting is no longer read).

## Verification

- `yarn test:lint` (eslint + prettier) exits 0; `tsc -p src/test/e2e/tsconfig.json` reports no errors in the changed files.
- Test discovery routes both new specs to the cheap (`ucws=false`) shard (19 specs total).
- **e2e green on linux + windows for both new specs** — the integration run for this commit passed all 38/38 e2e jobs (positive + negative × linux + windows), leaving the rest of the suite unchanged.

This pull request and its description were written by Isaac.