### PR TITLE
fix(release): match flat artifact layout after download-artifact v8

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -41,7 +41,7 @@ jobs:
           tmpfile=$(mktemp /tmp/commit-message.XXXXX)
           cat $CHANGELOG_FILE | awk 'BEGIN{C=0} $0 ~ /^# Release: v.*/ && C==1{C=2} $0 ~ /^# Release: v'"$RELEASE_VERSION"'.*/{C=1} C==1 {print $0}' > $tmpfile
           cat $tmpfile >> $GITHUB_STEP_SUMMARY
-          gh release create release-v$RELEASE_VERSION ${{ steps.download.outputs.download-path }}/databricks*/*.vsix \
+          gh release create release-v$RELEASE_VERSION ${{ steps.download.outputs.download-path }}/databricks*.vsix \
               -d --target main -t "$TITLE" -F $tmpfile
 
         env:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           REPO=databricks/databricks-vscode
           if gh release view "$TAG" --repo "$REPO" &>/dev/null; then
-            gh release upload "$TAG" --repo "$REPO" --clobber packages/databricks-vscode/databricks*/*.vsix
+            gh release upload "$TAG" --repo "$REPO" --clobber packages/databricks-vscode/databricks*.vsix
           else
             gh release create "$TAG" \
               --repo "$REPO" \
@@ -43,5 +43,5 @@ jobs:
               --prerelease \
               --target "${{ github.sha }}" \
               --notes "Nightly build from ${{ github.ref_name }}" \
-              packages/databricks-vscode/databricks*/*.vsix
+              packages/databricks-vscode/databricks*.vsix
           fi


### PR DESCRIPTION
## Why

Bumping `actions/download-artifact` to v8 (#2068) changed the on-disk layout of a downloaded artifact. In v4, downloading the single `databricks` artifact (no `name` filter) unpacked it into a `databricks/` **subdirectory**; in v8 the contents land **directly** in the download path.

Both release workflows still globbed `databricks*/*.vsix`, which assumes that subdirectory, so they now match nothing and `gh release` fails with `no matches found` (exit 1):

- `nightly-release.yml` — **broken now**: every nightly run after #2068 merged failed at "Update nightly release".
- `create-release.yml` — the real draft-release workflow (runs on `Release:` commits); would fail the next time we cut a release.

Evidence from a failed nightly run — the VSIX files sit flat in `packages/databricks-vscode/`:

```
packages/databricks-vscode:
-rw-r--r-- ... databricks-darwin-arm64-2.14.1.vsix
-rw-r--r-- ... databricks-darwin-x64-2.14.1.vsix
-rw-r--r-- ... databricks-linux-arm64-2.14.1.vsix
-rw-r--r-- ... databricks-linux-x64-2.14.1.vsix
-rw-r--r-- ... databricks-win32-arm64-2.14.1.vsix
-rw-r--r-- ... databricks-win32-x64-2.14.1.vsix
...
no matches found for `packages/databricks-vscode/databricks*/*.vsix`
```

## What

Drop the subdirectory level in the VSIX globs to match the new flat layout: `databricks*/*.vsix` → `databricks*.vsix`.

- `nightly-release.yml` — both the `gh release upload` and `gh release create` branches
- `create-release.yml` — the `gh release create` glob

## Verification

The six `databricks-*-<version>.vsix` files are directly under the download path, which `databricks*.vsix` matches. Triggering a `workflow_dispatch` nightly-release run on this branch to confirm green before merge.