### PR TITLE
feat(python-setup): recognize the W_DBCONNECT_CONSOLIDATED warning code

### DIFF
--- a/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
+++ b/packages/databricks-vscode/src/python-setup/models/PythonSetupResult.test.ts
@@ -74,7 +74,7 @@ describe("parsePythonSetupResult", () => {
         expect(r.warnings.map((w) => w.code)).to.deep.equal([
             "W_REQUIRES_PYTHON_OVERRIDDEN",
             "W_DBCONNECT_PIN_OVERRIDDEN",
-            "W_DBCONNECT_PIN_DUPLICATED",
+            "W_DBCONNECT_CONSOLIDATED",
             "W_USER_CONSTRAINT_CONFLICT",
             "W_USER_CONSTRAINT_CONFLICT",
         ]);

--- a/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
+++ b/packages/databricks-vscode/src/python-setup/models/fixtures/setupLocalResults.ts
@@ -111,11 +111,11 @@ export const SUCCESS_WITH_WARNINGS: PythonSetupResult = {
                 'the environment\'s "databricks-connect~=17.2.0"',
         },
         {
-            code: "W_DBCONNECT_PIN_DUPLICATED",
+            code: "W_DBCONNECT_CONSOLIDATED",
             message:
-                'databricks-connect "databricks-connect==15.0.0" is not rewritten ' +
-                'by the merge; the environment\'s "databricks-connect~=17.2.0" ' +
-                'sits in "dev" alongside it, and no version satisfies both',
+                'databricks-connect "databricks-connect==15.0.0" in ' +
+                "[dependency-groups].spark conflicts with the environment's " +
+                '"databricks-connect~=17.2.0" and is removed; it is managed in "dev"',
         },
         {
             code: "W_USER_CONSTRAINT_CONFLICT",

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.test.ts
@@ -271,16 +271,17 @@ describe(__filename, () => {
                 {code: "W_REQUIRES_PYTHON_OVERRIDDEN", message: "irrelevant"},
                 {code: "W_DBCONNECT_PIN_OVERRIDDEN", message: "irrelevant"},
                 {code: "W_DBCONNECT_PIN_DUPLICATED", message: "irrelevant"},
+                {code: "W_DBCONNECT_CONSOLIDATED", message: "irrelevant"},
                 {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
                 {code: "W_USER_CONSTRAINT_CONFLICT", message: "irrelevant"},
             ],
         });
 
         // The total is a numeric metric, not a property.
-        expect(events[1].metrics["event.warningsCount"]).to.equal(5);
+        expect(events[1].metrics["event.warningsCount"]).to.equal(6);
         expect(events[1].props).to.not.have.property("event.warningsCount");
         // The per-code counts are a JSON-stringified property (objects never
-        // become metrics), covering all four known codes with the repeated one
+        // become metrics), covering all five known codes with the repeated one
         // counted twice.
         expect(
             JSON.parse(events[1].props["event.warningCodeCounts"])
@@ -288,6 +289,7 @@ describe(__filename, () => {
             W_REQUIRES_PYTHON_OVERRIDDEN: 1,
             W_DBCONNECT_PIN_OVERRIDDEN: 1,
             W_DBCONNECT_PIN_DUPLICATED: 1,
+            W_DBCONNECT_CONSOLIDATED: 1,
             W_USER_CONSTRAINT_CONFLICT: 2,
         });
     });

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -138,6 +138,9 @@ function categoricalEnvKey(envKey: string | undefined): string | undefined {
  * - `W_DBCONNECT_PIN_OVERRIDDEN` — the user's databricks-connect pin is replaced.
  * - `W_DBCONNECT_PIN_DUPLICATED` — a retained databricks-connect pin now sits
  *   alongside the managed one, with no version satisfying both (needs a manual fix).
+ * - `W_DBCONNECT_CONSOLIDATED` — a conflicting databricks-connect pin outside the
+ *   managed dev group (in `[project].dependencies`, an optional-dependency extra, or
+ *   another dependency group) was removed so a single managed pin survives.
  * - `W_USER_CONSTRAINT_CONFLICT` — a user dependency is provably disjoint from an
  *   env constraint.
  *
@@ -150,6 +153,7 @@ const KNOWN_WARNING_CODES: ReadonlySet<string> = new Set([
     "W_REQUIRES_PYTHON_OVERRIDDEN",
     "W_DBCONNECT_PIN_OVERRIDDEN",
     "W_DBCONNECT_PIN_DUPLICATED",
+    "W_DBCONNECT_CONSOLIDATED",
     "W_USER_CONSTRAINT_CONFLICT",
 ]);
 


### PR DESCRIPTION
## Problem

The CLI's `environments setup-local` flow now emits a new merge-phase warning code, `W_DBCONNECT_CONSOLIDATED`, when it removes a conflicting `databricks-connect` pin from outside the managed dev group (in `[project].dependencies`, an optional-dependency extra, or another dependency group) so a single managed pin survives and `uv sync` stays satisfiable.

The extension's known-warning-code set in `pythonSetupExtensions.ts` did not recognize it, so every occurrence collapsed into the `"other"` telemetry bucket — invisible and miscounted in the per-code histogram.

## Change

- Add `W_DBCONNECT_CONSOLIDATED` to `KNOWN_WARNING_CODES`, with a doc bullet describing when the CLI emits it.
- Re-sync the `SUCCESS_WITH_WARNINGS` fixture to the CLI's updated `merge-warnings-json` golden verbatim: the entry that was `W_DBCONNECT_PIN_DUPLICATED` is now `W_DBCONNECT_CONSOLIDATED` (the CLI now consolidates that stray pin rather than leaving it duplicated).
- Extend the telemetry histogram test to exercise all five known codes (so `W_DBCONNECT_PIN_DUPLICATED` coverage is retained), and update the parse-order test to the new golden sequence.

`constants.ts` needs no change: its `warningCodeCounts` comment carries only an illustrative example (a still-valid code), not an enumerated list.

## Gating

This is only meaningful once the bundled CLI is bumped to a version that emits the code (the pinned `cli.version` predates it). Until then the code is simply absent from CLI output; recognizing it early is harmless and avoids a future `"other"`-bucket gap.

## Testing

- `yarn test:unit` — 842 passing, 0 failing. The five `W_*` codes now each get their own histogram bucket; none fall through to `"other"`.
- `yarn test:lint` — eslint and prettier clean.

This pull request and its description were written by Isaac.