### PR TITLE
ci(dependabot): ignore the typescript 6→7 major bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
       # floor is deliberately raised. See PR #1988.
       - dependency-name: "@types/node"
         versions: [">=23"]
+      # TypeScript 7 is the native-compiler rewrite; it removes the
+      # `moduleResolution: node10` our shared tsconfig_base uses, so moving to it
+      # is a deliberate migration, not a drop-in bump. Stay on 6.x for now.
+      # See PRs #1995, #1993.
+      - dependency-name: "typescript"
+        versions: [">=7"]
   - package-ecosystem: "npm"
     directory: "/packages/databricks-vscode-types"
     ignore:
@@ -40,6 +46,11 @@ updates:
       # See PR #1933.
       - dependency-name: "@types/vscode"
         versions: [">=1.87"]
+      # TypeScript 7 removes `moduleResolution: node10` (see tsconfig_base); moving
+      # to it is a deliberate migration, not a drop-in bump. Stay on 6.x for now.
+      # See PR #1993.
+      - dependency-name: "typescript"
+        versions: [">=7"]
     schedule:
       interval: "daily"
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Why
TypeScript 7 is the native-compiler rewrite. It removes the `moduleResolution: node10` option that the shared `tsconfig_base.json` relies on repo-wide, so `tsc --build` fails immediately (`TS5108`) until every package's config is migrated. Adopting TS 7 is a deliberate migration, not a drop-in bump — and we do not plan to do it now. Dependabot keeps reopening it (#1995, #1993).

## What
Add a `typescript` `>=7` entry to the Dependabot ignore list for the `/packages/databricks-vscode` and `/packages/databricks-vscode-types` npm updates. 6.x patch/minor bumps remain enabled; `databricks-sdk-js` has no `typescript` dep and is unchanged.

## Verification
- `.github/dependabot.yml` parses as valid YAML (4 update entries).
- Both npm entries now carry the `typescript >=7` ignore.

Closes the intent of #1995 and #1993, which can be closed once this lands.

This pull request and its description were written by Isaac.