### PR TITLE
feat(bundle): warn when a bundle uses the deprecated Terraform engine

### DIFF
--- a/packages/databricks-vscode/src/bundle/BundleEngineManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundleEngineManager.test.ts
@@ -1,0 +1,210 @@
+import assert from "assert";
+import {Disposable, Uri} from "vscode";
+import {
+    anything,
+    deepEqual,
+    instance,
+    mock,
+    reset,
+    verify,
+    when,
+} from "ts-mockito";
+import {StateStorage} from "../vscode-objs/StateStorage";
+import {Telemetry} from "../telemetry";
+import {Events} from "../telemetry/constants";
+import {BundleValidateModel} from "./models/BundleValidateModel";
+import {
+    BundleEngineManager,
+    BundleEnginePrompter,
+    DIRECT_ENGINE_DOCS_URL,
+    READ_MIGRATION_GUIDE_LABEL,
+    DONT_SHOW_AGAIN_LABEL,
+} from "./BundleEngineManager";
+
+const HIDE_KEY = "databricks.bundle.hideTerraformEngineWarning";
+
+/**
+ * Hand-rolled stand-in for {@link BundleValidateModel}: the base model exposes
+ * `onDidChange` and `get` as bound instance fields, which ts-mockito can't stub,
+ * so we drive them directly. `fire()` replays a validate-state change.
+ */
+class FakeValidateModel {
+    private listeners: Array<() => unknown> = [];
+    public engine: string | undefined;
+
+    onDidChange(cb: () => unknown): Disposable {
+        this.listeners.push(cb);
+        return {dispose() {}};
+    }
+
+    async get(): Promise<string | undefined> {
+        return this.engine;
+    }
+
+    async fire(): Promise<void> {
+        for (const cb of this.listeners) {
+            await cb();
+        }
+    }
+}
+
+function makePrompter(choice: string | undefined): {
+    prompter: BundleEnginePrompter;
+    opened: Uri[];
+    shownCount: () => number;
+} {
+    const opened: Uri[] = [];
+    let shown = 0;
+    const prompter: BundleEnginePrompter = {
+        showWarningMessage: (() => {
+            shown++;
+            return Promise.resolve(choice);
+        }) as BundleEnginePrompter["showWarningMessage"],
+        openExternal: ((uri: Uri) => {
+            opened.push(uri);
+            return Promise.resolve(true);
+        }) as BundleEnginePrompter["openExternal"],
+    };
+    return {prompter, opened, shownCount: () => shown};
+}
+
+describe("BundleEngineManager", () => {
+    let fakeModel: FakeValidateModel;
+    let mockStorage: StateStorage;
+    let mockTelemetry: Telemetry;
+
+    function build(prompter: BundleEnginePrompter): BundleEngineManager {
+        return new BundleEngineManager(
+            fakeModel as unknown as BundleValidateModel,
+            instance(mockStorage),
+            instance(mockTelemetry),
+            prompter
+        );
+    }
+
+    beforeEach(() => {
+        fakeModel = new FakeValidateModel();
+        mockStorage = mock(StateStorage);
+        mockTelemetry = mock(Telemetry);
+        when(mockStorage.get(HIDE_KEY)).thenReturn(false);
+    });
+
+    afterEach(() => {
+        reset(mockStorage);
+        reset(mockTelemetry);
+    });
+
+    it("warns when the engine is terraform", async () => {
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 1);
+    });
+
+    it("does not warn when the engine is direct", async () => {
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = "direct";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 0);
+        verify(
+            mockTelemetry.recordEvent(
+                Events.BUNDLE_TERRAFORM_ENGINE_WARNING,
+                anything()
+            )
+        ).never();
+    });
+
+    it("does not warn when the engine is unset", async () => {
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = undefined;
+
+        await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 0);
+    });
+
+    it("does not warn when the user has opted out", async () => {
+        when(mockStorage.get(HIDE_KEY)).thenReturn(true);
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 0);
+    });
+
+    it("warns at most once per session even across repeated validations", async () => {
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+        await fakeModel.fire();
+        await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 1);
+    });
+
+    it("opens the migration guide and records 'guide'", async () => {
+        const {prompter, opened} = makePrompter(READ_MIGRATION_GUIDE_LABEL);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(opened.length, 1);
+        assert.strictEqual(
+            opened[0].toString(),
+            Uri.parse(DIRECT_ENGINE_DOCS_URL).toString()
+        );
+        verify(mockStorage.set(HIDE_KEY, true)).never();
+        verify(
+            mockTelemetry.recordEvent(
+                Events.BUNDLE_TERRAFORM_ENGINE_WARNING,
+                deepEqual({action: "guide"})
+            )
+        ).once();
+    });
+
+    it("persists opt-out and records 'hidden' on 'Don't show again'", async () => {
+        const {prompter, opened} = makePrompter(DONT_SHOW_AGAIN_LABEL);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(opened.length, 0);
+        verify(mockStorage.set(HIDE_KEY, true)).once();
+        verify(
+            mockTelemetry.recordEvent(
+                Events.BUNDLE_TERRAFORM_ENGINE_WARNING,
+                deepEqual({action: "hidden"})
+            )
+        ).once();
+    });
+
+    it("records 'dismissed' when the warning is closed without a choice", async () => {
+        const {prompter, opened} = makePrompter(undefined);
+        build(prompter);
+        fakeModel.engine = "terraform";
+
+        await fakeModel.fire();
+
+        assert.strictEqual(opened.length, 0);
+        verify(mockStorage.set(HIDE_KEY, true)).never();
+        verify(
+            mockTelemetry.recordEvent(
+                Events.BUNDLE_TERRAFORM_ENGINE_WARNING,
+                deepEqual({action: "dismissed"})
+            )
+        ).once();
+    });
+});

