### PR TITLE
Add performance telemetry for the legacy databricks-connect install

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -890,7 +890,8 @@ export async function activate(
     const environmentDependenciesInstaller =
         new EnvironmentDependenciesInstaller(
             connectionManager,
-            pythonExtensionWrapper
+            pythonExtensionWrapper,
+            telemetry
         );
     const featureManager = new FeatureManager<FeatureId>([]);
     featureManager.registerFeature(

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.test.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.test.ts
@@ -1,0 +1,68 @@
+import {TelemetryReporter} from "@vscode/extension-telemetry";
+import {expect} from "chai";
+import {anything, capture, instance, mock, when} from "ts-mockito";
+import {Telemetry} from "../telemetry";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
+import {EnvironmentDependenciesInstaller} from "./EnvironmentDependenciesInstaller";
+
+describe(__filename, () => {
+    let reporter: TelemetryReporter;
+    let telemetry: Telemetry;
+
+    beforeEach(() => {
+        reporter = mock(TelemetryReporter);
+        telemetry = new Telemetry(instance(reporter));
+    });
+
+    // The installer's package installs run `onInstall`; uninstalls resolve to
+    // no-ops. connectionManager is only read by getSuggestedVersion(), which
+    // install() skips when handed an explicit version, so it is never touched.
+    function makeInstaller(onInstall: () => Promise<void>) {
+        const pythonExtension = mock(MsPythonExtensionWrapper);
+        when(
+            pythonExtension.uninstallPackageFromEnvironment(
+                anything(),
+                anything()
+            )
+        ).thenResolve();
+        when(
+            pythonExtension.installPackageInEnvironment(
+                anything(),
+                anything(),
+                anything()
+            )
+        ).thenCall(onInstall);
+        return new EnvironmentDependenciesInstaller(
+            instance(mock(ConnectionManager)),
+            instance(pythonExtension),
+            telemetry
+        );
+    }
+
+    it("records a successful databricks-connect install as outcome ok", async () => {
+        const installer = makeInstaller(async () => {});
+
+        await installer.install("1.2.3");
+
+        const [eventName, props, metrics] = capture(
+            reporter.sendTelemetryEvent
+        ).last();
+        expect(eventName).to.equal("python_env.dbconnect_install");
+        expect(props?.["event.outcome"]).to.equal("ok");
+        expect(metrics?.["event.duration"]).to.be.a("number");
+        expect(metrics?.["event.duration"]).to.be.at.least(0);
+    });
+
+    it("records a failed databricks-connect install as outcome failed", async () => {
+        const installer = makeInstaller(async () => {
+            throw new Error("pip failed");
+        });
+
+        await installer.install("1.2.3");
+
+        const [eventName, props] = capture(reporter.sendTelemetryEvent).last();
+        expect(eventName).to.equal("python_env.dbconnect_install");
+        expect(props?.["event.outcome"]).to.equal("failed");
+    });
+});

--- a/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
+++ b/packages/databricks-vscode/src/language/EnvironmentDependenciesInstaller.ts
@@ -5,6 +5,8 @@ import {MsPythonExtensionWrapper} from "./MsPythonExtensionWrapper";
 import {ConnectionManager} from "../configuration/ConnectionManager";
 import {DATABRICKS_CONNECT_VERSION as DATABRICKS_CONNECT_MINIMAL_VERSION} from "../utils/constants";
 import {workspaceConfigs} from "../vscode-objs/WorkspaceConfigs";
+import {Events} from "../telemetry";
+import type {Telemetry} from "../telemetry";
 
 export class EnvironmentDependenciesInstaller implements Disposable {
     private disposables: Disposable[] = [];
@@ -15,7 +17,8 @@ export class EnvironmentDependenciesInstaller implements Disposable {
 
     constructor(
         private readonly connectionManager: ConnectionManager,
-        private readonly pythonExtension: MsPythonExtensionWrapper
+        private readonly pythonExtension: MsPythonExtensionWrapper,
+        private readonly telemetry: Telemetry
     ) {}
 
     get outputChannel() {
@@ -35,6 +38,11 @@ export class EnvironmentDependenciesInstaller implements Disposable {
         if (!version) {
             version = await this.getSuggestedVersion();
         }
+        // Timed from here, not method entry, so the reported duration is the
+        // pip work only — not the interpreter/version prompts answered earlier.
+        const reportInstall = this.telemetry.start(
+            Events.PYTHON_ENV_DBCONNECT_INSTALL
+        );
         try {
             this.outputChannel.clear();
             this.outputChannel.show();
@@ -57,11 +65,13 @@ export class EnvironmentDependenciesInstaller implements Disposable {
                 undefined,
                 this.outputChannel
             );
+            reportInstall({outcome: "ok"});
         } catch (e: unknown) {
             if (e instanceof Error) {
                 window.showErrorMessage(e.message);
             }
             this.outputChannel.show();
+            reportInstall({outcome: "failed"});
         }
         this.onDidInstallAttemptEmitter.fire();
     }

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -29,6 +29,7 @@ export enum Events {
     PYTHON_ENV_SETUP_RESULT = "python_env.setup.result",
     PYTHON_ENV_DRIFT = "python_env.drift",
     PYTHON_ENV_ADOPTION = "python_env.adoption",
+    PYTHON_ENV_DBCONNECT_INSTALL = "python_env.dbconnect_install",
     AITOOLS_INSTALL = "aitoolsInstall",
     AITOOLS_UPDATE = "aitoolsUpdate",
     AITOOLS_UNINSTALL = "aitoolsUninstall",
@@ -154,6 +155,17 @@ export type PythonSetupFailurePhase =
     | PythonSetupPhaseName
     | "adopt"
     | "persist";
+
+/**
+ * How the legacy (pre-VPEX) databricks-connect install ended.
+ *
+ * Only `ok` / `failed`: the install itself is not user-cancellable once it
+ * starts (the prompts that a user can abandon run *before* `install()`), so a
+ * `cancelled` value would never be emitted. Deliberately a distinct, minimal
+ * vocabulary from {@link PythonSetupOutcome} — the legacy flow is its own
+ * event, not a variant of the uv-native result.
+ */
+export type DbConnectInstallOutcome = "ok" | "failed";
 
 /** How a drift check was triggered. */
 export type PythonSetupDriftTrigger =
@@ -616,6 +628,25 @@ export class EventTypes {
                 "The compute kind attached when the session check ran (cluster | serverless | " +
                 "none), so adoption can be sliced by compute. No cluster IDs or names",
         },
+    };
+    [Events.PYTHON_ENV_DBCONNECT_INSTALL]: EventType<
+        {
+            outcome: DbConnectInstallOutcome;
+        } & DurationMeasurement
+    > = {
+        comment:
+            "The outcome of a legacy (pre-VPEX) databricks-connect install run — the old " +
+            "environment-setup flow driven by EnvironmentDependenciesInstaller.install(). Its own " +
+            "event (not python_env.setup.result) so the legacy and uv-native flows stay cleanly " +
+            "separable in analysis. Categorical/numeric data only — no versions, paths, or names.",
+        outcome: {
+            comment:
+                "ok if the databricks-connect (and nbformat) install completed, failed if it threw",
+        },
+        // Measured by the extension around the install itself, so it is the pip
+        // work only — it excludes the prompts (interpreter/version) the user
+        // answers before install() runs.
+        ...getDurationProperty(),
     };
 }
 


### PR DESCRIPTION
## What

The legacy (pre-VPEX) Python environment setup — `EnvironmentDependenciesInstaller.install()`, reached via the `databricks.environment.setup` / `databricks.environment.reinstallDBConnect` commands — emits no success or duration telemetry.

Its only signal today is the generic `commandExecution` event, which sets `success=false` only when the command handler throws. But `install()` catches its own errors (shows a message, then returns normally), so the legacy flow reports success regardless of whether `databricks-connect` actually installed. There is no way to measure how long the install takes or how often it fails, and no way to compare it against the uv-native flow, which already emits `python_env.setup.attempt` / `python_env.setup.result`.

## Change

Emit a dedicated `python_env.dbconnect_install` event with:

- `outcome`: `ok` | `failed`
- `duration`: wall-clock ms, measured around the install itself — so it reflects the pip work, not the interpreter/version prompts answered beforehand.

A distinct event name (rather than reusing `python_env.setup.result`) keeps the legacy and uv-native flows cleanly separable in analysis and avoids overloading the uv-native result schema, whose failure phases/error codes have no legacy analogue. Categorical/numeric data only — no versions, paths, or names.

## Testing

- New co-located unit test `EnvironmentDependenciesInstaller.test.ts`: a successful install records `outcome: "ok"` with a `duration` metric; a throwing install records `outcome: "failed"`.
- `yarn test:lint` clean; the new unit tests pass. The pre-existing `CliWrapper` / `packageJsonUtils` failures in a fresh dev clone stem from the gitignored `bin/databricks` binary and version pins, and are unrelated to this change.

This pull request and its description were written by Isaac.
