### PR TITLE
test: set a 5s repo-wide unit-suite timeout floor

### DIFF
--- a/packages/databricks-vscode/src/test/suite.ts
+++ b/packages/databricks-vscode/src/test/suite.ts
@@ -7,10 +7,8 @@ export async function run(): Promise<void> {
     const mocha = new Mocha({
         ui: "bdd",
         color: true,
-        // Cold CI runners (AV scan + cold FS cache) push a test's first real
-        // I/O past mocha's 2s default, flaking whichever spawn test the glob
-        // happens to run first. 5s is the repo-wide floor; tests that spawn the
-        // real CLI still set their own higher timeout (see CliWrapper.test.ts).
+        // Cold CI runners push a test's first real I/O past mocha's 2s default;
+        // 5s is the repo-wide floor. Per-suite this.timeout() still overrides it.
         timeout: 5000,
     });
 

--- a/packages/databricks-vscode/src/test/suite.ts
+++ b/packages/databricks-vscode/src/test/suite.ts
@@ -7,6 +7,11 @@ export async function run(): Promise<void> {
     const mocha = new Mocha({
         ui: "bdd",
         color: true,
+        // Cold CI runners (AV scan + cold FS cache) push a test's first real
+        // I/O past mocha's 2s default, flaking whichever spawn test the glob
+        // happens to run first. 5s is the repo-wide floor; tests that spawn the
+        // real CLI still set their own higher timeout (see CliWrapper.test.ts).
+        timeout: 5000,
     });
 
     // Add files to the test suite

--- a/packages/databricks-vscode/src/utils/shellUtils.test.ts
+++ b/packages/databricks-vscode/src/utils/shellUtils.test.ts
@@ -563,8 +563,8 @@ describe("shellUtils", () => {
         }
 
         describe("cmd", function () {
-            // Each case spawns cmd.exe and writes a temp file, so the 2s default
-            // is too tight on a loaded Windows runner.
+            // Each case spawns cmd.exe and writes a temp file, so the default
+            // timeout is too tight on a loaded Windows runner.
             this.timeout(60_000);
 
             const cmdIt = onWindows ? it : it.skip;


### PR DESCRIPTION
## Why

The unit suite builds Mocha with only `ui`/`color`, so mocha's **2 s default** applies. On cold CI runners (AV scan + cold FS cache) a test's first real I/O can exceed 2 s, and the penalty attaches to **whichever spawn test the glob happens to run first** — an unstable contract, since adding or renaming a file under `src/` migrates the flake to the next spawn test. Raising the timeout per-file only chases the class one file at a time (this was the follow-up flagged in review of #2134).

## What

Set `timeout: 5000` on the shared Mocha instance in `src/test/suite.ts`. 5 s clears the cold-runner I/O spike while staying tight enough to fail a genuine hang fast. Tests that spawn the real CLI keep their own higher overrides (`CliWrapper.test.ts` 10 s, the packaging smoke describe 30 s), which still win per-suite.

## Verification

- `yarn test:unit` — 877 passing, 0 failing.
- `eslint` + `prettier` clean.

This pull request and its description were written by Isaac.