### PR TITLE
fix(python-setup): show an info toast on a successful setup that had warnings

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -809,14 +809,17 @@ describe("makePythonSetupDeps showSuccess", () => {
         expect(warnShownWith).to.have.length(0);
     });
 
-    it("raises a warning toast when the run had warnings", async () => {
+    it("raises an info toast (never a warning) when the run had warnings", async () => {
         const deps = makePythonSetupDeps(makeWiring());
 
         await deps.showSuccess(SUCCESS_WITH_WARNINGS);
 
-        expect(warnShownWith).to.have.length(1);
-        expect(warnShownWith[0].actions).to.contain("View Details");
-        expect(infoShownWith).to.have.length(0);
+        // A successful run is informational even when it carried warnings;
+        // the warning count is in the message and the details behind it.
+        expect(infoShownWith).to.have.length(1);
+        expect(infoShownWith[0].message).to.contain("warning");
+        expect(infoShownWith[0].actions).to.contain("View Details");
+        expect(warnShownWith).to.have.length(0);
     });
 
     it("reveals the channel again when View Details is picked", async () => {

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -290,13 +290,15 @@ export function makePythonSetupDeps(
             wiring.log.show();
             // A standard (non-modal) notification, not a modal dialog: the
             // outcome is informational, not something to interrupt the user
-            // for. A run with warnings raises a warning toast so it doesn't
-            // read as an unqualified success; the warnings are in the details.
-            const {message, isWarning} = formatSetupNotification(result);
+            // for. This path runs only on a successful setup, so it stays an
+            // info toast even when the run carried warnings — the count is in
+            // the message and the warnings themselves are in the details.
+            const message = formatSetupNotification(result);
             const viewDetails = "View Details";
-            const choice = isWarning
-                ? await window.showWarningMessage(message, viewDetails)
-                : await window.showInformationMessage(message, viewDetails);
+            const choice = await window.showInformationMessage(
+                message,
+                viewDetails
+            );
             if (choice === viewDetails) {
                 wiring.log.show();
             }

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -9,15 +9,13 @@ import {
 
 describe("formatSetupNotification", () => {
     it("is a concise, use-case-neutral one-liner with no warnings", () => {
-        const {message, isWarning} = formatSetupNotification(SUCCESS_DEFAULT);
-        expect(message).to.equal(
+        expect(formatSetupNotification(SUCCESS_DEFAULT)).to.equal(
             "Python environment ready — .venv created and selected for your " +
                 "Databricks project."
         );
-        expect(isWarning).to.equal(false);
     });
 
-    it("flags the count and marks a warning when warnings are present", () => {
+    it("flags the count in the message when warnings are present", () => {
         const warned: PythonSetupResult = {
             ...SUCCESS_DEFAULT,
             warnings: [
@@ -25,12 +23,10 @@ describe("formatSetupNotification", () => {
                 {code: "W_Y", message: "used a fallback mirror"},
             ],
         };
-        const {message, isWarning} = formatSetupNotification(warned);
-        expect(message).to.equal(
+        expect(formatSetupNotification(warned)).to.equal(
             "Python environment ready, with 2 warnings — .venv created and " +
                 "selected for your Databricks project."
         );
-        expect(isWarning).to.equal(true);
     });
 
     it("singularizes the count for one warning", () => {
@@ -38,10 +34,9 @@ describe("formatSetupNotification", () => {
             ...SUCCESS_DEFAULT,
             warnings: [{code: "W_X", message: "pinned an older wheel"}],
         };
-        const {message, isWarning} = formatSetupNotification(warned);
+        const message = formatSetupNotification(warned);
         expect(message).to.contain("with 1 warning —");
         expect(message).to.not.contain("1 warnings");
-        expect(isWarning).to.equal(true);
     });
 });
 

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -5,38 +5,25 @@ import {
 } from "../models/PythonSetupResult";
 import {venvInterpreterPath} from "./venvInterpreterPath";
 
-export interface PythonSetupNotification {
-    message: string;
-    /** True when the run had warnings — the caller shows a warning toast. */
-    isWarning: boolean;
-}
-
 /**
  * The one-line message shown in the success notification. Deliberately terse
  * and use-case-neutral (a local environment for a Databricks project, not tied
  * to Databricks Connect specifically) — the full breakdown lives behind the
- * notification's "View Details" button via {@link formatSetupLog}. When the run
- * completed with warnings the message says so and `isWarning` flips, so the
- * caller can raise a warning toast rather than a plain info one; the warnings
+ * notification's "View Details" button via {@link formatSetupLog}. This is only
+ * ever built for a successful run, so when it completed with warnings the
+ * message names the count but the outcome stays informational; the warnings
  * themselves are listed in the details.
  */
-export function formatSetupNotification(
-    result: PythonSetupResult
-): PythonSetupNotification {
+export function formatSetupNotification(result: PythonSetupResult): string {
     const tail = ".venv created and selected for your Databricks project.";
     const n = result.warnings.length;
     if (n === 0) {
-        return {
-            message: `Python environment ready — ${tail}`,
-            isWarning: false,
-        };
+        return `Python environment ready — ${tail}`;
     }
-    return {
-        message:
-            `Python environment ready, with ${n} ` +
-            `warning${n === 1 ? "" : "s"} — ${tail}`,
-        isWarning: true,
-    };
+    return (
+        `Python environment ready, with ${n} ` +
+        `warning${n === 1 ? "" : "s"} — ${tail}`
+    );
 }
 
 /**


### PR DESCRIPTION
## Why

The Python environment-setup success notification raised a ⚠️ **warning** toast whenever the run carried non-fatal warnings. That code path (`showSuccess`) runs only after a genuinely successful setup — every failure is routed to the error path instead — so the warning styling misrepresented a success as a problem. A successful run should read as informational; the warning count belongs in the message text and the individual warnings behind **View Details**.

## What

- **`pythonSetupDeps.ts`** — `showSuccess` now always uses `window.showInformationMessage`, dropping the branch to `showWarningMessage`.
- **`setupSummary.ts`** — `formatSetupNotification` no longer returns `isWarning`. With that flag gone the single-field return wrapper had no reason to exist, so it now returns the message string directly. The message still names the warning count (e.g. "…with 2 warnings…").

No behavior change to the error path, persisted state, settings, or message contract — this is purely notification severity, so there is no backward-compatibility concern.

## Verification

- `yarn test:unit` — 882 passing, 0 failing (after fetching the bundled CLI).
- `yarn test:lint` — clean.
- Updated the `showSuccess` test to assert an info toast (never a warning) when the run had warnings, and the `formatSetupNotification` tests for the new string return.

This pull request and its description were written by Isaac.