### PR TITLE
Avoid duplicate profile section creation in .databrickscfg during OAuth setup

### DIFF
--- a/packages/databricks-vscode/src/configuration/LoginWizard.test.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.test.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {expect} from "chai";
+import * as tmp from "tmp";
+import path from "node:path";
+import {readFileSync, writeFileSync} from "node:fs";
+import ini from "ini";
+import {instance, mock} from "ts-mockito";
+import {saveNewProfile} from "./LoginWizard";
+import {DatabricksCliAuthProvider} from "./auth/AuthProvider";
+import {CliWrapper} from "../cli/CliWrapper";
+
+describe("saveNewProfile", () => {
+    const host = new URL("https://test.cloud.databricks.com/");
+    const cliPath = "/path/to/bin/databricks";
+    const cleanups: Array<() => void> = [];
+    let previousConfigFile: string | undefined;
+
+    beforeEach(() => {
+        previousConfigFile = process.env.DATABRICKS_CONFIG_FILE;
+    });
+
+    afterEach(() => {
+        if (previousConfigFile === undefined) {
+            delete process.env.DATABRICKS_CONFIG_FILE;
+        } else {
+            process.env.DATABRICKS_CONFIG_FILE = previousConfigFile;
+        }
+        while (cleanups.length) {
+            cleanups.pop()!();
+        }
+    });
+
+    function tempConfigFile(contents?: string): string {
+        const dir = tmp.dirSync({unsafeCleanup: true});
+        cleanups.push(dir.removeCallback);
+        const file = path.join(dir.name, ".databrickscfg");
+        if (contents !== undefined) {
+            writeFileSync(file, contents);
+        }
+        process.env.DATABRICKS_CONFIG_FILE = file;
+        return file;
+    }
+
+    function oauthProvider(profile: string) {
+        return new DatabricksCliAuthProvider(
+            host,
+            cliPath,
+            instance(mock(CliWrapper)),
+            profile
+        );
+    }
+
+    function countSections(file: string, name: string): number {
+        // ini.parse collapses duplicate sections, so count the raw headers.
+        const headerRegex = new RegExp(
+            `^\\[${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\]\\s*$`,
+            "gm"
+        );
+        return (readFileSync(file, "utf-8").match(headerRegex) ?? []).length;
+    }
+
+    it("does not append a duplicate section when the CLI already wrote the profile", async () => {
+        // Simulate the section the Databricks CLI's `auth login --profile`
+        // persists during the auth check (databricks-vscode#2129).
+        const file = tempConfigFile(
+            ini.stringify({
+                "dev-profile": {
+                    host: host.toString(),
+                    auth_type: "databricks-cli",
+                },
+            })
+        );
+
+        await saveNewProfile(
+            "dev-profile",
+            oauthProvider("dev-profile"),
+            instance(mock(CliWrapper))
+        );
+
+        expect(countSections(file, "dev-profile")).to.equal(1);
+    });
+
+    it("appends the profile when no section exists yet", async () => {
+        const file = tempConfigFile(
+            ini.stringify({
+                other: {host: host.toString(), auth_type: "databricks-cli"},
+            })
+        );
+
+        await saveNewProfile(
+            "dev-profile",
+            oauthProvider("dev-profile"),
+            instance(mock(CliWrapper))
+        );
+
+        expect(countSections(file, "dev-profile")).to.equal(1);
+        const parsed = ini.parse(readFileSync(file, "utf-8"));
+        expect(parsed).to.have.property("dev-profile");
+        expect(parsed).to.have.property("other");
+    });
+});

--- a/packages/databricks-vscode/src/configuration/LoginWizard.ts
+++ b/packages/databricks-vscode/src/configuration/LoginWizard.ts
@@ -24,7 +24,7 @@ import {FileUtils, UrlUtils} from "../utils";
 import {AuthType as SdkAuthType} from "@databricks/sdk-experimental";
 import {randomUUID} from "crypto";
 import ini from "ini";
-import {appendFile, copyFile} from "fs/promises";
+import {appendFile, copyFile, readFile} from "fs/promises";
 import path from "path";
 import os from "os";
 import {createFile} from "fs-extra";
@@ -392,6 +392,19 @@ export async function saveNewProfile(
         window.showInformationMessage(
             `Created a new .databrickscfg file at ${configFilePath}`
         );
+    }
+
+    // The Databricks CLI's `auth login --profile <name>` (run during the auth
+    // check for databricks-cli/OAuth profiles) already persists the profile
+    // section itself. Appending our own copy on top of that would create a
+    // second [<name>] section, which is invalid for configparser/SDK consumers
+    // and fails with DuplicateSectionError (databricks-vscode#2129). If the CLI
+    // already wrote the section, reuse it instead of appending a duplicate.
+    if (shouldBackup) {
+        const existing = ini.parse(await readFile(configFilePath, "utf-8"));
+        if (Object.prototype.hasOwnProperty.call(existing, profileName)) {
+            return await ProfileAuthProvider.from(profileName, cli, true);
+        }
     }
 
     const profile: any = {};


### PR DESCRIPTION
## Changes

## Root cause

Creating a profile through the **OAuth – Create a profile and authenticate using
OAuth** flow wrote **two** identically-named sections into `~/.databrickscfg`
(e.g. two `[dev-profile]` blocks). A file with duplicate sections is invalid for
consumers using Python's `configparser` — including the Databricks SDK — which
fail to load it with `configparser.DuplicateSectionError`.

Fixes #2129.

## Root cause

`saveNewProfile` (`packages/databricks-vscode/src/configuration/LoginWizard.ts`)
runs two independent writes for the `databricks-cli` (OAuth) auth type:

1. The auth check (`checkAuthProvider` → `DatabricksCliCheck.login`) runs
   `databricks auth login --host <host> --profile <name>`, and **the CLI itself
   persists the `[<name>]` section**.
2. `saveNewProfile` then **unconditionally appended a second `[<name>]` section**
   (prefixed with the `;This profile is autogenerated…` comment).

The existing duplicate-name guard in the wizard runs *before* the CLI login, so
it never sees the section the CLI just wrote. This double-write only affects the
OAuth provider — for PAT and Azure CLI the CLI does not persist the profile, so
the extension's append is still required.

## Fix

Before appending, `saveNewProfile` now parses the config file and, if a section
with the target profile name already exists, reuses it instead of appending a
duplicate. This matches the issue's suggested "reuse the existing section rather
than append another" behavior. It's safe for the other callers: the wizard
already rejects existing names at input time, and bundle migration uses random
`${authType}-${rnd}` names.

## Tests

LoginWizard.test.ts
