### PR TITLE
feat(python-setup): resolve serverless version from pyproject.toml

### DIFF
--- a/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {writeFileSync} from "node:fs";
+import {
+    collectPyprojectServerlessVersion,
+    collectProjectPyprojectVersion,
+} from "./pyprojectServerlessVersion";
+
+describe("collectPyprojectServerlessVersion", () => {
+    it("reads environment_version from the canonical table", () => {
+        const contents = [
+            "[tool.databricks.environment]",
+            'environment_version = "4"',
+            "",
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([
+            {version: "4", source: "pyproject"},
+        ]);
+    });
+
+    it("tolerates surrounding whitespace, comments and single quotes", () => {
+        const contents = [
+            "# project config",
+            "[project]",
+            'name = "x"',
+            "",
+            "  [ tool.databricks.environment ]  # serverless env",
+            "   environment_version =   '5'   # pinned",
+            "",
+        ].join("\r\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([
+            {version: "5", source: "pyproject"},
+        ]);
+    });
+
+    it("accepts an unquoted (numeric) value", () => {
+        const contents = [
+            "[tool.databricks.environment]",
+            "environment_version = 3",
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([
+            {version: "3", source: "pyproject"},
+        ]);
+    });
+
+    it("ignores environment_version outside the databricks environment table", () => {
+        // A key of the same name in another table must never be harvested.
+        const contents = [
+            "[tool.other]",
+            'environment_version = "2"',
+            "",
+            "[project]",
+            'name = "x"',
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([]);
+    });
+
+    it("stops reading the table at the next header", () => {
+        // A key that appears only after a subsequent table header is no longer
+        // part of [tool.databricks.environment].
+        const contents = [
+            "[tool.databricks.environment]",
+            'base_environment = "x"',
+            "",
+            "[tool.databricks.environment.extra]",
+            'environment_version = "2"',
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([]);
+    });
+
+    it("ignores a commented-out table header", () => {
+        const contents = [
+            "# [tool.databricks.environment]",
+            'environment_version = "4"',
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([]);
+    });
+
+    it("does not match a key that merely ends with environment_version", () => {
+        const contents = [
+            "[tool.databricks.environment]",
+            'my_environment_version = "4"',
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([]);
+    });
+
+    it("returns nothing when the table or key is absent", () => {
+        expect(collectPyprojectServerlessVersion(undefined)).to.deep.equal([]);
+        expect(collectPyprojectServerlessVersion("")).to.deep.equal([]);
+        expect(
+            collectPyprojectServerlessVersion('[project]\nname = "x"\n')
+        ).to.deep.equal([]);
+        expect(
+            collectPyprojectServerlessVersion("[tool.databricks.environment]\n")
+        ).to.deep.equal([]);
+    });
+
+    it("skips an empty value", () => {
+        const contents = [
+            "[tool.databricks.environment]",
+            'environment_version = ""',
+        ].join("\n");
+
+        expect(collectPyprojectServerlessVersion(contents)).to.deep.equal([]);
+    });
+});
+
+describe("collectProjectPyprojectVersion", () => {
+    const cleanups: Array<() => void> = [];
+    afterEach(() => {
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    function tempProject(): string {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        return dir.name;
+    }
+
+    it("reads the version from a project's pyproject.toml", async () => {
+        const root = tempProject();
+        writeFileSync(
+            path.join(root, "pyproject.toml"),
+            '[tool.databricks.environment]\nenvironment_version = "4"\n'
+        );
+
+        expect(await collectProjectPyprojectVersion(root)).to.deep.equal([
+            {version: "4", source: "pyproject"},
+        ]);
+    });
+
+    it("contributes nothing when pyproject.toml is absent", async () => {
+        const root = tempProject();
+        expect(await collectProjectPyprojectVersion(root)).to.deep.equal([]);
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.ts
@@ -1,0 +1,106 @@
+import {readFile} from "fs/promises";
+import path from "path";
+import {VersionObservation} from "./serverlessVersionScoring";
+
+/**
+ * The table the environments team writes the serverless environment version
+ * into, and the key it holds:
+ *
+ *   [tool.databricks.environment]
+ *   environment_version = "4"
+ *
+ * This is an explicit user declaration -- the CLI writes it during a serverless
+ * setup-local run -- so it is the strongest scoring signal (see WEIGHTS in
+ * {@link ./serverlessVersionScoring}), stronger than the heuristics gathered
+ * from bundle YAML or notebook metadata.
+ */
+const TABLE_HEADER = /^\[\s*tool\s*\.\s*databricks\s*\.\s*environment\s*\]$/;
+const ENVIRONMENT_VERSION_KEY = /^environment_version\s*=\s*(.*)$/;
+
+/**
+ * Collect the serverless environment version declared in a `pyproject.toml`, as
+ * a scoring observation (source `pyproject`).
+ *
+ * Deliberately a bounded, comment-aware line scan rather than a full TOML parse
+ * (the same approach as {@link ../../language/packageManagerDetection}, so no
+ * TOML dependency is pulled in): it reads `environment_version` only from the
+ * canonical `[tool.databricks.environment]` table the CLI writes. A key of the
+ * same name in another table, or a dotted-key / inline-table spelling, is not
+ * harvested -- acceptable because the paired CLI work writes the canonical block
+ * form. The value's range validity is not checked here; the scorer drops
+ * anything the `--serverless-version` flag would reject.
+ *
+ * Pure over the file contents; returns [] for undefined input or when the table
+ * or key is absent.
+ */
+export function collectPyprojectServerlessVersion(
+    contents: string | undefined
+): VersionObservation[] {
+    if (contents === undefined) {
+        return [];
+    }
+
+    let inTargetTable = false;
+    for (const rawLine of contents.split(/\r?\n/)) {
+        // Strip a trailing comment, matching the sibling pyproject scans. A `#`
+        // inside a quoted value would be mishandled, but the version value is a
+        // bare integer string, so this never arises in practice.
+        const line = rawLine.split("#", 1)[0].trim();
+        if (line.length === 0) {
+            continue;
+        }
+        // Any table header ends the target section; only the exact canonical
+        // header (re)enters it, so a subtable like
+        // `[tool.databricks.environment.extra]` is treated as a different table.
+        if (line.startsWith("[")) {
+            inTargetTable = TABLE_HEADER.test(line);
+            continue;
+        }
+        if (!inTargetTable) {
+            continue;
+        }
+        const match = ENVIRONMENT_VERSION_KEY.exec(line);
+        if (match !== null) {
+            const version = normalizeVersion(match[1]);
+            return version === undefined
+                ? []
+                : [{version, source: "pyproject"}];
+        }
+    }
+    return [];
+}
+
+/**
+ * Read a project's root `pyproject.toml` and collect its serverless environment
+ * version. Thin I/O wrapper over {@link collectPyprojectServerlessVersion}: a
+ * missing or unreadable file contributes nothing rather than throwing into the
+ * flow that asked.
+ */
+export async function collectProjectPyprojectVersion(
+    projectRoot: string
+): Promise<VersionObservation[]> {
+    let contents: string;
+    try {
+        contents = await readFile(
+            path.join(projectRoot, "pyproject.toml"),
+            "utf-8"
+        );
+    } catch {
+        return [];
+    }
+    return collectPyprojectServerlessVersion(contents);
+}
+
+/**
+ * Strip an optional pair of matching quotes from a raw TOML value and return its
+ * bare-string form; reject empty values. Accepts an unquoted (numeric) value
+ * too, mirroring the tolerance of the bundle/notebook collectors.
+ */
+function normalizeVersion(rawValue: string): string | undefined {
+    let value = rawValue.trim();
+    const quote = value[0];
+    if ((quote === '"' || quote === "'") && value.endsWith(quote)) {
+        value = value.slice(1, -1);
+    }
+    return value.length > 0 ? value : undefined;
+}

--- a/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/pyprojectServerlessVersion.ts
@@ -24,11 +24,15 @@ const ENVIRONMENT_VERSION_KEY = /^environment_version\s*=\s*(.*)$/;
  * Deliberately a bounded, comment-aware line scan rather than a full TOML parse
  * (the same approach as {@link ../../language/packageManagerDetection}, so no
  * TOML dependency is pulled in): it reads `environment_version` only from the
- * canonical `[tool.databricks.environment]` table the CLI writes. A key of the
- * same name in another table, or a dotted-key / inline-table spelling, is not
- * harvested -- acceptable because the paired CLI work writes the canonical block
- * form. The value's range validity is not checked here; the scorer drops
- * anything the `--serverless-version` flag would reject.
+ * canonical `[tool.databricks.environment]` table the CLI writes. Like those
+ * sibling scanners it is stateless about string context, so spellings that only
+ * a real parser would resolve are out of scope: a key of the same name in
+ * another table, a dotted-key / inline-table form, or a key that sits inside a
+ * multi-line (`"""..."""`) string or after an array-continuation line beginning
+ * with `[`. This is acceptable because the paired CLI work writes the canonical
+ * block form -- a bare `environment_version` integer under the table header.
+ * The value's range validity is not checked here; the scorer drops anything the
+ * `--serverless-version` flag would reject.
  *
  * Pure over the file contents; returns [] for undefined input or when the table
  * or key is absent.

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.test.ts
@@ -1,7 +1,68 @@
 import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {writeFileSync} from "node:fs";
 import {collectServerlessVersionObservations} from "./serverlessVersionObservations";
 
 describe("collectServerlessVersionObservations", () => {
+    const cleanups: Array<() => void> = [];
+    afterEach(() => {
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    function tempProject(): string {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        return dir.name;
+    }
+
+    it("collects a pyproject declaration alongside the bundle evidence", async () => {
+        const root = tempProject();
+        writeFileSync(
+            path.join(root, "pyproject.toml"),
+            '[tool.databricks.environment]\nenvironment_version = "3"\n'
+        );
+
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => ({
+                resources: {
+                    jobs: {
+                        /* eslint-disable-next-line @typescript-eslint/naming-convention */
+                        j: {environments: [{spec: {environment_version: "4"}}]},
+                    },
+                },
+            }),
+            projectRoot: () => root,
+        });
+
+        expect(observations).to.deep.include.members([
+            {version: "3", source: "pyproject"},
+            {version: "4", source: "bundleYaml"},
+        ]);
+    });
+
+    it("keeps the other sources when the pyproject read throws", async () => {
+        const observations = await collectServerlessVersionObservations({
+            getValidateConfig: async () => ({
+                resources: {
+                    jobs: {
+                        /* eslint-disable-next-line @typescript-eslint/naming-convention */
+                        j: {environments: [{spec: {environment_version: "4"}}]},
+                    },
+                },
+            }),
+            projectRoot: () => {
+                throw new Error("no active project");
+            },
+        });
+
+        expect(observations).to.deep.equal([
+            {version: "4", source: "bundleYaml"},
+        ]);
+    });
+
     it("collects bundle observations from the validate config", async () => {
         const observations = await collectServerlessVersionObservations({
             getValidateConfig: async () => ({

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionObservations.ts
@@ -1,6 +1,7 @@
 import {VersionObservation} from "./serverlessVersionScoring";
 import {collectBundleServerlessVersions} from "./bundleServerlessVersions";
 import {collectProjectNotebookVersions} from "./projectNotebookVersions";
+import {collectProjectPyprojectVersion} from "./pyprojectServerlessVersion";
 
 /**
  * Where the version evidence comes from. Injected so collection stays testable
@@ -15,10 +16,10 @@ export interface ServerlessVersionObservationDeps {
 }
 
 /**
- * Gather serverless-version evidence from the project's local sources (bundle
- * config + notebooks). Each source is collected independently and guarded, so
- * one failing source never blocks the other or the flow that asked for it; the
- * scorer merges and de-dupes across sources.
+ * Gather serverless-version evidence from the project's local sources
+ * (`pyproject.toml`, bundle config, notebooks). Each source is collected
+ * independently and guarded, so one failing source never blocks the others or
+ * the flow that asked for it; the scorer merges and de-dupes across sources.
  *
  * The scorer also defines a `workspaceDefault` source, which is not collected
  * here: it would come from the workspace's default base environment, and the SDK
@@ -28,7 +29,18 @@ export interface ServerlessVersionObservationDeps {
 export async function collectServerlessVersionObservations(
     deps: ServerlessVersionObservationDeps
 ): Promise<VersionObservation[]> {
-    const [bundle, notebooks] = await Promise.all([
+    const [pyproject, bundle, notebooks] = await Promise.all([
+        (async () => {
+            try {
+                const root = deps.projectRoot();
+                if (root === undefined) {
+                    return [] as VersionObservation[];
+                }
+                return await collectProjectPyprojectVersion(root);
+            } catch {
+                return [] as VersionObservation[];
+            }
+        })(),
         (async () => {
             try {
                 return collectBundleServerlessVersions(
@@ -52,5 +64,5 @@ export async function collectServerlessVersionObservations(
             }
         })(),
     ]);
-    return [...bundle, ...notebooks];
+    return [...pyproject, ...bundle, ...notebooks];
 }

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.test.ts
@@ -35,6 +35,14 @@ describe("buildVersionPickItems", () => {
         expect(items[1].version).to.equal("4");
     });
 
+    it("names pyproject.toml as the provenance of a pyproject-sourced version", () => {
+        const items = buildVersionPickItems([
+            {version: "4", score: 200, sources: ["pyproject"]},
+        ]);
+
+        expect(items[0].description).to.match(/pyproject\.toml/i);
+    });
+
     it("handles a fallback-only list", () => {
         const items = buildVersionPickItems([
             {version: "5", score: 1, sources: ["fallback"]},

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionPicker.ts
@@ -12,6 +12,7 @@ export interface VersionPickItem {
 /** Human-readable provenance labels (the enum keys are internal jargon). */
 const SOURCE_LABELS: Record<VersionSource, string> = {
     /* eslint-disable @typescript-eslint/naming-convention */
+    pyproject: "pyproject.toml",
     bundleYaml: "bundle config",
     notebook: "notebook metadata",
     workspaceDefault: "workspace default",

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionResolver.ts
@@ -22,7 +22,7 @@ import {pickServerlessVersion} from "./serverlessVersionPicker";
  * single `undefined`.
  */
 export interface ServerlessVersionResolverDeps {
-    /** Gather raw version observations (bundle YAML, notebooks, workspace default). */
+    /** Gather raw version observations (pyproject.toml, bundle YAML, notebooks, workspace default). */
     collectObservations: () => Promise<VersionObservation[]>;
     /** Present the ranked candidates and return the confirmed bare version. */
     pick: (
@@ -32,8 +32,9 @@ export interface ServerlessVersionResolverDeps {
 
 /**
  * Resolve the serverless environment version to provision: collect the evidence
- * for what version this project should use (bundle YAML, notebooks, workspace
- * default), score it, and let the user confirm the best-ranked candidate.
+ * for what version this project should use (pyproject.toml, bundle YAML,
+ * notebooks, workspace default), score it, and let the user confirm the
+ * best-ranked candidate.
  * Returns the confirmed bare version (e.g. "5", the `--serverless-version`
  * value) or `undefined` when the user dismisses the picker.
  *

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.test.ts
@@ -12,6 +12,29 @@ describe("scoreServerlessVersions", () => {
         expect(ranked[0].version).to.equal("4");
     });
 
+    it("ranks a pyproject declaration above a competing bundle YAML one", () => {
+        // The explicit [tool.databricks.environment] declaration is the
+        // strongest signal, so it wins the recommended slot even when bundle
+        // YAML (the next-strongest) points elsewhere.
+        const ranked = scoreServerlessVersions([
+            {version: "3", source: "pyproject"},
+            {version: "5", source: "bundleYaml"},
+        ]);
+        expect(ranked[0].version).to.equal("3");
+        expect(ranked[0].sources).to.deep.equal(["pyproject"]);
+    });
+
+    it("merges pyproject with a matching bundle/notebook version", () => {
+        const ranked = scoreServerlessVersions([
+            {version: "4", source: "pyproject"},
+            {version: "4", source: "bundleYaml"},
+        ]);
+        const fours = ranked.filter((r) => r.version === "4");
+        expect(fours).to.have.length(1);
+        expect(fours[0].score).to.equal(WEIGHTS.pyproject + WEIGHTS.bundleYaml);
+        expect(fours[0].sources).to.have.members(["pyproject", "bundleYaml"]);
+    });
+
     it("adds weight when multiple sources agree on a version", () => {
         const ranked = scoreServerlessVersions([
             {version: "4", source: "bundleYaml"},

--- a/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/serverlessVersionScoring.ts
@@ -16,6 +16,7 @@
 
 /** Where a candidate serverless version was observed. */
 export type VersionSource =
+    | "pyproject"
     | "bundleYaml"
     | "notebook"
     | "workspaceDefault"
@@ -36,13 +37,16 @@ export interface VersionObservation {
 }
 
 /**
- * Per-source weights, high → low: an explicit project declaration (bundle YAML)
- * is the strongest signal, a notebook's recorded environment next, the
- * workspace default weaker, and the built-in fallback weakest so it only ever
- * wins when nothing else was observed.
+ * Per-source weights, high → low: the `pyproject.toml`
+ * `[tool.databricks.environment]` declaration is the strongest signal because it
+ * is an explicit user choice (the CLI writes it during setup-local), so it must
+ * outrank the heuristics; a bundle YAML declaration next, a notebook's recorded
+ * environment after that, the workspace default weaker, and the built-in
+ * fallback weakest so it only ever wins when nothing else was observed.
  */
 export const WEIGHTS: Record<VersionSource, number> = {
     /* eslint-disable @typescript-eslint/naming-convention */
+    pyproject: 200,
     bundleYaml: 100,
     notebook: 50,
     workspaceDefault: 20,


### PR DESCRIPTION
## Why

The environments team is introducing a `[tool.databricks.environment]` table in `pyproject.toml` that carries the serverless `environment_version`:

```toml
[tool.databricks.environment]
environment_version = "4"
```

The CLI writes this section during a serverless `setup-local` run. Because it is an **explicit user declaration**, it is a more reliable signal for the serverless version picker than the current heuristics (bundle YAML, notebook metadata, workspace default), and it lets the chosen value round-trip.

## What

- Add a new `pyproject` scoring source, weighted **above every current signal** (200 vs bundle's 100), so an explicit declaration becomes the recommended default — while still flowing through the picker, so there is no silent auto-selection.
- New `pyprojectServerlessVersion.ts`: a pure, comment-aware line scan that reads `environment_version` from the canonical `[tool.databricks.environment]` table (no TOML dependency — matching the repo's existing `pyproject.toml` handling in `packageManagerDetection.ts`), plus a thin I/O reader over the project-root file.
- Wire the source into `collectServerlessVersionObservations` as an independently guarded branch, and label it `pyproject.toml` in the picker's provenance.

Purely **additive**: no behaviour change when there is no `pyproject.toml` or no `[tool.databricks.environment]` table. Extends the earlier serverless version resolution work (#2052 / #2053).

### Scope note

The scan handles the canonical block form the paired CLI work writes; exotic TOML spellings (dotted-key / inline-table) are intentionally not parsed. A value outside the supported range is dropped like any other source (the CLI would reject it too).

## Verification

- `yarn test:unit` — **858 passing, 0 failing** (11 new `pyproject` collector tests + 3 extended scoring/observations/picker tests).
- `prettier -c` and `eslint` clean on all changed files.

This pull request and its description were written by Isaac.