### PR TITLE
test(e2e): retry a crashed Windows spec in a fresh VS Code session

### DIFF
--- a/packages/databricks-vscode/src/test/SpecRetryTracker.test.ts
+++ b/packages/databricks-vscode/src/test/SpecRetryTracker.test.ts
@@ -1,0 +1,48 @@
+import {expect} from "chai";
+import {SpecRetryTracker} from "./SpecRetryTracker";
+
+describe("SpecRetryTracker", () => {
+    it("does not flag a spec that passes on the first attempt", () => {
+        const tracker = new SpecRetryTracker();
+        tracker.record("a.e2e.ts", true);
+        expect(tracker.recoveredSpecs).to.deep.equal([]);
+    });
+
+    it("flags a spec that fails an attempt then passes", () => {
+        const tracker = new SpecRetryTracker();
+        tracker.record("a.e2e.ts", false);
+        tracker.record("a.e2e.ts", true);
+        expect(tracker.recoveredSpecs).to.deep.equal(["a.e2e.ts"]);
+    });
+
+    it("does not flag a spec that fails every attempt (a hard failure)", () => {
+        const tracker = new SpecRetryTracker();
+        tracker.record("a.e2e.ts", false);
+        tracker.record("a.e2e.ts", false);
+        expect(tracker.recoveredSpecs).to.deep.equal([]);
+    });
+
+    // Defensive: fail→pass→fail needs three attempts, which can't happen at
+    // specFileRetries=1 (a spec runs at most twice). This guards the
+    // recovered.delete branch for any future higher retry count.
+    it("un-flags a spec that recovers then fails again", () => {
+        const tracker = new SpecRetryTracker();
+        tracker.record("a.e2e.ts", false);
+        tracker.record("a.e2e.ts", true);
+        tracker.record("a.e2e.ts", false);
+        expect(tracker.recoveredSpecs).to.deep.equal([]);
+    });
+
+    it("tracks specs independently and lists each recovered one once", () => {
+        const tracker = new SpecRetryTracker();
+        tracker.record("a.e2e.ts", false);
+        tracker.record("a.e2e.ts", true);
+        tracker.record("b.e2e.ts", true);
+        tracker.record("c.e2e.ts", false);
+        tracker.record("c.e2e.ts", true);
+        expect(tracker.recoveredSpecs.sort()).to.deep.equal([
+            "a.e2e.ts",
+            "c.e2e.ts",
+        ]);
+    });
+});

--- a/packages/databricks-vscode/src/test/SpecRetryTracker.ts
+++ b/packages/databricks-vscode/src/test/SpecRetryTracker.ts
@@ -1,0 +1,30 @@
+// Lives under `src/test/` (not `src/test/e2e/`) for the same reason as
+// retry.ts: the e2e folder is excluded from the unit build, so a colocated unit
+// test only runs when the module sits outside it. The e2e config imports it via
+// an explicit `.ts` extension.
+
+// Tracks e2e spec outcomes across wdio's spec-file retries so a spec that only
+// passes on a retry — an otherwise-silent flake, since wdio reports the run as
+// green — can be surfaced at the end. `record` is called once per worker-end
+// (i.e. per attempt); `recoveredSpecs` lists specs that failed at least one
+// attempt but later passed. A spec that fails every attempt is a hard failure
+// wdio already reports, so it is deliberately not listed here.
+export class SpecRetryTracker {
+    private readonly failed = new Set<string>();
+    private readonly recovered = new Set<string>();
+
+    record(spec: string, passed: boolean): void {
+        if (!passed) {
+            this.failed.add(spec);
+            this.recovered.delete(spec);
+            return;
+        }
+        if (this.failed.has(spec)) {
+            this.recovered.add(spec);
+        }
+    }
+
+    get recoveredSpecs(): string[] {
+        return [...this.recovered];
+    }
+}

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -9,7 +9,14 @@ import fs from "fs/promises";
 import {Config, WorkspaceClient} from "@databricks/sdk-experimental";
 import * as ElementCustomCommands from "./customCommands/elementCustomCommands.ts";
 import {execFile as execFileCb} from "node:child_process";
-import {cpSync, mkdirSync, readdirSync, readFileSync, rmSync} from "node:fs";
+import {
+    cpSync,
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+} from "node:fs";
 import {tmpdir} from "node:os";
 import packageJson from "../../../package.json" assert {type: "json"};
 import {sleep} from "wdio-vscode-service";
@@ -18,9 +25,12 @@ import {getUniqueResourceName} from "./utils/commonUtils.ts";
 import {promisify} from "node:util";
 import {
     specFileRetriesForPlatform,
-    SpecRetryTracker,
+    specFileRetriesDelayForPlatform,
+    shouldPreserveFailedAttemptLogs,
+    failedAttemptLogRenames,
     formatRecoveredSpecsReport,
 } from "../retry.ts";
+import {SpecRetryTracker} from "../SpecRetryTracker.ts";
 
 // WebdriverIO v9 loads TypeScript by injecting `--import <tsx loader>` into
 // NODE_OPTIONS for every worker process. wdio-vscode-service installs the