--- a/packages/databricks-vscode/src/bundle/BundleEngineManager.test.ts
+++ b/packages/databricks-vscode/src/bundle/BundleEngineManager.test.ts
@@ -31,6 +31,9 @@ const HIDE_KEY = "databricks.bundle.hideTerraformEngineWarning";
 class FakeValidateModel {
     private listeners: Array<() => unknown> = [];
     public engine: string | undefined;
+    // When non-empty, successive get() calls consume this queue instead of
+    // `engine` — used to script the value seen by concurrent invocations.
+    public engines: Array<string | undefined> = [];
 
     onDidChange(cb: () => unknown): Disposable {
         this.listeners.push(cb);
@@ -38,13 +41,20 @@ class FakeValidateModel {
     }
 
     async get(): Promise<string | undefined> {
-        return this.engine;
+        return this.engines.length > 0 ? this.engines.shift() : this.engine;
     }
 
     async fire(): Promise<void> {
         for (const cb of this.listeners) {
             await cb();
         }
+    }
+
+    // Invoke the listener twice without awaiting between, so the second call
+    // runs while the first is still awaiting get() — the concurrency the
+    // manager must tolerate.
+    async fireConcurrentTwice(): Promise<void> {
+        await Promise.all(this.listeners.flatMap((cb) => [cb(), cb()]));
     }
 }
 
@@ -149,6 +159,18 @@ describe("BundleEngineManager", () => {
         await fakeModel.fire();
         await fakeModel.fire();
         await fakeModel.fire();
+
+        assert.strictEqual(shownCount(), 1);
+    });
+
+    it("still warns once when a concurrent validate resolves to terraform", async () => {
+        const {prompter, shownCount} = makePrompter(undefined);
+        build(prompter);
+        // First invocation reads "direct", the concurrent second reads
+        // "terraform"; the terraform transition must not be dropped.
+        fakeModel.engines = ["direct", "terraform"];
+
+        await fakeModel.fireConcurrentTwice();
 
         assert.strictEqual(shownCount(), 1);
     });

--- a/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
@@ -16,7 +16,7 @@ export const DONT_SHOW_AGAIN_LABEL = "Don't show again";
 const HIDE_WARNING_KEY = "databricks.bundle.hideTerraformEngineWarning";
 
 const WARNING_MESSAGE =
-    "This project uses the Terraform deployment engine, which is deprecated " +
+    "This bundle uses the Terraform deployment engine, which is deprecated " +
     "and will stop working in a future Databricks CLI version. Migrate to the " +
     "direct deployment engine.";
 

--- a/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
@@ -1,0 +1,112 @@
+import {Disposable, Uri, env, window} from "vscode";
+import {BundleValidateModel} from "./models/BundleValidateModel";
+import {StateStorage} from "../vscode-objs/StateStorage";
+import {Telemetry} from "../telemetry";
+import {
+    BundleTerraformEngineWarningAction,
+    Events,
+} from "../telemetry/constants";
+import {withOnErrorHandler} from "../utils/onErrorDecorator";
+
+export const DIRECT_ENGINE_DOCS_URL =
+    "https://docs.databricks.com/aws/en/dev-tools/bundles/direct";
+export const READ_MIGRATION_GUIDE_LABEL = "Read migration guide";
+export const DONT_SHOW_AGAIN_LABEL = "Don't show again";
+
+const WARNING_MESSAGE =
+    "This project uses the Terraform deployment engine, which is deprecated " +
+    "and will stop working in a future Databricks CLI version. Migrate to the " +
+    "direct deployment engine.";
+
+/**
+ * The prompting surface {@link BundleEngineManager} needs, behind one seam so
+ * the logic is unit-testable. The real implementation delegates to `window` /
+ * `env`.
+ */
+export interface BundleEnginePrompter {
+    showWarningMessage: (typeof window)["showWarningMessage"];
+    openExternal: (typeof env)["openExternal"];
+}
+
+/**
+ * Warns once, when a bundle's validate output reports the deprecated Terraform
+ * deployment engine, offering a link to the migration guide. Shows at most once
+ * per session per project; "Don't show again" persists the opt-out for the
+ * workspace via {@link StateStorage}.
+ */
+export class BundleEngineManager implements Disposable {
+    private disposables: Disposable[] = [];
+    private warned = false;
+    private checking = false;
+
+    constructor(
+        private readonly bundleValidateModel: BundleValidateModel,
+        private readonly stateStorage: StateStorage,
+        private readonly telemetry: Telemetry,
+        private readonly prompter: BundleEnginePrompter = {
+            showWarningMessage: window.showWarningMessage,
+            openExternal: env.openExternal,
+        }
+    ) {
+        this.disposables.push(
+            this.bundleValidateModel.onDidChange(
+                withOnErrorHandler(() => this.checkEngine(), {
+                    log: true,
+                    throw: false,
+                })
+            )
+        );
+    }
+
+    private async checkEngine(): Promise<void> {
+        if (this.warned || this.checking) {
+            return;
+        }
+        if (
+            this.stateStorage.get(
+                "databricks.bundle.hideTerraformEngineWarning"
+            )
+        ) {
+            return;
+        }
+        this.checking = true;
+        try {
+            const engine = await this.bundleValidateModel.get("engine");
+            if (engine !== "terraform") {
+                return;
+            }
+            this.warned = true;
+            await this.warn();
+        } finally {
+            this.checking = false;
+        }
+    }
+
+    private async warn(): Promise<void> {
+        const choice = await this.prompter.showWarningMessage(
+            WARNING_MESSAGE,
+            READ_MIGRATION_GUIDE_LABEL,
+            DONT_SHOW_AGAIN_LABEL
+        );
+
+        let action: BundleTerraformEngineWarningAction = "dismissed";
+        if (choice === READ_MIGRATION_GUIDE_LABEL) {
+            action = "guide";
+            await this.prompter.openExternal(Uri.parse(DIRECT_ENGINE_DOCS_URL));
+        } else if (choice === DONT_SHOW_AGAIN_LABEL) {
+            action = "hidden";
+            await this.stateStorage.set(
+                "databricks.bundle.hideTerraformEngineWarning",
+                true
+            );
+        }
+
+        this.telemetry.recordEvent(Events.BUNDLE_TERRAFORM_ENGINE_WARNING, {
+            action,
+        });
+    }
+
+    dispose() {
+        this.disposables.forEach((d) => d.dispose());
+    }
+}

--- a/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
+++ b/packages/databricks-vscode/src/bundle/BundleEngineManager.ts
@@ -13,6 +13,8 @@ export const DIRECT_ENGINE_DOCS_URL =
 export const READ_MIGRATION_GUIDE_LABEL = "Read migration guide";
 export const DONT_SHOW_AGAIN_LABEL = "Don't show again";
 
+const HIDE_WARNING_KEY = "databricks.bundle.hideTerraformEngineWarning";
+
 const WARNING_MESSAGE =
     "This project uses the Terraform deployment engine, which is deprecated " +
     "and will stop working in a future Databricks CLI version. Migrate to the " +
@@ -22,6 +24,11 @@ const WARNING_MESSAGE =
  * The prompting surface {@link BundleEngineManager} needs, behind one seam so
  * the logic is unit-testable. The real implementation delegates to `window` /
  * `env`.
+ *
+ * This is a Manager that renders `window.*` itself (via the seam) rather than
+ * delegating to a Commands/Component, since the warning is reactive to validate
+ * state with no command trigger — matching the existing
+ * {@link BundlePipelinesManager}, which surfaces its warnings the same way.
  */
 export interface BundleEnginePrompter {
     showWarningMessage: (typeof window)["showWarningMessage"];
@@ -29,15 +36,14 @@ export interface BundleEnginePrompter {
 }
 
 /**
- * Warns once, when a bundle's validate output reports the deprecated Terraform
+ * Warns when a bundle's validate output reports the deprecated Terraform
  * deployment engine, offering a link to the migration guide. Shows at most once
- * per session per project; "Don't show again" persists the opt-out for the
+ * per session per workspace; "Don't show again" persists the opt-out for the
  * workspace via {@link StateStorage}.
  */
 export class BundleEngineManager implements Disposable {
     private disposables: Disposable[] = [];
     private warned = false;
-    private checking = false;
 
     constructor(
         private readonly bundleValidateModel: BundleValidateModel,
@@ -59,27 +65,17 @@ export class BundleEngineManager implements Disposable {
     }
 
     private async checkEngine(): Promise<void> {
-        if (this.warned || this.checking) {
+        if (this.warned || this.stateStorage.get(HIDE_WARNING_KEY)) {
             return;
         }
-        if (
-            this.stateStorage.get(
-                "databricks.bundle.hideTerraformEngineWarning"
-            )
-        ) {
+        const engine = await this.bundleValidateModel.get("engine");
+        // Re-check `warned` after the await: a concurrent validate change may
+        // have shown the warning while we were reading the engine.
+        if (engine !== "terraform" || this.warned) {
             return;
         }
-        this.checking = true;
-        try {
-            const engine = await this.bundleValidateModel.get("engine");
-            if (engine !== "terraform") {
-                return;
-            }
-            this.warned = true;
-            await this.warn();
-        } finally {
-            this.checking = false;
-        }
+        this.warned = true;
+        await this.warn();
     }
 
     private async warn(): Promise<void> {
@@ -95,10 +91,7 @@ export class BundleEngineManager implements Disposable {
             await this.prompter.openExternal(Uri.parse(DIRECT_ENGINE_DOCS_URL));
         } else if (choice === DONT_SHOW_AGAIN_LABEL) {
             action = "hidden";
-            await this.stateStorage.set(
-                "databricks.bundle.hideTerraformEngineWarning",
-                true
-            );
+            await this.stateStorage.set(HIDE_WARNING_KEY, true);
         }
 
         this.telemetry.recordEvent(Events.BUNDLE_TERRAFORM_ENGINE_WARNING, {

--- a/packages/databricks-vscode/src/bundle/models/BundleValidateModel.test.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleValidateModel.test.ts
@@ -1,0 +1,56 @@
+import assert from "assert";
+import {Uri} from "vscode";
+import {anything, instance, mock, when} from "ts-mockito";
+import {CliWrapper} from "../../cli/CliWrapper";
+import {BundleWatcher} from "../BundleWatcher";
+import {WorkspaceFolderManager} from "../../vscode-objs/WorkspaceFolderManager";
+import {AuthProvider} from "../../configuration/auth/AuthProvider";
+import {BundleValidateModel} from "./BundleValidateModel";
+
+describe("BundleValidateModel", () => {
+    function buildModel(validateStdout: object): BundleValidateModel {
+        const fakeWatcher = {
+            onDidChange: () => ({dispose() {}}),
+        } as unknown as BundleWatcher;
+        const fakeWorkspaceFolderManager = {
+            activeProjectUri: Uri.file("/tmp/project"),
+        } as unknown as WorkspaceFolderManager;
+        const mockCli = mock(CliWrapper);
+        when(
+            mockCli.bundleValidate(
+                anything(),
+                anything(),
+                anything(),
+                anything(),
+                anything()
+            )
+        ).thenResolve({stdout: JSON.stringify(validateStdout), stderr: ""});
+
+        const model = new BundleValidateModel(
+            fakeWatcher,
+            instance(mockCli),
+            fakeWorkspaceFolderManager
+        );
+        model.setTarget("dev");
+        model.setAuthProvider({
+            toJSON: () => ({}),
+        } as unknown as AuthProvider);
+        return model;
+    }
+
+    it("reads bundle.engine off the validate output", async () => {
+        const model = buildModel({
+            bundle: {name: "proj", engine: "terraform"},
+        });
+
+        assert.strictEqual(await model.get("engine"), "terraform");
+    });
+
+    it("leaves engine undefined when the validate output omits it", async () => {
+        const model = buildModel({
+            bundle: {name: "proj"},
+        });
+
+        assert.strictEqual(await model.get("engine"), undefined);
+    });
+});

--- a/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
+++ b/packages/databricks-vscode/src/bundle/models/BundleValidateModel.ts
@@ -14,6 +14,9 @@ import {WorkspaceFolderManager} from "../../vscode-objs/WorkspaceFolderManager";
 export type BundleValidateState = {
     clusterId?: string;
     remoteRootPath?: string;
+    // The bundle deployment engine ("terraform" | "direct"). Not modelled in the
+    // generated BundleSchema, so read off the validate output directly.
+    engine?: string;
 } & BundleTarget;
 
 export class BundleValidateModel extends BaseModelWithStateCache<BundleValidateState> {
@@ -87,6 +90,8 @@ export class BundleValidateModel extends BaseModelWithStateCache<BundleValidateS
                 validateOutput?.bundle?.compute_id ??
                 validateOutput?.bundle?.cluster_id,
             remoteRootPath: validateOutput?.workspace?.file_path,
+            engine: (validateOutput?.bundle as {engine?: string} | undefined)
+                ?.engine,
             ...validateOutput,
         };
     }

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -80,6 +80,7 @@ import {
 } from "./bundle";
 import {showWhatsNewPopup} from "./whatsNewPopup";
 import {BundleValidateModel} from "./bundle/models/BundleValidateModel";
+import {BundleEngineManager} from "./bundle/BundleEngineManager";
 import {ConfigModel} from "./configuration/models/ConfigModel";
 import {OverrideableConfigModel} from "./configuration/models/OverrideableConfigModel";
 import {BundlePreValidateModel} from "./bundle/models/BundlePreValidateModel";
@@ -712,6 +713,12 @@ export async function activate(
         stateStorage
     );
 
+    const bundleEngineManager = new BundleEngineManager(
+        bundleValidateModel,
+        stateStorage,
+        telemetry
+    );
+
     const connectionManager = new ConnectionManager(
         cli,
         configModel,
@@ -744,6 +751,7 @@ export async function activate(
         bundlePreValidateModel,
         bundleRemoteStateModel,
         configModel,
+        bundleEngineManager,
         connectionManager,
         connectionManager.onDidChangeState(async () => {
             telemetry.setMetadata(

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -350,7 +350,7 @@ export class EventTypes {
             "Surfaced the deprecation warning for the Terraform bundle deployment engine. Recorded once per surfacing (at most once per session per workspace, until the user opts out), so the count tracks how many users still have bundles on the Terraform engine.",
         action: {
             comment:
-                "What the user did with the warning: 'guide' opened the migration guide, 'hidden' chose \"Don't show again\" (persisted opt-out for the workspace), 'dismissed' closed it without either.",
+                "What the user did with the warning: 'guide' chose to open the migration guide, 'hidden' chose \"Don't show again\" (persisted opt-out for the workspace), 'dismissed' closed it without either.",
         },
     };
     [Events.AITOOLS_INSTALL]: EventType<

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -19,6 +19,7 @@ export enum Events {
     BUNDLE_RUN = "bundleRun",
     BUNDLE_INIT = "bundleInit",
     BUNDLE_SUB_PROJECTS = "bundleSubProjects",
+    BUNDLE_TERRAFORM_ENGINE_WARNING = "bundleTerraformEngineWarning",
     CONNECTION_STATE_CHANGED = "connectionStateChanged",
     COMPUTE_SELECTED = "computeSelected",
     WORKFLOW_RUN = "workflowRun",
@@ -43,6 +44,16 @@ export type ManualLoginSource =
     | "command"
     | "api";
 export type BundleRunResourceType = "pipelines" | "jobs";
+/**
+ * What the user did with the Terraform-engine deprecation warning:
+ *  - `'guide'` — opened the migration guide.
+ *  - `'hidden'` — chose "Don't show again" (persisted opt-out for the workspace).
+ *  - `'dismissed'` — closed it without either.
+ */
+export type BundleTerraformEngineWarningAction =
+    | "guide"
+    | "hidden"
+    | "dismissed";
 export type BundleRunType =
     | "run"
     | "validate"
@@ -330,6 +341,16 @@ export class EventTypes {
         comment: "An external resource URL was opened",
         type: {
             comment: "The resource type",
+        },
+    };
+    [Events.BUNDLE_TERRAFORM_ENGINE_WARNING]: EventType<{
+        action: BundleTerraformEngineWarningAction;
+    }> = {
+        comment:
+            "Surfaced the deprecation warning for the Terraform bundle deployment engine. Recorded once per surfacing (at most once per session per project, until the user opts out), so the count tracks how many users still have bundles on the Terraform engine.",
+        action: {
+            comment:
+                "What the user did with the warning: 'guide' opened the migration guide, 'hidden' chose \"Don't show again\" (persisted opt-out for the workspace), 'dismissed' closed it without either.",
         },
     };
     [Events.AITOOLS_INSTALL]: EventType<

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -347,7 +347,7 @@ export class EventTypes {
         action: BundleTerraformEngineWarningAction;
     }> = {
         comment:
-            "Surfaced the deprecation warning for the Terraform bundle deployment engine. Recorded once per surfacing (at most once per session per project, until the user opts out), so the count tracks how many users still have bundles on the Terraform engine.",
+            "Surfaced the deprecation warning for the Terraform bundle deployment engine. Recorded once per surfacing (at most once per session per workspace, until the user opts out), so the count tracks how many users still have bundles on the Terraform engine.",
         action: {
             comment:
                 "What the user did with the warning: 'guide' opened the migration guide, 'hidden' chose \"Don't show again\" (persisted opt-out for the workspace), 'dismissed' closed it without either.",

--- a/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
+++ b/packages/databricks-vscode/src/vscode-objs/StateStorage.ts
@@ -117,6 +117,15 @@ const StorageConfigurations = {
         location: "global",
         defaultValue: false,
     }),
+
+    // Set when the user picks "Don't show again" on the deprecation warning for
+    // the Terraform bundle deployment engine, so it stays silenced for this
+    // workspace. A plain dismissal leaves it false so the warning can resurface
+    // on a later session (see BundleEngineManager).
+    "databricks.bundle.hideTerraformEngineWarning": withType<boolean>()({
+        location: "workspace",
+        defaultValue: false,
+    }),
 };
 
 type Keys = keyof typeof StorageConfigurations;


### PR DESCRIPTION
## Summary

The Databricks CLI has deprecated the **Terraform** bundle deployment engine in favour of the **direct** engine. For bundles still pinned to `engine: terraform`, the CLI emits a deprecation warning — but the extension surfaced nothing: the warning only reached the raw "Databricks Logs" output channel, where users don't see it.

This adds a one-time warning notification when a project's bundle uses the Terraform engine.

## What changed

- **Detection (structured, not text-parsing):** `bundle.engine` is now read off the `bundle validate` output onto `BundleValidateState`. (The field isn't in the generated `BundleSchema`, so it's read directly — `BundleSchema.ts` is untouched.)
- **`BundleEngineManager`:** observes validate changes and, when the engine is `terraform`, shows a warning notification:
  > This project uses the Terraform deployment engine, which is deprecated and will stop working in a future Databricks CLI version. Migrate to the direct deployment engine.

  with **Read migration guide** (opens the direct-engine docs) and **Don't show again**. Shown at most once per session per project; the opt-out is persisted per workspace.
- **State + telemetry:** a new workspace `StateStorage` key backs the opt-out, and a telemetry event records that the warning surfaced and what the user did with it (so we can measure how many users are still on the Terraform engine).

## Testing

- `yarn test:lint` clean (only a pre-existing `MOCHA_GREP` naming warning).
- Full unit suite: **924 passing**, including **8 new** `BundleEngineManager` tests (warns on terraform; silent on direct/unset; once-per-session; respects persisted opt-out; guide/hidden/dismissed actions).
- Manually reproduced the CLI warning against a `bundle init` project pinned to `engine: terraform` (validate + deploy).

This pull request and its description were written by Isaac.
