### PR TITLE
test(packaging): unit-test bundled-CLI version logic, isolate the real-binary smoke test

### DIFF
--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -165,10 +165,18 @@ describe(__filename, () => {
                 false
             );
         });
+
+        it("is not a mismatch when both versions are unknown", () => {
+            assert.equal(
+                isBundledCliVersionMismatch(undefined, undefined),
+                false
+            );
+        });
     });
 
-    // Logic-only checkBundledCliVersion paths that return before spawning the
-    // CLI — safe to keep in the unit suite.
+    // checkBundledCliVersion paths that never launch the real bundled CLI —
+    // they hit the dev-flag / unpinned gate, or fail fast on a missing binary —
+    // so they stay fast in the unit suite.
     describe("checkBundledCliVersion gating", () => {
         const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
         afterEach(() => {
@@ -193,10 +201,13 @@ describe(__filename, () => {
         it("does not warn when the pinned version is unknown", async () => {
             process.env[EXTENSION_DEVELOPMENT] = "true";
             assert.ok(
-                await checkBundledCliVersion("/nonexistent/databricks", {
-                    packageName: "databricks",
-                    version: "2.13.0",
-                })
+                await checkBundledCliVersion(
+                    path.join(__dirname, "nonexistent-databricks"),
+                    {
+                        packageName: "databricks",
+                        version: "2.13.0",
+                    }
+                )
             );
         });
 

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -9,7 +9,6 @@ import {
     getBundledCliVersion,
     getCorrectVsixInstallString,
     getMetadata,
-    isBundledCliVersionMismatch,
     isCompatibleArchitecture,
     isEqual,
     nodeArchMap,
@@ -29,6 +28,19 @@ const cliPath = path.join(
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pinnedCliVersion = require("../../package.json").cli.version;
+
+// Restores EXTENSION_DEVELOPMENT after each test in the enclosing describe, so a
+// suite that toggles the dev flag can't leak it into the rest of the run.
+function restoreDevFlagAfterEach() {
+    const original = process.env[EXTENSION_DEVELOPMENT];
+    afterEach(() => {
+        if (original === undefined) {
+            delete process.env[EXTENSION_DEVELOPMENT];
+        } else {
+            process.env[EXTENSION_DEVELOPMENT] = original;
+        }
+    });
+}
 
 describe(__filename, () => {
     it("should correctly check compatibility", () => {
@@ -137,55 +149,11 @@ describe(__filename, () => {
         });
     });
 
-    describe("isBundledCliVersionMismatch", () => {
-        it("flags two known versions that differ", () => {
-            assert.equal(
-                isBundledCliVersionMismatch("0.240.0", "0.241.0"),
-                true
-            );
-        });
-
-        it("is not a mismatch when the versions match", () => {
-            assert.equal(
-                isBundledCliVersionMismatch("0.240.0", "0.240.0"),
-                false
-            );
-        });
-
-        it("is not a mismatch when the actual version is unknown", () => {
-            assert.equal(
-                isBundledCliVersionMismatch(undefined, "0.240.0"),
-                false
-            );
-        });
-
-        it("is not a mismatch when the expected version is unpinned", () => {
-            assert.equal(
-                isBundledCliVersionMismatch("0.240.0", undefined),
-                false
-            );
-        });
-
-        it("is not a mismatch when both versions are unknown", () => {
-            assert.equal(
-                isBundledCliVersionMismatch(undefined, undefined),
-                false
-            );
-        });
-    });
-
     // checkBundledCliVersion paths that never launch the real bundled CLI —
     // they hit the dev-flag / unpinned gate, or fail fast on a missing binary —
     // so they stay fast in the unit suite.
     describe("checkBundledCliVersion gating", () => {
-        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
-        afterEach(() => {
-            if (originalDevFlag === undefined) {
-                delete process.env[EXTENSION_DEVELOPMENT];
-            } else {
-                process.env[EXTENSION_DEVELOPMENT] = originalDevFlag;
-            }
-        });
+        restoreDevFlagAfterEach();
 
         it("does not warn outside a dev checkout (no CLI spawn)", async () => {
             delete process.env[EXTENSION_DEVELOPMENT];
@@ -223,22 +191,15 @@ describe(__filename, () => {
 
     // Smoke tests: these spawn the REAL bundled CLI that CI fetches at the
     // pinned version, so they validate the `package:cli:fetch` step, not unit
-    // logic (the version parsing/compare is unit-tested above). Cold-spawning a
+    // logic (the version parsing is unit-tested above). Cold-spawning a
     // ~50MB binary on the Windows runner exceeds the 2s mocha default, so give
     // the suite a generous timeout — the default made this flake intermittently.
     describe("bundled CLI (smoke — spawns the real fetched binary)", function () {
         this.timeout(30_000);
 
-        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
+        restoreDevFlagAfterEach();
         beforeEach(() => {
             process.env[EXTENSION_DEVELOPMENT] = "true";
-        });
-        afterEach(() => {
-            if (originalDevFlag === undefined) {
-                delete process.env[EXTENSION_DEVELOPMENT];
-            } else {
-                process.env[EXTENSION_DEVELOPMENT] = originalDevFlag;
-            }
         });
 
         it("reports the pinned version", async () => {

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -9,10 +9,12 @@ import {
     getBundledCliVersion,
     getCorrectVsixInstallString,
     getMetadata,
+    isBundledCliVersionMismatch,
     isCompatibleArchitecture,
     isEqual,
     nodeArchMap,
     nodeOsMap,
+    parseCliVersion,
     vsixArchMap,
 } from "./packageJsonUtils";
 import {EXTENSION_DEVELOPMENT} from "./developmentUtils";
@@ -116,13 +118,59 @@ describe(__filename, () => {
         });
     });
 
-    describe("bundled CLI version", () => {
-        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
-
-        beforeEach(() => {
-            process.env[EXTENSION_DEVELOPMENT] = "true";
+    describe("parseCliVersion", () => {
+        it("reads the Version field from `databricks version --output json`", () => {
+            assert.equal(parseCliVersion('{"Version": "0.240.0"}'), "0.240.0");
         });
 
+        it("returns undefined when Version is missing", () => {
+            assert.equal(parseCliVersion('{"foo": "bar"}'), undefined);
+        });
+
+        it("returns undefined when Version is not a string", () => {
+            assert.equal(parseCliVersion('{"Version": 240}'), undefined);
+        });
+
+        it("returns undefined on malformed JSON", () => {
+            assert.equal(parseCliVersion("not json"), undefined);
+            assert.equal(parseCliVersion(""), undefined);
+        });
+    });
+
+    describe("isBundledCliVersionMismatch", () => {
+        it("flags two known versions that differ", () => {
+            assert.equal(
+                isBundledCliVersionMismatch("0.240.0", "0.241.0"),
+                true
+            );
+        });
+
+        it("is not a mismatch when the versions match", () => {
+            assert.equal(
+                isBundledCliVersionMismatch("0.240.0", "0.240.0"),
+                false
+            );
+        });
+
+        it("is not a mismatch when the actual version is unknown", () => {
+            assert.equal(
+                isBundledCliVersionMismatch(undefined, "0.240.0"),
+                false
+            );
+        });
+
+        it("is not a mismatch when the expected version is unpinned", () => {
+            assert.equal(
+                isBundledCliVersionMismatch("0.240.0", undefined),
+                false
+            );
+        });
+    });
+
+    // Logic-only checkBundledCliVersion paths that return before spawning the
+    // CLI — safe to keep in the unit suite.
+    describe("checkBundledCliVersion gating", () => {
+        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
         afterEach(() => {
             if (originalDevFlag === undefined) {
                 delete process.env[EXTENSION_DEVELOPMENT];
@@ -131,31 +179,7 @@ describe(__filename, () => {
             }
         });
 
-        it("should read the version the bundled CLI reports", async () => {
-            assert.equal(await getBundledCliVersion(cliPath), pinnedCliVersion);
-        });
-
-        it("should accept a CLI matching the pinned version", async () => {
-            assert.ok(
-                await checkBundledCliVersion(cliPath, {
-                    packageName: "databricks",
-                    version: "2.13.0",
-                    cliVersion: pinnedCliVersion,
-                })
-            );
-        });
-
-        it("should detect a stale CLI", async () => {
-            assert.ok(
-                !(await checkBundledCliVersion(cliPath, {
-                    packageName: "databricks",
-                    version: "2.13.0",
-                    cliVersion: `${pinnedCliVersion}-not-the-bundled-version`,
-                }))
-            );
-        });
-
-        it("should not warn outside a dev checkout", async () => {
+        it("does not warn outside a dev checkout (no CLI spawn)", async () => {
             delete process.env[EXTENSION_DEVELOPMENT];
             assert.ok(
                 await checkBundledCliVersion(cliPath, {
@@ -166,7 +190,17 @@ describe(__filename, () => {
             );
         });
 
-        it("should return undefined for a missing binary", async () => {
+        it("does not warn when the pinned version is unknown", async () => {
+            process.env[EXTENSION_DEVELOPMENT] = "true";
+            assert.ok(
+                await checkBundledCliVersion("/nonexistent/databricks", {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                })
+            );
+        });
+
+        it("returns undefined for a missing binary", async () => {
             assert.equal(
                 await getBundledCliVersion(
                     path.join(__dirname, "nonexistent-databricks")
@@ -174,13 +208,49 @@ describe(__filename, () => {
                 undefined
             );
         });
+    });
 
-        it("should not warn when the pinned version is unknown", async () => {
+    // Smoke tests: these spawn the REAL bundled CLI that CI fetches at the
+    // pinned version, so they validate the `package:cli:fetch` step, not unit
+    // logic (the version parsing/compare is unit-tested above). Cold-spawning a
+    // ~50MB binary on the Windows runner exceeds the 2s mocha default, so give
+    // the suite a generous timeout — the default made this flake intermittently.
+    describe("bundled CLI (smoke — spawns the real fetched binary)", function () {
+        this.timeout(30_000);
+
+        const originalDevFlag = process.env[EXTENSION_DEVELOPMENT];
+        beforeEach(() => {
+            process.env[EXTENSION_DEVELOPMENT] = "true";
+        });
+        afterEach(() => {
+            if (originalDevFlag === undefined) {
+                delete process.env[EXTENSION_DEVELOPMENT];
+            } else {
+                process.env[EXTENSION_DEVELOPMENT] = originalDevFlag;
+            }
+        });
+
+        it("reports the pinned version", async () => {
+            assert.equal(await getBundledCliVersion(cliPath), pinnedCliVersion);
+        });
+
+        it("is accepted as matching the pinned version", async () => {
             assert.ok(
-                await checkBundledCliVersion("/nonexistent/databricks", {
+                await checkBundledCliVersion(cliPath, {
                     packageName: "databricks",
                     version: "2.13.0",
+                    cliVersion: pinnedCliVersion,
                 })
+            );
+        });
+
+        it("is flagged as stale against a different pinned version", async () => {
+            assert.ok(
+                !(await checkBundledCliVersion(cliPath, {
+                    packageName: "databricks",
+                    version: "2.13.0",
+                    cliVersion: `${pinnedCliVersion}-not-the-bundled-version`,
+                }))
             );
         });
     });

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.test.ts
@@ -187,6 +187,22 @@ describe(__filename, () => {
                 undefined
             );
         });
+
+        it("does not warn when the CLI version can't be read but a version is pinned", async () => {
+            // Dev checkout with a pinned version, but the CLI is unreadable —
+            // the actual version is unknown, so we must not warn (nor throw).
+            process.env[EXTENSION_DEVELOPMENT] = "true";
+            assert.ok(
+                await checkBundledCliVersion(
+                    path.join(__dirname, "nonexistent-databricks"),
+                    {
+                        packageName: "databricks",
+                        version: "2.13.0",
+                        cliVersion: "0.240.0",
+                    }
+                )
+            );
+        });
     });
 
     // Smoke tests: these spawn the REAL bundled CLI that CI fetches at the

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -98,6 +98,31 @@ export async function getMetadata(
  * callers treat that as "unknown" rather than as a mismatch, since a missing
  * binary already fails loudly elsewhere.
  */
+// Extracts the "Version" string from `databricks version --output json` stdout.
+// Returns undefined on malformed JSON or a missing/non-string field, so callers
+// treat an unreadable version the same as an absent one. Pure — unit-tested
+// without spawning the CLI (getBundledCliVersion is the thin process wrapper).
+export function parseCliVersion(stdout: string): string | undefined {
+    try {
+        const version = JSON.parse(stdout)["Version"];
+        return typeof version === "string" ? version : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+// True only when both versions are known and differ — the case worth warning
+// about. An unknown actual (CLI unreadable) or unknown expected (unpinned) is
+// deliberately not a mismatch. Pure — unit-tested without spawning the CLI.
+export function isBundledCliVersionMismatch(
+    actual: string | undefined,
+    expected: string | undefined
+): boolean {
+    return (
+        actual !== undefined && expected !== undefined && actual !== expected
+    );
+}
+
 export async function getBundledCliVersion(
     cliPath: string
 ): Promise<string | undefined> {
@@ -107,8 +132,7 @@ export async function getBundledCliVersion(
             "--output",
             "json",
         ]);
-        const version = JSON.parse(stdout)["Version"];
-        return typeof version === "string" ? version : undefined;
+        return parseCliVersion(stdout);
     } catch (e) {
         logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
             "Failed to read the bundled Databricks CLI version",
@@ -166,7 +190,7 @@ export async function checkBundledCliVersion(
     }
 
     const actual = await getBundledCliVersion(cliPath);
-    if (actual === undefined || actual === metaData.cliVersion) {
+    if (!isBundledCliVersionMismatch(actual, metaData.cliVersion)) {
         return true;
     }
 

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -91,10 +91,8 @@ export async function getMetadata(
     };
 }
 
-// Extracts the "Version" string from `databricks version --output json` stdout.
-// Returns undefined on malformed JSON or a missing/non-string field, so callers
-// treat an unreadable version the same as an absent one. Pure — unit-tested
-// without spawning the CLI (getBundledCliVersion is the thin process wrapper).
+// Returns undefined on unparseable output so callers treat an unreadable version
+// the same as an absent one.
 export function parseCliVersion(stdout: string): string | undefined {
     try {
         const version = JSON.parse(stdout)["Version"];
@@ -104,24 +102,9 @@ export function parseCliVersion(stdout: string): string | undefined {
     }
 }
 
-// True only when both versions are known and differ — the case worth warning
-// about. An unknown actual (CLI unreadable) or unknown expected (unpinned) is
-// deliberately not a mismatch. Pure — unit-tested without spawning the CLI.
-export function isBundledCliVersionMismatch(
-    actual: string | undefined,
-    expected: string | undefined
-): boolean {
-    return (
-        actual !== undefined && expected !== undefined && actual !== expected
-    );
-}
-
 /**
- * Reads the version of the CLI binary bundled at `cliPath`.
- *
- * Returns undefined when the binary is missing or its output can't be parsed —
- * callers treat that as "unknown" rather than as a mismatch, since a missing
- * binary already fails loudly elsewhere. Both failure modes log at debug.
+ * Reads the version of the CLI binary bundled at `cliPath`, or undefined when it's
+ * missing or unreadable — callers treat that as "unknown" rather than a mismatch.
  */
 export async function getBundledCliVersion(
     cliPath: string
@@ -136,7 +119,7 @@ export async function getBundledCliVersion(
         if (version === undefined) {
             logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
                 "Bundled Databricks CLI version output was unparseable",
-                {stdout}
+                {stdout: stdout.slice(0, 200)}
             );
         }
         return version;
@@ -196,8 +179,10 @@ export async function checkBundledCliVersion(
         return true;
     }
 
+    // An unknown version (CLI unreadable) is treated as "not stale"; the gate
+    // above guarantees metaData.cliVersion is defined here.
     const actual = await getBundledCliVersion(cliPath);
-    if (!isBundledCliVersionMismatch(actual, metaData.cliVersion)) {
+    if (actual === undefined || actual === metaData.cliVersion) {
         return true;
     }
 

--- a/packages/databricks-vscode/src/utils/packageJsonUtils.ts
+++ b/packages/databricks-vscode/src/utils/packageJsonUtils.ts
@@ -91,13 +91,6 @@ export async function getMetadata(
     };
 }
 
-/**
- * Reads the version of the CLI binary bundled at `cliPath`.
- *
- * Returns undefined when the binary is missing or its output can't be parsed —
- * callers treat that as "unknown" rather than as a mismatch, since a missing
- * binary already fails loudly elsewhere.
- */
 // Extracts the "Version" string from `databricks version --output json` stdout.
 // Returns undefined on malformed JSON or a missing/non-string field, so callers
 // treat an unreadable version the same as an absent one. Pure — unit-tested
@@ -123,6 +116,13 @@ export function isBundledCliVersionMismatch(
     );
 }
 
+/**
+ * Reads the version of the CLI binary bundled at `cliPath`.
+ *
+ * Returns undefined when the binary is missing or its output can't be parsed —
+ * callers treat that as "unknown" rather than as a mismatch, since a missing
+ * binary already fails loudly elsewhere. Both failure modes log at debug.
+ */
 export async function getBundledCliVersion(
     cliPath: string
 ): Promise<string | undefined> {
@@ -132,7 +132,14 @@ export async function getBundledCliVersion(
             "--output",
             "json",
         ]);
-        return parseCliVersion(stdout);
+        const version = parseCliVersion(stdout);
+        if (version === undefined) {
+            logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
+                "Bundled Databricks CLI version output was unparseable",
+                {stdout}
+            );
+        }
+        return version;
     } catch (e) {
         logging.NamedLogger.getOrCreate(Loggers.Extension).debug(
             "Failed to read the bundled Databricks CLI version",


### PR DESCRIPTION
## Why

The `bundled CLI version` tests in `packageJsonUtils.test.ts` spawned the **real ~50 MB `databricks` CLI** under mocha's **2 s default timeout**. On the slow Windows unit runner, the first cold spawn (AV scan + cold FS cache) intermittently exceeded 2 s → `Timeout of 2000ms exceeded`. It's a genuine flake — the same untouched file alternated pass/fail across recent commits (Linux always passes; it spawns faster).

Spawning the real CLI from a unit test is itself established here (`CliWrapper.test.ts:63` does the same, and it already carries a 10 s timeout), so the fix is a timeout bump plus an extraction that gives the version parse real coverage without spawning — not a relabel.

## What

- Raised the timeout on the real-binary assertions to **30 s** and grouped them into a clearly-labeled **smoke** describe — they validate the `package:cli:fetch` step (the "re-fetch the CLI" pitfall), not unit logic. Non-spawning gate paths (dev-checkout gate, unpinned version, missing binary) stay as fast unit tests.
- Extracted `parseCliVersion(stdout)` — the `databricks version --output json` → `Version` parse (undefined on malformed/missing/non-string) — and unit-tested it **without spawning**. `getBundledCliVersion` delegates to it and logs a (capped) debug line when the output is unparseable.
- `checkBundledCliVersion` keeps its behavior: an unknown version (CLI unreadable) is treated as "not stale", and the dev-checkout / unpinned gate short-circuits before any spawn.

Net: the version parse gets real, fast, deterministic unit coverage; the one honest real-binary check is isolated and no longer flakes on the 2 s default.

## Verification

- `yarn test:unit` — 862 passing, 0 failing (the new `parseCliVersion` units + the smoke describe with the fetched binary).
- `eslint` + `prettier` clean.

This pull request and its description were written by Isaac.