@@ -44,6 +54,9 @@ if (
 }
 
 const WORKSPACE_PATH = path.resolve(tmpdir(), "test-root");
+
+// wdio's `outputDir`; also where onWorkerEnd parks a crashed attempt's logs.
+const LOGS_DIR = "logs";
 
 // Records spec outcomes across specFileRetries (see specFileRetriesForPlatform)
 // so a spec that passes only on a retry is surfaced in onComplete rather than
@@ -233,7 +246,7 @@ export const config: WebdriverIO.Config = {
     // Level of logging verbosity: trace | debug | info | warn | error | silent
     logLevel: "debug",
 
-    outputDir: "logs",
+    outputDir: LOGS_DIR,
 
     //
     // Set specific log levels per logger
@@ -299,7 +312,7 @@ export const config: WebdriverIO.Config = {
     specFileRetries: specFileRetriesForPlatform(process.platform),
     //
     // Delay in seconds between the spec file retry attempts
-    specFileRetriesDelay: 0,
+    specFileRetriesDelay: specFileRetriesDelayForPlatform(process.platform),
     //
     // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
     specFileRetriesDeferred: true,
@@ -414,13 +427,25 @@ export const config: WebdriverIO.Config = {
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {Number} retries  number of retries used
      */
-    onWorkerEnd: function (cid, exitCode, specs) {
+    onWorkerEnd: function (cid, exitCode, specs, retries) {
         // `exitCode` is per worker, not per spec; attributing it to each entry
         // is correct only because the flat `specs` glob runs exactly one spec
         // file per worker. If specs are ever grouped, gate this on
         // `specs.length === 1` to avoid mis-flagging a passing sibling.
         for (const spec of specs) {
             specRetryTracker.record(spec, exitCode === 0);
+        }
+        // A retry reuses this cid, so wdio reopens logs/wdio-<cid>*.log with
+        // flags:"w" and truncates the crash we retried for. Park them first so
+        // the recovered-flake report still has something to point at.
+        if (shouldPreserveFailedAttemptLogs(exitCode, retries)) {
+            for (const {from, to} of failedAttemptLogRenames(LOGS_DIR, cid)) {
+                try {
+                    renameSync(from, to);
+                } catch (error) {
+                    console.error(`Could not preserve ${from}:`, error);
+                }
+            }
         }
     },
 

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -16,7 +16,11 @@ import {sleep} from "wdio-vscode-service";
 import {glob} from "glob";
 import {getUniqueResourceName} from "./utils/commonUtils.ts";
 import {promisify} from "node:util";
-import {specFileRetriesForPlatform, SpecRetryTracker} from "../retry.ts";
+import {
+    specFileRetriesForPlatform,
+    SpecRetryTracker,
+    formatRecoveredSpecsReport,
+} from "../retry.ts";
 
 // WebdriverIO v9 loads TypeScript by injecting `--import <tsx loader>` into
 // NODE_OPTIONS for every worker process. wdio-vscode-service installs the
@@ -411,6 +415,10 @@ export const config: WebdriverIO.Config = {
      * @param  {Number} retries  number of retries used
      */
     onWorkerEnd: function (cid, exitCode, specs) {
+        // `exitCode` is per worker, not per spec; attributing it to each entry
+        // is correct only because the flat `specs` glob runs exactly one spec
+        // file per worker. If specs are ever grouped, gate this on
+        // `specs.length === 1` to avoid mis-flagging a passing sibling.
         for (const spec of specs) {
             specRetryTracker.record(spec, exitCode === 0);
         }
@@ -659,13 +667,12 @@ export const config: WebdriverIO.Config = {
      * @param {<Object>} results object containing test results
      */
     onComplete: function () {
-        const recovered = specRetryTracker.recoveredSpecs;
-        if (recovered.length > 0) {
-            console.log(
-                "\n⚠️  PASSED ONLY ON RETRY (flaky — investigate):\n" +
-                    recovered.map((spec) => `  - ${spec}`).join("\n") +
-                    "\n"
-            );
+        const lines = formatRecoveredSpecsReport(
+            specRetryTracker.recoveredSpecs,
+            Boolean(process.env.GITHUB_ACTIONS)
+        );
+        if (lines.length > 0) {
+            console.log("\n" + lines.join("\n") + "\n");
         }
     },
 

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -15,6 +15,7 @@ import packageJson from "../../../package.json" assert {type: "json"};
 import {sleep} from "wdio-vscode-service";
 import {glob} from "glob";
 import {getUniqueResourceName} from "./utils/commonUtils.ts";
+import {specFileRetriesForPlatform} from "../retry.ts";
 import {promisify} from "node:util";
 
 // WebdriverIO v9 loads TypeScript by injecting `--import <tsx loader>` into
@@ -281,8 +282,11 @@ export const config: WebdriverIO.Config = {
     // before running any tests.
     framework: "mocha",
     //
-    // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 0,
+    // The number of times to retry the entire specfile when it fails as a whole.
+    // Windows-only (see specFileRetriesForPlatform): recovers the WS-1006
+    // whole-session window crashes that no in-test wait can, by re-running the
+    // spec in a fresh VS Code session.
+    specFileRetries: specFileRetriesForPlatform(process.platform),
     //
     // Delay in seconds between the spec file retry attempts
     specFileRetriesDelay: 0,

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -435,11 +435,16 @@ export const config: WebdriverIO.Config = {
         for (const spec of specs) {
             specRetryTracker.record(spec, exitCode === 0);
         }
-        // A retry reuses this cid, so wdio reopens logs/wdio-<cid>*.log with
+        // A retry reuses this cid, so wdio reopens the worker's logs with
         // flags:"w" and truncates the crash we retried for. Park them first so
-        // the recovered-flake report still has something to point at.
-        if (shouldPreserveFailedAttemptLogs(exitCode, retries)) {
-            for (const {from, to} of failedAttemptLogRenames(LOGS_DIR, cid)) {
+        // the recovered-flake report still has something to point at. The runner
+        // log is named after specs[0] (see failedAttemptLogRenames).
+        if (shouldPreserveFailedAttemptLogs(exitCode, retries) && specs[0]) {
+            for (const {from, to} of failedAttemptLogRenames(
+                LOGS_DIR,
+                cid,
+                specs[0]
+            )) {
                 try {
                     renameSync(from, to);
                 } catch (error) {

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -15,8 +15,8 @@ import packageJson from "../../../package.json" assert {type: "json"};
 import {sleep} from "wdio-vscode-service";
 import {glob} from "glob";
 import {getUniqueResourceName} from "./utils/commonUtils.ts";
-import {specFileRetriesForPlatform} from "../retry.ts";
 import {promisify} from "node:util";
+import {specFileRetriesForPlatform} from "../retry.ts";
 
 // WebdriverIO v9 loads TypeScript by injecting `--import <tsx loader>` into
 // NODE_OPTIONS for every worker process. wdio-vscode-service installs the

--- a/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
+++ b/packages/databricks-vscode/src/test/e2e/wdio.conf.ts
@@ -16,7 +16,7 @@ import {sleep} from "wdio-vscode-service";
 import {glob} from "glob";
 import {getUniqueResourceName} from "./utils/commonUtils.ts";
 import {promisify} from "node:util";
-import {specFileRetriesForPlatform} from "../retry.ts";
+import {specFileRetriesForPlatform, SpecRetryTracker} from "../retry.ts";
 
 // WebdriverIO v9 loads TypeScript by injecting `--import <tsx loader>` into
 // NODE_OPTIONS for every worker process. wdio-vscode-service installs the
@@ -40,6 +40,12 @@ if (
 }
 
 const WORKSPACE_PATH = path.resolve(tmpdir(), "test-root");
+
+// Records spec outcomes across specFileRetries (see specFileRetriesForPlatform)
+// so a spec that passes only on a retry is surfaced in onComplete rather than
+// going silently green. Lives in the launcher process, which is where the
+// onWorkerEnd/onComplete hooks run.
+const specRetryTracker = new SpecRetryTracker();
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -404,8 +410,11 @@ export const config: WebdriverIO.Config = {
      * @param  {[type]} specs    specs to be run in the worker process
      * @param  {Number} retries  number of retries used
      */
-    // onWorkerEnd: function (cid, exitCode, specs, retries) {
-    // },
+    onWorkerEnd: function (cid, exitCode, specs) {
+        for (const spec of specs) {
+            specRetryTracker.record(spec, exitCode === 0);
+        }
+    },
 
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
@@ -649,8 +658,16 @@ export const config: WebdriverIO.Config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {<Object>} results object containing test results
      */
-    // onComplete: function (exitCode, config, capabilities, results) {
-    // },
+    onComplete: function () {
+        const recovered = specRetryTracker.recoveredSpecs;
+        if (recovered.length > 0) {
+            console.log(
+                "\n⚠️  PASSED ONLY ON RETRY (flaky — investigate):\n" +
+                    recovered.map((spec) => `  - ${spec}`).join("\n") +
+                    "\n"
+            );
+        }
+    },
 
     /**
      * Gets executed when a refresh happens.

--- a/packages/databricks-vscode/src/test/retry.test.ts
+++ b/packages/databricks-vscode/src/test/retry.test.ts
@@ -1,9 +1,12 @@
 import {expect} from "chai";
+import path from "node:path";
 import {
     isTransientFileLockError,
     retryOnTransientError,
     specFileRetriesForPlatform,
-    SpecRetryTracker,
+    specFileRetriesDelayForPlatform,
+    shouldPreserveFailedAttemptLogs,
+    failedAttemptLogRenames,
     formatRecoveredSpecsReport,
 } from "./retry";
 
@@ -222,48 +225,45 @@ describe("retry", () => {
         });
     });
 
-    describe("SpecRetryTracker", () => {
-        it("does not flag a spec that passes on the first attempt", () => {
-            const tracker = new SpecRetryTracker();
-            tracker.record("a.e2e.ts", true);
-            expect(tracker.recoveredSpecs).to.deep.equal([]);
+    describe("specFileRetriesDelayForPlatform", () => {
+        it("waits before a retry on Windows", () => {
+            expect(specFileRetriesDelayForPlatform("win32")).to.equal(5);
         });
 
-        it("flags a spec that fails an attempt then passes", () => {
-            const tracker = new SpecRetryTracker();
-            tracker.record("a.e2e.ts", false);
-            tracker.record("a.e2e.ts", true);
-            expect(tracker.recoveredSpecs).to.deep.equal(["a.e2e.ts"]);
+        it("does not wait on Linux or macOS", () => {
+            expect(specFileRetriesDelayForPlatform("linux")).to.equal(0);
+            expect(specFileRetriesDelayForPlatform("darwin")).to.equal(0);
+        });
+    });
+
+    describe("shouldPreserveFailedAttemptLogs", () => {
+        it("preserves when a failed attempt will be retried", () => {
+            expect(shouldPreserveFailedAttemptLogs(1, 1)).to.equal(true);
         });
 
-        it("does not flag a spec that fails every attempt (a hard failure)", () => {
-            const tracker = new SpecRetryTracker();
-            tracker.record("a.e2e.ts", false);
-            tracker.record("a.e2e.ts", false);
-            expect(tracker.recoveredSpecs).to.deep.equal([]);
+        it("does not preserve a passing attempt", () => {
+            expect(shouldPreserveFailedAttemptLogs(0, 1)).to.equal(false);
         });
 
-        // Defensive: fail→pass→fail needs three attempts, which can't happen
-        // at specFileRetries=1 (a spec runs at most twice). This guards the
-        // recovered.delete branch for any future higher retry count.
-        it("un-flags a spec that recovers then fails again", () => {
-            const tracker = new SpecRetryTracker();
-            tracker.record("a.e2e.ts", false);
-            tracker.record("a.e2e.ts", true);
-            tracker.record("a.e2e.ts", false);
-            expect(tracker.recoveredSpecs).to.deep.equal([]);
+        it("does not preserve the final failed attempt (no retries left)", () => {
+            expect(shouldPreserveFailedAttemptLogs(1, 0)).to.equal(false);
         });
+    });
 
-        it("tracks specs independently and lists each recovered one once", () => {
-            const tracker = new SpecRetryTracker();
-            tracker.record("a.e2e.ts", false);
-            tracker.record("a.e2e.ts", true);
-            tracker.record("b.e2e.ts", true);
-            tracker.record("c.e2e.ts", false);
-            tracker.record("c.e2e.ts", true);
-            expect(tracker.recoveredSpecs.sort()).to.deep.equal([
-                "a.e2e.ts",
-                "c.e2e.ts",
+    describe("failedAttemptLogRenames", () => {
+        it("parks the wdio and chromedriver logs for the worker's cid", () => {
+            expect(failedAttemptLogRenames("logs", "0-3")).to.deep.equal([
+                {
+                    from: path.join("logs", "wdio-0-3.log"),
+                    to: path.join("logs", "wdio-0-3-failed-attempt.log"),
+                },
+                {
+                    from: path.join("logs", "wdio-0-3-chromedriver.log"),
+                    to: path.join(
+                        "logs",
+                        "wdio-0-3-chromedriver-failed-attempt.log"
+                    ),
+                },
             ]);
         });
     });
@@ -291,6 +291,22 @@ describe("retry", () => {
                 "⚠️  PASSED ONLY ON RETRY (flaky — investigate):",
                 "  - a.e2e.ts",
                 "::warning::PASSED ONLY ON RETRY: a.e2e.ts",
+            ]);
+        });
+
+        it("shows the basename for an absolute path or file:// URL", () => {
+            expect(
+                formatRecoveredSpecsReport(
+                    [
+                        "file:///C:/a/eng-dev-ecosystem/ext/src/test/e2e/bundle_init.e2e.ts",
+                        "/home/runner/work/src/test/e2e/auth.e2e.ts",
+                    ],
+                    false
+                )
+            ).to.deep.equal([
+                "⚠️  PASSED ONLY ON RETRY (flaky — investigate):",
+                "  - bundle_init.e2e.ts",
+                "  - auth.e2e.ts",
             ]);
         });
     });

--- a/packages/databricks-vscode/src/test/retry.test.ts
+++ b/packages/databricks-vscode/src/test/retry.test.ts
@@ -1,5 +1,9 @@
 import {expect} from "chai";
-import {isTransientFileLockError, retryOnTransientError} from "./retry";
+import {
+    isTransientFileLockError,
+    retryOnTransientError,
+    specFileRetriesForPlatform,
+} from "./retry";
 
 // A pip failure Node's execFile surfaces: `.message` is only "Command failed:
 // <cmd>", while the diagnostic (the WinError line) lands in `.stderr`. The
@@ -199,6 +203,20 @@ describe("retry", () => {
                 {attempt: 1, message: "fail 1"},
                 {attempt: 2, message: "fail 2"},
             ]);
+        });
+    });
+
+    describe("specFileRetriesForPlatform", () => {
+        it("retries a whole spec once on Windows", () => {
+            expect(specFileRetriesForPlatform("win32")).to.equal(1);
+        });
+
+        it("does not retry on Linux", () => {
+            expect(specFileRetriesForPlatform("linux")).to.equal(0);
+        });
+
+        it("does not retry on macOS", () => {
+            expect(specFileRetriesForPlatform("darwin")).to.equal(0);
         });
     });
 });

--- a/packages/databricks-vscode/src/test/retry.test.ts
+++ b/packages/databricks-vscode/src/test/retry.test.ts
@@ -3,6 +3,7 @@ import {
     isTransientFileLockError,
     retryOnTransientError,
     specFileRetriesForPlatform,
+    SpecRetryTracker,
 } from "./retry";
 
 // A pip failure Node's execFile surfaces: `.message` is only "Command failed:
@@ -217,6 +218,49 @@ describe("retry", () => {
 
         it("does not retry on macOS", () => {
             expect(specFileRetriesForPlatform("darwin")).to.equal(0);
+        });
+    });
+
+    describe("SpecRetryTracker", () => {
+        it("does not flag a spec that passes on the first attempt", () => {
+            const tracker = new SpecRetryTracker();
+            tracker.record("a.e2e.ts", true);
+            expect(tracker.recoveredSpecs).to.deep.equal([]);
+        });
+
+        it("flags a spec that fails an attempt then passes", () => {
+            const tracker = new SpecRetryTracker();
+            tracker.record("a.e2e.ts", false);
+            tracker.record("a.e2e.ts", true);
+            expect(tracker.recoveredSpecs).to.deep.equal(["a.e2e.ts"]);
+        });
+
+        it("does not flag a spec that fails every attempt (a hard failure)", () => {
+            const tracker = new SpecRetryTracker();
+            tracker.record("a.e2e.ts", false);
+            tracker.record("a.e2e.ts", false);
+            expect(tracker.recoveredSpecs).to.deep.equal([]);
+        });
+
+        it("un-flags a spec that recovers then fails again", () => {
+            const tracker = new SpecRetryTracker();
+            tracker.record("a.e2e.ts", false);
+            tracker.record("a.e2e.ts", true);
+            tracker.record("a.e2e.ts", false);
+            expect(tracker.recoveredSpecs).to.deep.equal([]);
+        });
+
+        it("tracks specs independently and lists each recovered one once", () => {
+            const tracker = new SpecRetryTracker();
+            tracker.record("a.e2e.ts", false);
+            tracker.record("a.e2e.ts", true);
+            tracker.record("b.e2e.ts", true);
+            tracker.record("c.e2e.ts", false);
+            tracker.record("c.e2e.ts", true);
+            expect(tracker.recoveredSpecs.sort()).to.deep.equal([
+                "a.e2e.ts",
+                "c.e2e.ts",
+            ]);
         });
     });
 });

--- a/packages/databricks-vscode/src/test/retry.test.ts
+++ b/packages/databricks-vscode/src/test/retry.test.ts
@@ -251,11 +251,24 @@ describe("retry", () => {
     });
 
     describe("failedAttemptLogRenames", () => {
-        it("parks the wdio and chromedriver logs for the worker's cid", () => {
-            expect(failedAttemptLogRenames("logs", "0-3")).to.deep.equal([
+        // wdio names the runner log after the spec basename when a spec is
+        // present (@wdio/local-runner: `${specBaseName}-${cid}.log`), stripping
+        // only the final extension — so `bundle_init.e2e.ts` -> `bundle_init.e2e`.
+        // The chromedriver log keeps the `wdio-<cid>-` prefix (@wdio/utils).
+        it("parks the spec-named runner log and the chromedriver log", () => {
+            expect(
+                failedAttemptLogRenames(
+                    "logs",
+                    "0-3",
+                    "/x/y/bundle_init.e2e.ts"
+                )
+            ).to.deep.equal([
                 {
-                    from: path.join("logs", "wdio-0-3.log"),
-                    to: path.join("logs", "wdio-0-3-failed-attempt.log"),
+                    from: path.join("logs", "bundle_init.e2e-0-3.log"),
+                    to: path.join(
+                        "logs",
+                        "bundle_init.e2e-0-3-failed-attempt.log"
+                    ),
                 },
                 {
                     from: path.join("logs", "wdio-0-3-chromedriver.log"),
@@ -265,6 +278,16 @@ describe("retry", () => {
                     ),
                 },
             ]);
+        });
+
+        it("derives the spec basename from a file:// URL too", () => {
+            expect(
+                failedAttemptLogRenames(
+                    "logs",
+                    "0-0",
+                    "file:///C:/a/ext/src/test/e2e/auth.e2e.ts"
+                )[0].from
+            ).to.equal(path.join("logs", "auth.e2e-0-0.log"));
         });
     });
 

--- a/packages/databricks-vscode/src/test/retry.test.ts
+++ b/packages/databricks-vscode/src/test/retry.test.ts
@@ -4,6 +4,7 @@ import {
     retryOnTransientError,
     specFileRetriesForPlatform,
     SpecRetryTracker,
+    formatRecoveredSpecsReport,
 } from "./retry";
 
 // A pip failure Node's execFile surfaces: `.message` is only "Command failed:
@@ -242,6 +243,9 @@ describe("retry", () => {
             expect(tracker.recoveredSpecs).to.deep.equal([]);
         });
 
+        // Defensive: fail→pass→fail needs three attempts, which can't happen
+        // at specFileRetries=1 (a spec runs at most twice). This guards the
+        // recovered.delete branch for any future higher retry count.
         it("un-flags a spec that recovers then fails again", () => {
             const tracker = new SpecRetryTracker();
             tracker.record("a.e2e.ts", false);
@@ -260,6 +264,33 @@ describe("retry", () => {
             expect(tracker.recoveredSpecs.sort()).to.deep.equal([
                 "a.e2e.ts",
                 "c.e2e.ts",
+            ]);
+        });
+    });
+
+    describe("formatRecoveredSpecsReport", () => {
+        it("returns no lines when nothing recovered", () => {
+            expect(formatRecoveredSpecsReport([], false)).to.deep.equal([]);
+            expect(formatRecoveredSpecsReport([], true)).to.deep.equal([]);
+        });
+
+        it("lists recovered specs under a header without CI annotations", () => {
+            expect(
+                formatRecoveredSpecsReport(["a.e2e.ts", "b.e2e.ts"], false)
+            ).to.deep.equal([
+                "⚠️  PASSED ONLY ON RETRY (flaky — investigate):",
+                "  - a.e2e.ts",
+                "  - b.e2e.ts",
+            ]);
+        });
+
+        it("adds a ::warning:: workflow command per spec under GitHub Actions", () => {
+            expect(
+                formatRecoveredSpecsReport(["a.e2e.ts"], true)
+            ).to.deep.equal([
+                "⚠️  PASSED ONLY ON RETRY (flaky — investigate):",
+                "  - a.e2e.ts",
+                "::warning::PASSED ONLY ON RETRY: a.e2e.ts",
             ]);
         });
     });

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -87,17 +87,26 @@ export function shouldPreserveFailedAttemptLogs(
 }
 
 // The per-worker log files wdio truncates on retry, paired with a stable
-// `-failed-attempt` name to rename them to before the retry reopens them. See
-// `@wdio/local-runner` (wdio-<cid>.log) and `@wdio/utils`
-// (wdio-<cid>-chromedriver.log), both opened with flags:"w".
+// `-failed-attempt` name to rename them to before the retry reopens them. The
+// runner log is named after the spec basename when a spec is present
+// (`@wdio/local-runner`: `${specBaseName}-${cid}.log`, only the final extension
+// stripped); the driver log keeps the `wdio-<cid>-` prefix (`@wdio/utils`).
+// Both are opened with flags:"w".
 export function failedAttemptLogRenames(
     outputDir: string,
-    cid: string
+    cid: string,
+    spec: string
 ): {from: string; to: string}[] {
-    return [`wdio-${cid}.log`, `wdio-${cid}-chromedriver.log`].map((name) => ({
-        from: path.join(outputDir, name),
-        to: path.join(outputDir, name.replace(/\.log$/, "-failed-attempt.log")),
-    }));
+    const specBaseName = path.basename(spec, path.extname(spec));
+    return [`${specBaseName}-${cid}.log`, `wdio-${cid}-chromedriver.log`].map(
+        (name) => ({
+            from: path.join(outputDir, name),
+            to: path.join(
+                outputDir,
+                name.replace(/\.log$/, "-failed-attempt.log")
+            ),
+        })
+    );
 }
 
 // Formats the "passed only on retry" flake report for stdout. Under GitHub

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -3,6 +3,8 @@
 // unit build, so a colocated unit test only runs when the module lives outside
 // it; the e2e specs import it via an explicit `.ts` extension.
 
+import path from "node:path";
+
 export interface RetryOptions {
     // Total number of tries, including the first (so `attempts: 3` == 1 try + 2
     // retries).
@@ -61,30 +63,41 @@ export function specFileRetriesForPlatform(platform: NodeJS.Platform): number {
     return platform === "win32" ? 1 : 0;
 }
 
-// Tracks e2e spec outcomes across wdio's spec-file retries so a spec that only
-// passes on a retry — an otherwise-silent flake, since wdio reports the run as
-// green — can be surfaced at the end. `record` is called once per worker-end
-// (i.e. per attempt); `recoveredSpecs` lists specs that failed at least one
-// attempt but later passed. A spec that fails every attempt is a hard failure
-// wdio already reports, so it is deliberately not listed here.
-export class SpecRetryTracker {
-    private readonly failed = new Set<string>();
-    private readonly recovered = new Set<string>();
+// Seconds wdio waits before a spec-file retry (`specFileRetriesDelay`), per
+// platform. Windows-only, non-zero: the retry relaunches VS Code and reinstalls
+// the extension into the shared extensions dir while the crashed Electron and
+// its chromedriver are still exiting — the same Windows file-lock territory
+// isTransientFileLockError guards. A short pause lets them release first; it
+// costs nothing on the stable platforms (0) and only ever runs after a failure.
+export function specFileRetriesDelayForPlatform(
+    platform: NodeJS.Platform
+): number {
+    return platform === "win32" ? 5 : 0;
+}
 
-    record(spec: string, passed: boolean): void {
-        if (!passed) {
-            this.failed.add(spec);
-            this.recovered.delete(spec);
-            return;
-        }
-        if (this.failed.has(spec)) {
-            this.recovered.add(spec);
-        }
-    }
+// A retry reuses the failed worker's cid, so wdio reopens `wdio-<cid>.log` (and
+// the driver log) with flags:"w" and truncates the very crash we retried for.
+// True when a failed attempt is about to be requeued, i.e. worth parking those
+// logs first (wdio passes `retries` > 0 in that case).
+export function shouldPreserveFailedAttemptLogs(
+    exitCode: number,
+    retries: number
+): boolean {
+    return exitCode !== 0 && retries > 0;
+}
 
-    get recoveredSpecs(): string[] {
-        return [...this.recovered];
-    }
+// The per-worker log files wdio truncates on retry, paired with a stable
+// `-failed-attempt` name to rename them to before the retry reopens them. See
+// `@wdio/local-runner` (wdio-<cid>.log) and `@wdio/utils`
+// (wdio-<cid>-chromedriver.log), both opened with flags:"w".
+export function failedAttemptLogRenames(
+    outputDir: string,
+    cid: string
+): {from: string; to: string}[] {
+    return [`wdio-${cid}.log`, `wdio-${cid}-chromedriver.log`].map((name) => ({
+        from: path.join(outputDir, name),
+        to: path.join(outputDir, name.replace(/\.log$/, "-failed-attempt.log")),
+    }));
 }
 
 // Formats the "passed only on retry" flake report for stdout. Under GitHub
@@ -101,9 +114,12 @@ export function formatRecoveredSpecsReport(
     }
     const lines = ["⚠️  PASSED ONLY ON RETRY (flaky — investigate):"];
     for (const spec of recoveredSpecs) {
-        lines.push(`  - ${spec}`);
+        // wdio hands us an absolute path / file:// URL; the basename reads
+        // better and is enough to identify the spec. Split on both separators.
+        const name = spec.split(/[\\/]/).pop() ?? spec;
+        lines.push(`  - ${name}`);
         if (isGithubActions) {
-            lines.push(`::warning::PASSED ONLY ON RETRY: ${spec}`);
+            lines.push(`::warning::PASSED ONLY ON RETRY: ${name}`);
         }
     }
     return lines;

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -87,6 +87,28 @@ export class SpecRetryTracker {
     }
 }
 
+// Formats the "passed only on retry" flake report for stdout. Under GitHub
+// Actions (`isGithubActions`) it also emits a `::warning::` workflow command per
+// spec, so a retry-recovered flake shows as a checks-UI annotation even when the
+// run is green — otherwise the warning would just scroll past in a passing log,
+// defeating the point of tracking it. Returns [] when nothing recovered.
+export function formatRecoveredSpecsReport(
+    recoveredSpecs: string[],
+    isGithubActions: boolean
+): string[] {
+    if (recoveredSpecs.length === 0) {
+        return [];
+    }
+    const lines = ["⚠️  PASSED ONLY ON RETRY (flaky — investigate):"];
+    for (const spec of recoveredSpecs) {
+        lines.push(`  - ${spec}`);
+        if (isGithubActions) {
+            lines.push(`::warning::PASSED ONLY ON RETRY: ${spec}`);
+        }
+    }
+    return lines;
+}
+
 export async function retryOnTransientError<T>(
     operation: () => Promise<T>,
     options: RetryOptions

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -48,6 +48,19 @@ export function isTransientFileLockError(error: unknown): boolean {
     );
 }
 
+// How many times wdio re-runs a whole spec file that fails as a whole
+// (`specFileRetries`). Windows-only, because its e2e shards hit whole-session
+// crashes no in-test wait can recover: a VS Code window reload (e.g. opening a
+// freshly initialized bundle) can drop the wdio<->VS Code websocket with
+// "Connection closed. Code: 1006", killing the session so every remaining test
+// in the spec cascades. Only a fresh session recovers, which is exactly what a
+// spec-file retry starts. Linux/macOS stay at 0 so a real regression there
+// fails fast instead of being masked, and CI time isn't doubled on the stable
+// platforms.
+export function specFileRetriesForPlatform(platform: NodeJS.Platform): number {
+    return platform === "win32" ? 1 : 0;
+}
+
 export async function retryOnTransientError<T>(
     operation: () => Promise<T>,
     options: RetryOptions

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -48,13 +48,43 @@ export function isTransientFileLockError(error: unknown): boolean {
     );
 }
 
-// wdio `specFileRetries` count per platform. Windows-only: its e2e shards hit
-// whole-session crashes no in-test wait can recover — a VS Code window reload
-// can drop the wdio websocket ("Connection closed. Code: 1006"), so the rest of
-// the spec cascades and only a fresh session (which a retry starts) recovers.
-// Others stay at 0 so a real regression there isn't masked.
+// wdio `specFileRetries` count per platform. Windows-only, because its e2e
+// shards hit whole-session crashes no in-test wait can recover — a VS Code
+// window reload can drop the wdio websocket ("Connection closed. Code: 1006"),
+// so the rest of the spec cascades and only a fresh session (which a retry
+// starts) recovers. Note the retry fires on *any* whole-spec failure, not just
+// that crash — wdio has no retry-on-specific-error hook. A deterministic
+// regression still fails on both attempts; a *flaky* one can pass on retry, so
+// SpecRetryTracker surfaces those (see wdio.conf.ts) rather than letting them go
+// silently green. Others stay at 0 so a real regression there isn't masked.
 export function specFileRetriesForPlatform(platform: NodeJS.Platform): number {
     return platform === "win32" ? 1 : 0;
+}
+
+// Tracks e2e spec outcomes across wdio's spec-file retries so a spec that only
+// passes on a retry — an otherwise-silent flake, since wdio reports the run as
+// green — can be surfaced at the end. `record` is called once per worker-end
+// (i.e. per attempt); `recoveredSpecs` lists specs that failed at least one
+// attempt but later passed. A spec that fails every attempt is a hard failure
+// wdio already reports, so it is deliberately not listed here.
+export class SpecRetryTracker {
+    private readonly failed = new Set<string>();
+    private readonly recovered = new Set<string>();
+
+    record(spec: string, passed: boolean): void {
+        if (!passed) {
+            this.failed.add(spec);
+            this.recovered.delete(spec);
+            return;
+        }
+        if (this.failed.has(spec)) {
+            this.recovered.add(spec);
+        }
+    }
+
+    get recoveredSpecs(): string[] {
+        return [...this.recovered];
+    }
 }
 
 export async function retryOnTransientError<T>(

--- a/packages/databricks-vscode/src/test/retry.ts
+++ b/packages/databricks-vscode/src/test/retry.ts
@@ -48,15 +48,11 @@ export function isTransientFileLockError(error: unknown): boolean {
     );
 }
 
-// How many times wdio re-runs a whole spec file that fails as a whole
-// (`specFileRetries`). Windows-only, because its e2e shards hit whole-session
-// crashes no in-test wait can recover: a VS Code window reload (e.g. opening a
-// freshly initialized bundle) can drop the wdio<->VS Code websocket with
-// "Connection closed. Code: 1006", killing the session so every remaining test
-// in the spec cascades. Only a fresh session recovers, which is exactly what a
-// spec-file retry starts. Linux/macOS stay at 0 so a real regression there
-// fails fast instead of being masked, and CI time isn't doubled on the stable
-// platforms.
+// wdio `specFileRetries` count per platform. Windows-only: its e2e shards hit
+// whole-session crashes no in-test wait can recover — a VS Code window reload
+// can drop the wdio websocket ("Connection closed. Code: 1006"), so the rest of
+// the spec cascades and only a fresh session (which a retry starts) recovers.
+// Others stay at 0 so a real regression there isn't masked.
 export function specFileRetriesForPlatform(platform: NodeJS.Platform): number {
     return platform === "win32" ? 1 : 0;
 }


### PR DESCRIPTION
## Why

On the slow Windows e2e shards, a VS Code **window reload** — e.g. opening a freshly initialized bundle in `bundle_init.e2e.ts` — can drop the wdio↔VS Code websocket with `Connection closed. Code: 1006`. That kills the whole session, so every remaining test in the spec cascades into `target window already closed` / `web view not found`. It was the failure on PR #2130's IT run and recurs across nightlies as a bystander flake.

This whole-session crash is **unrecoverable from inside the test**: no added wait or `try/catch` helps once the session is dead (the earlier per-`waitUntil` hardening in #2056/#2123 addresses a different class — transient element races within a live session). The only recovery is a fresh session, which is exactly what a spec-file retry starts.

`wdio`'s `specFileRetries` was `0`, so this class of infra flake was an instant hard failure with no recovery.

## What

- Set `specFileRetries` to re-run a whole spec **once, Windows-only**, via a small `specFileRetriesForPlatform(platform)` helper in `src/test/retry.ts`.
- Linux/macOS stay at `0` so a real regression there fails fast instead of being masked, and CI time isn't doubled on the stable platforms.
- Each CI shard already runs a single spec file, so a retry re-runs that spec in a fresh VS Code session within the same job and reports green if it recovers.

## Tradeoff

Blanket spec retry can mask a reproducible-once real failure. Scoping to Windows + a single retry keeps that risk small while covering the observed crash class.

## Verification

- `yarn test:unit` — 845 passing, 0 failing (includes the new helper tests).
- `eslint` + `prettier -c` clean on the changed files.

This pull request and its description were written by Isaac.