### PR TITLE
Prompt users to report post-preflight setup-local failures

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1025,6 +1025,11 @@ export async function activate(
                 append: (chunk) => getPythonSetupLogChannel().append(chunk),
                 show: () => getPythonSetupLogChannel().show(true),
             },
+            reportEnvironment: {
+                extensionVersion: packageMetadata.version,
+                cliVersion: packageMetadata.cliVersion,
+                platform: process.platform,
+            },
             telemetry,
         })
     );

--- a/packages/databricks-vscode/src/python-setup/README.md
+++ b/packages/databricks-vscode/src/python-setup/README.md
@@ -3,3 +3,21 @@
 Frictionless, uv-native "set up Python environment" feature: a thin wrapper over
 the `databricks environments setup-local` CLI command that matches the local
 Python environment to the selected Databricks compute.
+
+## "Report this problem" affordance
+
+A setup-local failure that gets *past* the pre-flight checks usually indicates a
+defect we own — a bad published constraint or an extension/CLI bug — not
+something the user can fix. Those failures surface a "Report this problem" button
+that deep-links a pre-filled GitHub new-issue form, routed by error code to the
+repository that owns the defect (`databricks/environments` for constraint-content
+defects, `databricks/databricks-vscode` for extension/CLI defects). Pre-flight,
+local, and network codes are deliberately excluded — they stay actionable from
+the mapped message alone (see `reportSetupIssue.ts` for the closed routing list).
+
+**Privacy posture.** The issue body carries only build metadata (error code,
+phase, env key, package manager, extension/CLI versions, OS) plus the CLI's
+stderr. The stderr is scrubbed of usernames, home paths, tokens, and emails
+before it goes into the URL — but that scrub is *defence-in-depth*, not the sole
+guard: a deep-link only pre-fills the form, which the user reviews and submits
+themselves. Nothing is sent automatically.

--- a/packages/databricks-vscode/src/python-setup/README.md
+++ b/packages/databricks-vscode/src/python-setup/README.md
@@ -6,7 +6,7 @@ Python environment to the selected Databricks compute.
 
 ## "Report this problem" affordance
 
-A setup-local failure that gets *past* the pre-flight checks usually indicates a
+A setup-local failure that gets _past_ the pre-flight checks usually indicates a
 defect we own — a bad published constraint or an extension/CLI bug — not
 something the user can fix. Those failures surface a "Report this problem" button
 that deep-links a pre-filled GitHub new-issue form, routed by error code to the
@@ -15,9 +15,15 @@ defects, `databricks/databricks-vscode` for extension/CLI defects). Pre-flight,
 local, and network codes are deliberately excluded — they stay actionable from
 the mapped message alone (see `reportSetupIssue.ts` for the closed routing list).
 
-**Privacy posture.** The issue body carries only build metadata (error code,
-phase, env key, package manager, extension/CLI versions, OS) plus the CLI's
-stderr. The stderr is scrubbed of usernames, home paths, tokens, and emails
-before it goes into the URL — but that scrub is *defence-in-depth*, not the sole
-guard: a deep-link only pre-fills the form, which the user reviews and submits
-themselves. Nothing is sent automatically.
+`E_PROVISION` (a uv resolution conflict) is intentionally _not_ a report button:
+such a conflict is usually the user's own declared dependencies. When the
+published constraints are what conflict, that genuine case is served by a soft,
+conditional pointer in the output log instead (see `formatSetupFailureDetail`).
+
+**Privacy posture.** The issue body carries build metadata (error code, phase,
+env key, package manager, extension/CLI versions, OS) plus the CLI's stderr. The
+stderr is scrubbed on a best-effort basis — usernames, home paths, tokens
+(Databricks PATs, GitHub/AWS keys, JWTs, bearer credentials), URL credentials,
+and emails — to _reduce, not eliminate,_ PII exposure. That scrub is
+defence-in-depth, not the sole guard: a deep-link only pre-fills the form, which
+the user reviews and submits themselves. Nothing is sent automatically.

--- a/packages/databricks-vscode/src/python-setup/README.md
+++ b/packages/databricks-vscode/src/python-setup/README.md
@@ -27,3 +27,9 @@ stderr is scrubbed on a best-effort basis — usernames, home paths, tokens
 and emails — to _reduce, not eliminate,_ PII exposure. That scrub is
 defence-in-depth, not the sole guard: a deep-link only pre-fills the form, which
 the user reviews and submits themselves. Nothing is sent automatically.
+
+The `pyproject.toml` is the crux for merge/resolution failures but is **not**
+auto-collected (it can carry private dependencies); the body instead includes a
+placeholder asking the reporter to paste a redacted copy. The body carries no
+`#` markdown headings on purpose — a `#` in the deep-link's query is
+double-encoded before the browser and renders as `%23`.

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -1281,11 +1281,15 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
 
     it("does not report ok when the post-adoption state bookkeeping throws", async () => {
         const telemetry = makeTelemetryRecorder();
+        const shown: {action?: PythonSetupErrorAction}[] = [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 ...telemetry,
                 saveState: () => {
                     throw new Error("workspaceState write failed");
+                },
+                showError: async (_m, _detail, action) => {
+                    shown.push({action});
                 },
             })
         );
@@ -1300,11 +1304,18 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         // The run rejected, so recording success would permanently overstate the
         // success rate.
         expect(rejected).to.equal(true);
+        // The user is still told the run failed and offered a report — a persist
+        // break is the extension's own defect, like adopt.
+        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].action?.url).to.contain(
+            "databricks/databricks-vscode/issues/new"
+        );
         expect(telemetry.results).to.deep.equal([
             {
                 outcome: "failed",
                 failurePhase: "persist",
                 envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                reportOffered: true,
                 warnings: SUCCESS_REAL_RUN.warnings,
             },
         ]);

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -562,6 +562,31 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         });
     });
 
+    it("handles a non-Error rejection without throwing on the spawn path", async () => {
+        const shown: {message: string; action?: PythonSetupErrorAction}[] = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                // A rejection that is not an Error instance: `.message` would be
+                // undefined, and the redactor must not throw on it.
+                cli: {
+                    run: async () => {
+                        throw "spawn failed as a bare string";
+                    },
+                },
+                showError: async (message, _detail, action) => {
+                    shown.push({message, action});
+                },
+            })
+        );
+
+        // Must resolve, not reject — the original failure has to reach the user.
+        await setup.setup();
+
+        expect(shown).to.have.length(1);
+        expect(shown[0].message).to.contain("spawn failed as a bare string");
+        expect(shown[0].action?.label).to.equal("Report this problem");
+    });
+
     it("offers a Report this problem action when interpreter adoption fails", async () => {
         const shown: {action?: PythonSetupErrorAction}[] = [];
         const telemetry = makeTelemetryRecorder();

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -127,6 +127,11 @@ function makeDeps(
         notify: async () => {},
         showError: async () => {},
         showSuccess: async () => {},
+        reportEnvironment: {
+            extensionVersion: "2.14.1",
+            cliVersion: "1.13.0",
+            platform: "darwin",
+        },
         // Mirror the production wrapper: hand the task a log sink and a
         // (never-cancelled) progress token.
         withProgress: async (_title, task) => task(() => {}, makeToken()),
@@ -414,6 +419,106 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         expect(shown[0].action).to.equal(undefined);
     });
 
+    it("makes Report this problem the button for a report-worthy CLI failure", async () => {
+        const shown: {detail?: string; action?: PythonSetupErrorAction}[] = [];
+        const telemetry = makeTelemetryRecorder();
+        const mergeFailure: PythonSetupResult = {
+            schemaVersion: 1,
+            command: "environments setup-local",
+            ok: false,
+            mode: "default",
+            dryRun: false,
+            greenfield: false,
+            phases: [],
+            warnings: [],
+            durationMs: 0,
+            error: {
+                code: "E_MERGE",
+                failurePhase: "merge",
+                message: "merge blew up",
+                diskMutated: true,
+            },
+        };
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: mergeFailure}),
+                recordSetupAttempt: telemetry.recordSetupAttempt,
+                showError: async (_m, detail, action) => {
+                    shown.push({detail, action});
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].action?.url).to.contain(
+            "databricks/databricks-vscode/issues/new"
+        );
+        // The bare new-issue URL is mirrored into the log too.
+        expect(shown[0].detail).to.contain(
+            "Report this problem: https://github.com/databricks/databricks-vscode/issues/new"
+        );
+        expect(telemetry.results[0].reportOffered).to.equal(true);
+    });
+
+    it("keeps Report as the button while mirroring the doc link into the log", async () => {
+        // E_ENV_UNSUPPORTED is report-worthy AND has a doc link: report wins the
+        // button; the doc link still appears in the log.
+        const shown: {detail?: string; action?: PythonSetupErrorAction}[] = [];
+        const envUnsupported: PythonSetupResult = {
+            schemaVersion: 1,
+            command: "environments setup-local",
+            ok: false,
+            mode: "default",
+            dryRun: false,
+            greenfield: false,
+            phases: [],
+            warnings: [],
+            durationMs: 0,
+            compute: {source: "cluster", envKey: "dbr/15.4.x-scala2.12"},
+            error: {
+                code: "E_ENV_UNSUPPORTED",
+                failurePhase: "resolve",
+                message: "no published environment",
+                diskMutated: false,
+            },
+        };
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: envUnsupported}),
+                showError: async (_m, detail, action) => {
+                    shown.push({detail, action});
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].action?.url).to.contain(
+            "databricks/environments/issues/new"
+        );
+        expect(shown[0].detail).to.contain("Databricks Runtime versions");
+        expect(shown[0].detail).to.contain(
+            "Report this problem: https://github.com/databricks/environments/issues/new"
+        );
+    });
+
+    it("records reportOffered=false for a non-report-worthy CLI failure", async () => {
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: ERROR_NO_TARGET}),
+                recordSetupAttempt: telemetry.recordSetupAttempt,
+            })
+        );
+
+        await setup.setup();
+
+        expect(telemetry.results[0].reportOffered).to.equal(false);
+    });
+
     it("surfaces the raw error message when the CLI run rejects", async () => {
         const shownErrors: string[] = [];
         const setup = new PythonSetupEnvironmentSetup(
@@ -430,6 +535,60 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
 
         expect(setup.ready).to.equal(false);
         expect(shownErrors).to.deep.equal(["spawn databricks ENOENT"]);
+    });
+
+    it("offers a Report this problem action on a spawn/parse rejection", async () => {
+        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({reject: new Error("spawn databricks ENOENT")}),
+                recordSetupAttempt: telemetry.recordSetupAttempt,
+                showError: async (_m, _detail, action) => {
+                    shown.push({action});
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].action?.url).to.contain(
+            "databricks/databricks-vscode/issues/new"
+        );
+        expect(telemetry.results[0]).to.include({
+            outcome: "not_started",
+            reportOffered: true,
+        });
+    });
+
+    it("offers a Report this problem action when interpreter adoption fails", async () => {
+        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const telemetry = makeTelemetryRecorder();
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: SUCCESS_REAL_RUN}),
+                adoptInterpreter: async () => {
+                    throw new Error("adopt failed");
+                },
+                recordSetupAttempt: telemetry.recordSetupAttempt,
+                showError: async (_m, _detail, action) => {
+                    shown.push({action});
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].action?.url).to.contain(
+            "databricks/databricks-vscode/issues/new"
+        );
+        expect(telemetry.results[0]).to.include({
+            outcome: "failed",
+            failurePhase: "adopt",
+            reportOffered: true,
+        });
     });
 
     it("treats a success without a venv path as a failure", async () => {
@@ -894,6 +1053,8 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 diskMutated: ERROR_NO_TARGET.error!.diskMutated,
                 // E_NO_TARGET is not one of the package-fetching phases.
                 indexUnreachable: false,
+                // E_NO_TARGET is a preflight/local code, never report-worthy.
+                reportOffered: false,
                 warnings: ERROR_NO_TARGET.warnings,
             },
         ]);
@@ -951,6 +1112,8 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
                 outcome: "failed",
                 failurePhase: "adopt",
                 envKey: SUCCESS_REAL_RUN.compute!.envKey,
+                // An adopt failure is the extension's own defect → report offered.
+                reportOffered: true,
                 warnings: SUCCESS_REAL_RUN.warnings,
             },
         ]);
@@ -983,8 +1146,11 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         await setup.setup();
 
         // A spawn/parse error has no result object, so there is no phase or
-        // error code to attribute the break to.
-        expect(telemetry.results).to.deep.equal([{outcome: "not_started"}]);
+        // error code to attribute the break to. It is the extension/CLI's own
+        // defect, so a report against databricks-vscode is offered.
+        expect(telemetry.results).to.deep.equal([
+            {outcome: "not_started", reportOffered: true},
+        ]);
     });
 
     it("records nothing when there is no project or the gate is closed", async () => {

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -18,6 +18,14 @@ import {
     NO_COMPUTE_TARGET_MESSAGE,
     PythonSetupErrorAction,
 } from "../utils/errorMessages";
+import {
+    buildExtensionFailureReportAction,
+    getPythonSetupReportAction,
+    reportLogLink,
+    reportLogMirror,
+    reportRepoForResult,
+    ReportEnvironment,
+} from "../utils/reportSetupIssue";
 import {SetupLocalInvocation} from "../utils/setupLocalArgs";
 import {
     PythonSetupAttempt,
@@ -146,6 +154,13 @@ export interface PythonSetupSetupDeps {
     ) => Promise<void>;
 
     showSuccess: (result: PythonSetupResult) => Promise<void>;
+
+    /**
+     * Static build context (extension/CLI versions, OS) stamped into a
+     * "Report this problem" issue body. The per-run package manager is merged in
+     * by the orchestrator; this carries only what is constant for the session.
+     */
+    reportEnvironment: ReportEnvironment;
 
     withProgress: <T>(title: string, task: ProgressTask<T>) => Promise<T>;
 
@@ -350,7 +365,15 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         // exit below reports an outcome. The reporter also starts the clock:
         // the duration we publish is the whole user-visible wait, including CLI
         // spawn and interpreter adoption.
-        const reportResult = await this.recordAttempt(invocation, cwd);
+        const {reportResult, packageManager} = await this.recordAttempt(
+            invocation,
+            cwd
+        );
+        // Per-run report context: the static build info plus this run's manager.
+        const reportEnv: ReportEnvironment = {
+            ...this.deps.reportEnvironment,
+            packageManager,
+        };
 
         let result: PythonSetupResult;
         try {
@@ -367,13 +390,30 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             // Spawn/parse errors reject with a real Error carrying CLI stderr;
             // there is no result to map, so surface the message directly. No
             // result object exists, hence `not_started` rather than `failed`:
-            // there is no phase or error code to attribute the break to.
-            reportResult({outcome: "not_started"});
-            this.present(this.deps.showError((e as Error).message));
+            // there is no phase or error code to attribute the break to. A
+            // spawn/parse break is the extension/CLI's own defect, so it always
+            // offers a report against databricks/databricks-vscode.
+            const reportAction = buildExtensionFailureReportAction(reportEnv, {
+                phase: "spawn",
+                message: (e as Error).message,
+            });
+            reportResult({outcome: "not_started", reportOffered: true});
+            this.present(
+                this.deps.showError(
+                    (e as Error).message,
+                    reportLogMirror("databricks/databricks-vscode"),
+                    reportAction
+                )
+            );
             return;
         }
 
         if (!isLocalEnvironmentReady(result)) {
+            // Report is the primary button for a report-worthy failure; its doc
+            // link (if any) drops to the log. A non-report-worthy failure keeps
+            // its doc-link button, unchanged.
+            const reportAction = getPythonSetupReportAction(result, reportEnv);
+            const reportRepo = reportRepoForResult(result);
             reportResult({
                 outcome: "failed",
                 failurePhase: result.error?.failurePhase,
@@ -381,13 +421,17 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 envKey: result.compute?.envKey,
                 diskMutated: result.error?.diskMutated,
                 indexUnreachable: isIndexUnreachableFailure(result),
+                reportOffered: reportAction !== undefined,
                 warnings: result.warnings,
             });
             this.present(
                 this.deps.showError(
                     getPythonSetupErrorMessage(result),
-                    formatSetupFailureDetail(result),
-                    getPythonSetupErrorAction(result)
+                    formatSetupFailureDetail(
+                        result,
+                        reportRepo ? reportLogLink(reportRepo) : undefined
+                    ),
+                    reportAction ?? getPythonSetupErrorAction(result)
                 )
             );
             return;
@@ -404,14 +448,27 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         } catch (e) {
             // The CLI succeeded, so there is no CLI error to report — but the
             // flow failed. `adopt` is the extension's own phase, appended to the
-            // CLI's six so the funnel shows breaks that happen after it exits.
+            // CLI's six so the funnel shows breaks that happen after it exits. An
+            // adopt failure is the extension's own defect, so it always offers a
+            // report against databricks/databricks-vscode.
+            const reportAction = buildExtensionFailureReportAction(reportEnv, {
+                phase: "adopt",
+                message: (e as Error).message,
+            });
             reportResult({
                 outcome: "failed",
                 failurePhase: "adopt",
                 envKey: result.compute.envKey,
+                reportOffered: true,
                 warnings: result.warnings,
             });
-            this.present(this.deps.showError((e as Error).message));
+            this.present(
+                this.deps.showError(
+                    (e as Error).message,
+                    reportLogMirror("databricks/databricks-vscode"),
+                    reportAction
+                )
+            );
             return;
         }
 
@@ -458,11 +515,18 @@ export class PythonSetupEnvironmentSetup implements Disposable {
      * best-effort: a failure gathering the attempt's context degrades to
      * `unknown`/omitted, and a failure in the emit itself is swallowed — the
      * returned reporter then becomes a no-op rather than throwing mid-run.
+     *
+     * The detected `packageManager` is returned alongside the reporter so the
+     * failure paths can stamp it into a "Report this problem" issue body without
+     * re-running detection.
      */
     private async recordAttempt(
         invocation: SetupLocalInvocation,
         projectRoot: string
-    ): Promise<PythonSetupResultReporter> {
+    ): Promise<{
+        reportResult: PythonSetupResultReporter;
+        packageManager: PrimaryManager;
+    }> {
         const {compute} = invocation;
         // An unavailable detection degrades to "no manager fired", which reads as
         // a greenfield-suitable project -- the same reading the visibility gate
@@ -507,16 +571,19 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 // so every entry point labels the same event correctly.
                 trigger: this.readyRoots.has(projectRoot) ? "rerun" : "initial",
             });
-            return (report) => {
-                try {
-                    reportResult(report);
-                } catch {
-                    // Swallow: the run's outcome has already been decided and
-                    // surfaced to the user by the time this is called.
-                }
+            return {
+                packageManager,
+                reportResult: (report) => {
+                    try {
+                        reportResult(report);
+                    } catch {
+                        // Swallow: the run's outcome has already been decided and
+                        // surfaced to the user by the time this is called.
+                    }
+                },
             };
         } catch {
-            return () => {};
+            return {packageManager, reportResult: () => {}};
         }
     }
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -491,12 +491,28 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             this.readyRoots.add(cwd);
             this.stateEmitter.fire();
         } catch (e) {
+            // A persist break happens after the environment already works, so
+            // it is the extension's own defect — surface it and offer a report
+            // (like the adopt path) instead of failing silently. The throw is
+            // preserved so the run is never mis-recorded as ok.
+            const message = e instanceof Error ? e.message : String(e);
             reportResult({
                 outcome: "failed",
                 failurePhase: "persist",
                 envKey: result.compute.envKey,
+                reportOffered: true,
                 warnings: result.warnings,
             });
+            this.present(
+                this.deps.showError(
+                    message,
+                    reportLogMirror("databricks/databricks-vscode"),
+                    buildExtensionFailureReportAction(reportEnv, {
+                        phase: "persist",
+                        message,
+                    })
+                )
+            );
             throw e;
         }
 

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -392,15 +392,18 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             // result object exists, hence `not_started` rather than `failed`:
             // there is no phase or error code to attribute the break to. A
             // spawn/parse break is the extension/CLI's own defect, so it always
-            // offers a report against databricks/databricks-vscode.
+            // offers a report against databricks/databricks-vscode. Normalize a
+            // non-Error rejection so `.message` is never undefined (the redactor
+            // would throw on it, swallowing the original failure).
+            const message = e instanceof Error ? e.message : String(e);
             const reportAction = buildExtensionFailureReportAction(reportEnv, {
                 phase: "spawn",
-                message: (e as Error).message,
+                message,
             });
             reportResult({outcome: "not_started", reportOffered: true});
             this.present(
                 this.deps.showError(
-                    (e as Error).message,
+                    message,
                     reportLogMirror("databricks/databricks-vscode"),
                     reportAction
                 )
@@ -450,10 +453,13 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             // flow failed. `adopt` is the extension's own phase, appended to the
             // CLI's six so the funnel shows breaks that happen after it exits. An
             // adopt failure is the extension's own defect, so it always offers a
-            // report against databricks/databricks-vscode.
+            // report against databricks/databricks-vscode. Normalize a non-Error
+            // rejection so `.message` is never undefined (the redactor would
+            // throw on it, swallowing the original failure).
+            const message = e instanceof Error ? e.message : String(e);
             const reportAction = buildExtensionFailureReportAction(reportEnv, {
                 phase: "adopt",
-                message: (e as Error).message,
+                message,
             });
             reportResult({
                 outcome: "failed",
@@ -464,7 +470,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             });
             this.present(
                 this.deps.showError(
-                    (e as Error).message,
+                    message,
                     reportLogMirror("databricks/databricks-vscode"),
                     reportAction
                 )

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -167,6 +167,11 @@ function makeWiring(
         setActiveInterpreter: async () => {},
         persistSetupState: () => {},
         log: {append: () => {}, show: () => {}},
+        reportEnvironment: {
+            extensionVersion: "2.14.1",
+            cliVersion: "1.13.0",
+            platform: "darwin",
+        },
         // A reporter-less client: recordEvent short-circuits, so the setup
         // events are inert here (they have their own tests).
         telemetry: new Telemetry(undefined),

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -7,6 +7,7 @@ import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
 import {openExternal} from "../../utils/urlUtils";
 import {PythonSetupErrorAction} from "../utils/errorMessages";
+import {ReportEnvironment} from "../utils/reportSetupIssue";
 import {isUvSetupSuitable} from "../utils/pythonSetupGate";
 import {withElapsedProgress} from "../utils/setupProgress";
 import {formatSetupLog, formatSetupNotification} from "../utils/setupSummary";
@@ -154,6 +155,12 @@ export interface PythonSetupWiringDeps {
         append: (chunk: string) => void;
         show: () => void;
     };
+    /**
+     * Static build context stamped into a "Report this problem" issue body
+     * (extension/CLI versions, OS). The per-run package manager is merged in by
+     * the orchestrator.
+     */
+    reportEnvironment: ReportEnvironment;
     /** Records the setup attempt/result events. */
     telemetry: Telemetry;
 }
@@ -304,6 +311,7 @@ export function makePythonSetupDeps(
                 wiring.log.show();
             }
         },
+        reportEnvironment: wiring.reportEnvironment,
         recordSetupAttempt: (attempt) =>
             wiring.telemetry.recordPythonSetupAttempt(attempt),
         recordNoCompute: () => wiring.telemetry.recordPythonSetupNoCompute(),

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -455,6 +455,38 @@ describe("formatSetupFailureDetail", () => {
         expect(detail).to.not.contain("UV_INDEX_URL");
     });
 
+    it("adds a constraints-report hint for a genuine E_PROVISION conflict", () => {
+        const detail = formatSetupFailureDetail(
+            failure("E_PROVISION", {
+                message: "No solution found when resolving dependencies",
+            })
+        );
+        // A soft, conditional pointer — no button — so a user who believes the
+        // published constraints are at fault can report it, without labelling
+        // an ordinary (user-owned) dependency conflict as a product defect.
+        expect(detail).to.match(/constraint/i);
+        expect(detail).to.contain(
+            "https://github.com/databricks/environments/issues/new"
+        );
+    });
+
+    it("adds no constraints-report hint for a blocked-index E_PROVISION", () => {
+        // A blocked index is a local network condition, not a constraint defect.
+        const detail = formatSetupFailureDetail(
+            failure("E_PROVISION", {message: INDEX_UNREACHABLE_CLI_MSG})
+        );
+        expect(detail).to.not.contain(
+            "https://github.com/databricks/environments/issues/new"
+        );
+    });
+
+    it("adds no constraints-report hint for a non-E_PROVISION failure", () => {
+        const detail = formatSetupFailureDetail(failure("E_MERGE"));
+        expect(detail).to.not.contain(
+            "https://github.com/databricks/environments/issues/new"
+        );
+    });
+
     it("appends the documentation link and its label for a code that has one", () => {
         const detail = formatSetupFailureDetail(
             failure("E_NO_TARGET", {failurePhase: "resolve"})

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -419,6 +419,21 @@ describe("formatSetupFailureDetail", () => {
         expect(formatSetupFailureDetail(ok)).to.equal(undefined);
     });
 
+    it("mirrors the report link into the log when one is provided", () => {
+        const detail = formatSetupFailureDetail(failure("E_MERGE"), {
+            label: "Report this problem",
+            url: "https://github.com/databricks/databricks-vscode/issues/new",
+        });
+        expect(detail).to.contain(
+            "Report this problem: https://github.com/databricks/databricks-vscode/issues/new"
+        );
+    });
+
+    it("omits the report line when no report link is given", () => {
+        const detail = formatSetupFailureDetail(failure("E_MERGE"));
+        expect(detail).to.not.contain("Report this problem");
+    });
+
     it("appends copy-pasteable proxy remediation for a blocked index", () => {
         const detail = formatSetupFailureDetail(
             failure("E_PROVISION", {message: INDEX_UNREACHABLE_CLI_MSG})

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -274,9 +274,13 @@ export function getPythonSetupErrorAction(
  *
  * Returns `undefined` when the result carries no error, i.e. there is nothing to
  * add to the log.
+ *
+ * `reportLink`, when given, is a "Report this problem" link mirrored into the log
+ * so it outlives the dismissed notification — see the report-issue helpers.
  */
 export function formatSetupFailureDetail(
-    result: PythonSetupResult
+    result: PythonSetupResult,
+    reportLink?: PythonSetupErrorAction
 ): string | undefined {
     const err = result.error;
     if (!err) {
@@ -320,6 +324,12 @@ export function formatSetupFailureDetail(
     const action = getPythonSetupErrorAction(result);
     if (action) {
         lines.push("", `${action.label}: ${action.url}`);
+    }
+    // The report link is mirrored here too (a bare new-issue URL, not the popup's
+    // long pre-filled deep-link) so it survives the notification being dismissed.
+    // It is additive to the doc link above: a report-worthy code can carry both.
+    if (reportLink) {
+        lines.push("", `${reportLink.label}: ${reportLink.url}`);
     }
     // Bracket with blank lines so the block stands apart from any streamed CLI
     // output already in the channel.

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -69,6 +69,15 @@ export const DATABRICKS_RUNTIME_DOCS_URL =
     "https://docs.databricks.com/aws/en/release-notes/runtime/";
 
 /**
+ * New-issue page for the published environment constraints. Surfaced only as a
+ * soft, conditional pointer in the log for a genuine `E_PROVISION` conflict —
+ * not a button — because such a conflict is usually the user's own dependencies,
+ * not a constraint defect (see the report-worthiness routing in reportSetupIssue).
+ */
+export const DATABRICKS_ENVIRONMENTS_NEW_ISSUE_URL =
+    "https://github.com/databricks/environments/issues/new";
+
+/**
  * "Cannot reach the host" phrases in uv's error text (matched case-insensitively).
  * TLS-interception and proxy-auth (407) are deliberately left out: they need a
  * CA-trust / credentials fix, not a different index.
@@ -317,6 +326,18 @@ export function formatSetupFailureDetail(
             "       [global]",
             "       index-url = https://<your-proxy>/simple",
             "     Use index-url (not extra-index-url) so pypi.org is replaced, not merely supplemented."
+        );
+    }
+    // A genuine E_PROVISION conflict gets no report button (it is usually the
+    // user's own dependencies). But if the *published constraints* are what
+    // conflict, that is a defect worth reporting — so offer a soft, conditional
+    // pointer here. Excludes the blocked-index variant, a local network issue.
+    if (err.code === "E_PROVISION" && !isIndexUnreachableFailure(result)) {
+        lines.push(
+            "",
+            "If you believe this conflict comes from the published runtime " +
+                "constraints rather than your own project dependencies, report " +
+                `it to the environments repository: ${DATABRICKS_ENVIRONMENTS_NEW_ISSUE_URL}`
         );
     }
     // The same doc link the popup offers as a button, spelled out here so the URL

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -195,6 +195,14 @@ describe("redactSetupStderr", () => {
         expect(out).to.not.contain(jwt);
     });
 
+    it("redacts secret values passed as URL query parameters", () => {
+        const out = redactSetupStderr(
+            "fetch https://pkgs.corp/simple/?token=SECRETVAL&sig=AZURESAS123"
+        );
+        expect(out).to.not.contain("SECRETVAL");
+        expect(out).to.not.contain("AZURESAS123");
+    });
+
     it("redacts a bearer token containing non-word characters", () => {
         const out = redactSetupStderr(
             "Authorization: Bearer abc.def/ghi+jkl=mno end"

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -1,0 +1,255 @@
+import {expect} from "chai";
+import {
+    buildExtensionFailureReportAction,
+    buildSetupReportUrl,
+    getPythonSetupReportAction,
+    redactSetupStderr,
+    reportNewIssueBaseUrl,
+    reportRepoForResult,
+    isReportWorthy,
+    ReportEnvironment,
+} from "./reportSetupIssue";
+import {
+    PythonSetupResult,
+    PythonSetupErrorCode,
+} from "../models/PythonSetupResult";
+
+/**
+ * A uv "package index unreachable" error message — the same signature the
+ * blocked-index detector in errorMessages keys off. Used to prove the
+ * network-blocked variant of E_PROVISION is NOT report-worthy.
+ */
+const INDEX_UNREACHABLE_CLI_MSG =
+    "Using CPython 3.12.8\n" +
+    "error: Failed to fetch: `https://pypi.org/simple/ipykernel/`\n" +
+    "  Caused by: tcp connect error: Connection refused (os error 61)";
+
+/** Build a minimal failed result carrying a specific error. */
+function failure(
+    code: PythonSetupErrorCode,
+    extra: Partial<NonNullable<PythonSetupResult["error"]>> = {},
+    resultExtra: Partial<PythonSetupResult> = {}
+): PythonSetupResult {
+    return {
+        schemaVersion: 1,
+        command: "environments setup-local",
+        ok: false,
+        mode: "default",
+        dryRun: false,
+        greenfield: false,
+        phases: [],
+        warnings: [],
+        durationMs: 0,
+        error: {
+            code,
+            failurePhase: "provision",
+            message: "raw cli detail",
+            diskMutated: false,
+            ...extra,
+        },
+        ...resultExtra,
+    };
+}
+
+const ENV: ReportEnvironment = {
+    extensionVersion: "2.14.1",
+    cliVersion: "1.13.0",
+    platform: "darwin",
+    packageManager: "uv",
+};
+
+describe("reportRepoForResult / isReportWorthy", () => {
+    it("routes constraint-content defects to databricks/environments", () => {
+        for (const code of [
+            "E_ENV_UNSUPPORTED",
+            "E_PROVISION",
+            "E_VALIDATE",
+        ] as PythonSetupErrorCode[]) {
+            expect(reportRepoForResult(failure(code))).to.equal(
+                "databricks/environments"
+            );
+            expect(isReportWorthy(failure(code))).to.equal(true);
+        }
+    });
+
+    it("routes extension/CLI defects to databricks/databricks-vscode", () => {
+        for (const code of ["E_MERGE", "E_WRITE"] as PythonSetupErrorCode[]) {
+            expect(reportRepoForResult(failure(code))).to.equal(
+                "databricks/databricks-vscode"
+            );
+        }
+    });
+
+    it("does NOT treat a blocked-index E_PROVISION as report-worthy", () => {
+        const r = failure("E_PROVISION", {message: INDEX_UNREACHABLE_CLI_MSG});
+        expect(reportRepoForResult(r)).to.equal(undefined);
+        expect(isReportWorthy(r)).to.equal(false);
+    });
+
+    it("does NOT offer a report for preflight/local/network codes", () => {
+        for (const code of [
+            "E_USAGE",
+            "E_MANAGER_UNSUPPORTED",
+            "E_NOT_WRITABLE",
+            "E_UV_MISSING",
+            "E_NO_TARGET",
+            "E_RESOLVE",
+            "E_FETCH",
+            "E_PYTHON_INSTALL",
+        ] as PythonSetupErrorCode[]) {
+            expect(reportRepoForResult(failure(code))).to.equal(undefined);
+        }
+    });
+
+    it("is not report-worthy when the result carries no error", () => {
+        const ok = failure("E_MERGE");
+        ok.error = null;
+        expect(isReportWorthy(ok)).to.equal(false);
+    });
+});
+
+describe("redactSetupStderr", () => {
+    it("strips the username from a POSIX home path", () => {
+        const out = redactSetupStderr(
+            "error at /Users/grigory.panov/proj/pyproject.toml"
+        );
+        expect(out).to.not.contain("grigory.panov");
+        expect(out).to.contain("/Users/");
+    });
+
+    it("strips the username from a Linux home path", () => {
+        const out = redactSetupStderr("see /home/jdoe/work/app");
+        expect(out).to.not.contain("jdoe");
+    });
+
+    it("strips the username from a Windows user path", () => {
+        const out = redactSetupStderr(
+            "C:\\Users\\Jane.Doe\\project\\pyproject.toml"
+        );
+        expect(out).to.not.contain("Jane.Doe");
+        expect(out.toLowerCase()).to.contain("c:\\users\\");
+    });
+
+    it("redacts a Databricks PAT and an email address", () => {
+        // A `dapi`-prefixed token shape (not a real hex secret) plus an email.
+        const fakeToken = "dapi" + "FAKEtestTOKENnotReal000";
+        const out = redactSetupStderr(
+            `token ${fakeToken} used by alice@example.com`
+        );
+        expect(out).to.not.contain(fakeToken);
+        expect(out).to.not.contain("alice@example.com");
+    });
+
+    it("keeps benign uv output (package names and versions) intact", () => {
+        const msg = "error: no solution: numpy==1.26.4 conflicts with pandas";
+        expect(redactSetupStderr(msg)).to.contain("numpy==1.26.4");
+    });
+
+    it("truncates to the length budget and marks the cut", () => {
+        const out = redactSetupStderr("x".repeat(10000), 1500);
+        expect(out.length).to.be.lessThan(1600);
+        expect(out).to.match(/truncat/i);
+    });
+});
+
+describe("buildSetupReportUrl", () => {
+    it("targets the repo's new-issue page", () => {
+        const url = buildSetupReportUrl({
+            repo: "databricks/environments",
+            env: ENV,
+        });
+        expect(url).to.contain(
+            "https://github.com/databricks/environments/issues/new"
+        );
+    });
+
+    it("URL-encodes the title and body (no raw spaces or newlines)", () => {
+        const url = buildSetupReportUrl({
+            repo: "databricks/databricks-vscode",
+            errorCode: "E_MERGE",
+            failurePhase: "merge",
+            env: ENV,
+            redactedStderr: "line one\nline two",
+        });
+        const query = url.split("?")[1];
+        expect(query).to.not.match(/[ \n]/);
+    });
+
+    it("puts the diagnostic fields into the decoded body", () => {
+        const url = buildSetupReportUrl({
+            repo: "databricks/environments",
+            errorCode: "E_ENV_UNSUPPORTED",
+            failurePhase: "resolve",
+            envKey: "dbr/15.4.x-scala2.12",
+            env: ENV,
+        });
+        const body = decodeURIComponent(url.split("body=")[1]);
+        expect(body).to.contain("E_ENV_UNSUPPORTED");
+        expect(body).to.contain("resolve");
+        expect(body).to.contain("dbr/15.4.x-scala2.12");
+        expect(body).to.contain("2.14.1");
+        expect(body).to.contain("1.13.0");
+        expect(body).to.contain("darwin");
+    });
+});
+
+describe("getPythonSetupReportAction", () => {
+    it('returns a "Report this problem" action for a report-worthy failure', () => {
+        const action = getPythonSetupReportAction(
+            failure("E_ENV_UNSUPPORTED", {failurePhase: "resolve"}),
+            ENV
+        );
+        expect(action?.label).to.equal("Report this problem");
+        expect(action?.url).to.contain("databricks/environments/issues/new");
+    });
+
+    it("returns undefined for a non-report-worthy failure", () => {
+        expect(
+            getPythonSetupReportAction(failure("E_UV_MISSING"), ENV)
+        ).to.equal(undefined);
+    });
+
+    it("keeps the prefilled URL bounded even for enormous CLI stderr", () => {
+        const action = getPythonSetupReportAction(
+            failure("E_PROVISION", {message: "boom\n" + "y".repeat(50000)}),
+            ENV
+        );
+        expect(action).to.not.equal(undefined);
+        expect(action!.url.length).to.be.lessThan(8000);
+    });
+
+    it("does not leak PII from stderr into the prefilled body", () => {
+        const action = getPythonSetupReportAction(
+            failure("E_VALIDATE", {
+                message: "failed at /Users/grigory.panov/proj",
+            }),
+            ENV
+        );
+        const body = decodeURIComponent(action!.url.split("body=")[1]);
+        expect(body).to.not.contain("grigory.panov");
+    });
+});
+
+describe("buildExtensionFailureReportAction", () => {
+    it("always routes to databricks/databricks-vscode with a redacted message", () => {
+        const action = buildExtensionFailureReportAction(ENV, {
+            phase: "adopt",
+            message: "adoption failed for /Users/jdoe/app",
+        });
+        expect(action.label).to.equal("Report this problem");
+        expect(action.url).to.contain(
+            "databricks/databricks-vscode/issues/new"
+        );
+        const body = decodeURIComponent(action.url.split("body=")[1]);
+        expect(body).to.contain("adopt");
+        expect(body).to.not.contain("jdoe");
+    });
+});
+
+describe("reportNewIssueBaseUrl", () => {
+    it("builds the bare new-issue URL for the log mirror", () => {
+        expect(reportNewIssueBaseUrl("databricks/environments")).to.equal(
+            "https://github.com/databricks/environments/issues/new"
+        );
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -260,9 +260,9 @@ describe("buildSetupReportUrl", () => {
         expect(query).to.not.match(/[ \n]/);
     });
 
-    it("uses a plain label (no '#' markdown heading) for the CLI output block", () => {
+    it("uses a bold label (not a '#' heading) for the CLI output block", () => {
         // A `#` in the query is double-encoded on the way to the browser and
-        // renders as `%23`, so the body must carry no markdown headings.
+        // renders as `%23`, so labels are bold (`**…**`), never headings.
         const url = buildSetupReportUrl({
             repo: "databricks/databricks-vscode",
             errorCode: "E_MERGE",
@@ -271,7 +271,7 @@ describe("buildSetupReportUrl", () => {
             redactedStderr: "boom",
         });
         const body = decodeURIComponent(url.split("body=")[1]);
-        expect(body).to.contain("CLI output (auto-redacted):");
+        expect(body).to.contain("**CLI output (auto-redacted):**");
         expect(body).to.not.contain("#");
     });
 
@@ -282,7 +282,7 @@ describe("buildSetupReportUrl", () => {
             env: ENV,
         });
         const body = decodeURIComponent(url.split("body=")[1]);
-        expect(body).to.match(/pyproject\.toml/i);
+        expect(body).to.contain("**Your pyproject.toml**");
         expect(body).to.match(/reproduce/i);
         // No markdown headings anywhere (no stderr in this case, so no `#` at all).
         expect(body).to.not.contain("#");

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -260,6 +260,34 @@ describe("buildSetupReportUrl", () => {
         expect(query).to.not.match(/[ \n]/);
     });
 
+    it("uses a plain label (no '#' markdown heading) for the CLI output block", () => {
+        // A `#` in the query is double-encoded on the way to the browser and
+        // renders as `%23`, so the body must carry no markdown headings.
+        const url = buildSetupReportUrl({
+            repo: "databricks/databricks-vscode",
+            errorCode: "E_MERGE",
+            failurePhase: "merge",
+            env: ENV,
+            redactedStderr: "boom",
+        });
+        const body = decodeURIComponent(url.split("body=")[1]);
+        expect(body).to.contain("CLI output (auto-redacted):");
+        expect(body).to.not.contain("#");
+    });
+
+    it("asks the user to paste their pyproject.toml to help reproduce", () => {
+        const url = buildSetupReportUrl({
+            repo: "databricks/environments",
+            errorCode: "E_VALIDATE",
+            env: ENV,
+        });
+        const body = decodeURIComponent(url.split("body=")[1]);
+        expect(body).to.match(/pyproject\.toml/i);
+        expect(body).to.match(/reproduce/i);
+        // No markdown headings anywhere (no stderr in this case, so no `#` at all).
+        expect(body).to.not.contain("#");
+    });
+
     it("puts the diagnostic fields into the decoded body", () => {
         const url = buildSetupReportUrl({
             repo: "databricks/environments",

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -62,7 +62,6 @@ describe("reportRepoForResult / isReportWorthy", () => {
     it("routes constraint-content defects to databricks/environments", () => {
         for (const code of [
             "E_ENV_UNSUPPORTED",
-            "E_PROVISION",
             "E_VALIDATE",
         ] as PythonSetupErrorCode[]) {
             expect(reportRepoForResult(failure(code))).to.equal(
@@ -78,6 +77,20 @@ describe("reportRepoForResult / isReportWorthy", () => {
                 "databricks/databricks-vscode"
             );
         }
+    });
+
+    it("does NOT make a genuine E_PROVISION conflict button-report-worthy", () => {
+        // A real dependency conflict is usually the user's own declared deps
+        // (possibly private packages), not a constraint defect — so it gets no
+        // report button; the output-channel hint (in errorMessages) covers the
+        // "if you think it's the constraints" case instead.
+        const r = failure("E_PROVISION", {
+            message:
+                "error: No solution found when resolving dependencies: " +
+                "x==1 depends on y<2, but the runtime requires y==2",
+        });
+        expect(reportRepoForResult(r)).to.equal(undefined);
+        expect(isReportWorthy(r)).to.equal(false);
     });
 
     it("does NOT treat a blocked-index E_PROVISION as report-worthy", () => {
@@ -138,6 +151,57 @@ describe("redactSetupStderr", () => {
         );
         expect(out).to.not.contain(fakeToken);
         expect(out).to.not.contain("alice@example.com");
+    });
+
+    it("strips a username containing a space from a home path", () => {
+        const out = redactSetupStderr(
+            "error at /Users/Jane Doe/proj/pyproject.toml"
+        );
+        expect(out).to.not.contain("Jane Doe");
+        expect(out).to.not.contain("Doe");
+        expect(out).to.contain("/proj/pyproject.toml");
+    });
+
+    it("strips a Windows username containing a space", () => {
+        const out = redactSetupStderr(
+            "C:\\Users\\Jane Doe\\project\\pyproject.toml"
+        );
+        expect(out).to.not.contain("Jane Doe");
+        expect(out).to.not.contain("Doe");
+        expect(out).to.contain("\\project\\pyproject.toml");
+    });
+
+    it("strips credentials embedded in a URL", () => {
+        const out = redactSetupStderr(
+            "failed to fetch https://alice:s3cr3tPAT@pkgs.corp.example/simple/"
+        );
+        expect(out).to.not.contain("s3cr3tPAT");
+        expect(out).to.not.contain("alice:s3cr3tPAT");
+    });
+
+    it("redacts a GitHub token, an AWS access key id, and a JWT", () => {
+        const ghToken = "ghp_" + "abcdEFGH1234abcdEFGH1234abcdEFGH1234";
+        const awsKey = "AKIA" + "IOSFODNN7EXAMPLE0";
+        // Assembled at runtime so no contiguous JWT literal sits in the source
+        // (it exercises the three-segment redaction regex all the same).
+        const jwt = [
+            "eyJ" + "hbGciOiJIUzI1NiJ9",
+            "eyJ" + "zdWIiOiIxMjM0NTY3ODkwIn0",
+            "abc-DEF_123",
+        ].join(".");
+        const out = redactSetupStderr(`gh=${ghToken} aws=${awsKey} jwt=${jwt}`);
+        expect(out).to.not.contain(ghToken);
+        expect(out).to.not.contain(awsKey);
+        expect(out).to.not.contain(jwt);
+    });
+
+    it("redacts a bearer token containing non-word characters", () => {
+        const out = redactSetupStderr(
+            "Authorization: Bearer abc.def/ghi+jkl=mno end"
+        );
+        expect(out).to.not.contain("abc.def/ghi+jkl=mno");
+        expect(out).to.not.contain("ghi+jkl=mno");
+        expect(out).to.contain("Bearer");
     });
 
     it("keeps benign uv output (package names and versions) intact", () => {
@@ -211,7 +275,7 @@ describe("getPythonSetupReportAction", () => {
 
     it("keeps the prefilled URL bounded even for enormous CLI stderr", () => {
         const action = getPythonSetupReportAction(
-            failure("E_PROVISION", {message: "boom\n" + "y".repeat(50000)}),
+            failure("E_VALIDATE", {message: "boom\n" + "y".repeat(50000)}),
             ENV
         );
         expect(action).to.not.equal(undefined);

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -217,6 +217,19 @@ describe("redactSetupStderr", () => {
         expect(redactSetupStderr(msg)).to.contain("numpy==1.26.4");
     });
 
+    it("returns empty for a non-string message instead of throwing", () => {
+        // A drifted CLI result could carry a non-string `message` (the parser
+        // validates only `ok`); the redactor must not throw, which would
+        // suppress the failure notification.
+        expect(redactSetupStderr(undefined as unknown as string)).to.equal("");
+    });
+
+    it("strips the username from a forward-slash Windows path", () => {
+        const out = redactSetupStderr("C:/Users/Jane/proj/pyproject.toml");
+        expect(out).to.not.contain("Jane");
+        expect(out).to.contain("/proj/pyproject.toml");
+    });
+
     it("truncates to the length budget and marks the cut", () => {
         const out = redactSetupStderr("x".repeat(10000), 1500);
         expect(out.length).to.be.lessThan(1600);
@@ -279,6 +292,13 @@ describe("getPythonSetupReportAction", () => {
         expect(
             getPythonSetupReportAction(failure("E_UV_MISSING"), ENV)
         ).to.equal(undefined);
+    });
+
+    it("builds an action even when the CLI message is not a string", () => {
+        const r = failure("E_VALIDATE");
+        (r.error as {message: unknown}).message = undefined;
+        const action = getPythonSetupReportAction(r, ENV);
+        expect(action?.label).to.equal("Report this problem");
     });
 
     it("keeps the prefilled URL bounded even for enormous CLI stderr", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -1,0 +1,258 @@
+import {
+    PythonSetupResult,
+    PythonSetupErrorCode,
+} from "../models/PythonSetupResult";
+import {PrimaryManager} from "../../language/packageManagerDetection";
+import {
+    PythonSetupErrorAction,
+    isIndexUnreachableFailure,
+} from "./errorMessages";
+
+/**
+ * The two GitHub repositories a post-preflight setup-local failure can be
+ * reported against. A failure is only ever "report-worthy" when it points at a
+ * defect we own — a bad published constraint (`databricks/environments`) or a
+ * bug in the extension/CLI wiring (`databricks/databricks-vscode`) — never a
+ * local/user/network condition, which stays actionable from the message alone.
+ */
+export type ReportRepo =
+    | "databricks/environments"
+    | "databricks/databricks-vscode";
+
+/**
+ * Post-preflight error codes that indicate a defect worth reporting, and the
+ * repo each belongs to. Deliberately a closed allowlist: every code absent here
+ * (the preflight/local/network set — E_UV_MISSING, E_USAGE, E_NO_TARGET,
+ * E_MANAGER_UNSUPPORTED, E_NOT_WRITABLE, E_PYTHON_INSTALL, E_FETCH, E_RESOLVE)
+ * is user- or environment-fixable and gets no report prompt.
+ *
+ * - Constraint-content defects → `databricks/environments`: the published
+ *   constraints have no entry for the runtime, don't resolve, or don't validate.
+ * - Extension/CLI behaviour defects → `databricks/databricks-vscode`: merging
+ *   into or writing the user's pyproject.toml broke.
+ */
+/* eslint-disable @typescript-eslint/naming-convention */
+const REPORT_ROUTING: Partial<Record<PythonSetupErrorCode, ReportRepo>> = {
+    E_ENV_UNSUPPORTED: "databricks/environments",
+    E_PROVISION: "databricks/environments",
+    E_VALIDATE: "databricks/environments",
+    E_MERGE: "databricks/databricks-vscode",
+    E_WRITE: "databricks/databricks-vscode",
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Static, session-scoped context stamped into every report so a maintainer sees
+ * which build produced the failure. Injected (not read from globals) so the
+ * URL builders stay pure and unit-testable. `platform` is `process.platform`.
+ */
+export interface ReportEnvironment {
+    extensionVersion: string;
+    cliVersion?: string;
+    platform: string;
+    packageManager?: PrimaryManager;
+}
+
+/** Cap on the redacted stderr embedded in a report, so the deep-link URL stays
+ * well under GitHub's practical query-length limit even after URL-encoding. */
+const REPORT_STDERR_BUDGET = 1200;
+
+/** The label shared by every "Report this problem" affordance, so the button and
+ * its log mirror never drift apart. */
+export const REPORT_ACTION_LABEL = "Report this problem";
+
+/**
+ * The repo a failed result should be reported against, or `undefined` when the
+ * failure is not report-worthy. A blocked package index arrives as `E_PROVISION`
+ * but is a local network condition, not a constraint defect — so it is excluded
+ * even though `E_PROVISION` is otherwise routed (matching the same distinction
+ * {@link isIndexUnreachableFailure} draws for the error copy).
+ */
+export function reportRepoForResult(
+    result: PythonSetupResult
+): ReportRepo | undefined {
+    const err = result.error;
+    if (!err) {
+        return undefined;
+    }
+    if (isIndexUnreachableFailure(result)) {
+        return undefined;
+    }
+    return REPORT_ROUTING[err.code];
+}
+
+/** Whether a failed result should surface a "Report this problem" affordance. */
+export function isReportWorthy(result: PythonSetupResult): boolean {
+    return reportRepoForResult(result) !== undefined;
+}
+
+/**
+ * Best-effort scrub of CLI stderr before it is embedded in a public issue: no
+ * usernames, local paths, tokens, or emails. This is defence-in-depth, not the
+ * sole guard — the deep-link only *pre-fills* GitHub's new-issue form, which the
+ * user reviews and submits themselves. The tail is kept (uv prints its
+ * resolution summary last) and marked when truncated to the length budget.
+ */
+export function redactSetupStderr(
+    raw: string,
+    maxLength: number = 2000
+): string {
+    let out = raw
+        // Emails first: an address never spans a path separator, so running it
+        // ahead of the path rules can't be undone by them.
+        .replace(
+            /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+            "<redacted-email>"
+        )
+        // Databricks personal access tokens and bearer credentials.
+        .replace(/dapi[A-Za-z0-9]{10,}/gi, "<redacted-token>")
+        .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted-token>")
+        // Home-directory paths: keep the shape, drop the username segment.
+        .replace(/([A-Za-z]:\\Users\\)([^\\/\s"']+)/gi, "$1<redacted>")
+        .replace(/(\/Users\/)([^/\s"']+)/g, "$1<redacted>")
+        .replace(/(\/home\/)([^/\s"']+)/g, "$1<redacted>");
+
+    if (out.length > maxLength) {
+        out = "…[truncated]\n" + out.slice(out.length - maxLength);
+    }
+    return out;
+}
+
+/** The bare new-issue page for a repo — used for the readable log mirror (the
+ * button carries the full pre-filled deep-link instead). */
+export function reportNewIssueBaseUrl(repo: ReportRepo): string {
+    return `https://github.com/${repo}/issues/new`;
+}
+
+/**
+ * The report link mirrored into the failure log as a {@link PythonSetupErrorAction}
+ * (for {@link formatSetupFailureDetail}'s report-line param) — the readable bare
+ * new-issue URL, not the popup's long pre-filled deep-link.
+ */
+export function reportLogLink(repo: ReportRepo): PythonSetupErrorAction {
+    return {label: REPORT_ACTION_LABEL, url: reportNewIssueBaseUrl(repo)};
+}
+
+/**
+ * The same report link as a ready-to-append log block, for failure paths that
+ * have no {@link formatSetupFailureDetail} of their own (spawn/parse, adopt).
+ */
+export function reportLogMirror(repo: ReportRepo): string {
+    return `\n${REPORT_ACTION_LABEL}: ${reportNewIssueBaseUrl(repo)}\n`;
+}
+
+function buildReportBody(ctx: {
+    errorCode?: string;
+    failurePhase?: string;
+    envKey?: string;
+    env: ReportEnvironment;
+    redactedStderr?: string;
+}): string {
+    const lines = [
+        "Automated setup of the local Python environment failed after its " +
+            "pre-flight checks. The details below were collected automatically " +
+            "(local paths, usernames, and credentials redacted). Please add " +
+            "anything else that helps us reproduce it.",
+        "",
+    ];
+    const field = (label: string, value?: string) => {
+        if (value !== undefined && value.length > 0) {
+            lines.push(`**${label}:** ${value}`);
+        }
+    };
+    field("Error code", ctx.errorCode);
+    field("Failing phase", ctx.failurePhase);
+    field("Environment key", ctx.envKey);
+    field("Package manager", ctx.env.packageManager);
+    field("Extension version", ctx.env.extensionVersion);
+    field("CLI version", ctx.env.cliVersion);
+    field("OS", ctx.env.platform);
+    if (ctx.redactedStderr !== undefined && ctx.redactedStderr.length > 0) {
+        lines.push(
+            "",
+            "### CLI output (auto-redacted)",
+            "```",
+            ctx.redactedStderr,
+            "```"
+        );
+    }
+    return lines.join("\n");
+}
+
+/**
+ * The pre-filled GitHub new-issue deep-link for a report. Title and body are
+ * URL-encoded so the query carries no raw whitespace or newlines.
+ */
+export function buildSetupReportUrl(ctx: {
+    repo: ReportRepo;
+    errorCode?: string;
+    failurePhase?: string;
+    envKey?: string;
+    env: ReportEnvironment;
+    redactedStderr?: string;
+}): string {
+    const phasePart = ctx.failurePhase
+        ? ` in the ${ctx.failurePhase} phase`
+        : "";
+    const title = `[setup-local] ${ctx.errorCode ?? "failure"}${phasePart}`;
+    const body = buildReportBody(ctx);
+    return (
+        `${reportNewIssueBaseUrl(ctx.repo)}?title=${encodeURIComponent(
+            title
+        )}` + `&body=${encodeURIComponent(body)}`
+    );
+}
+
+/**
+ * The "Report this problem" button/link for a CLI-reported failure, or
+ * `undefined` when the failure is not report-worthy. Reuses
+ * {@link PythonSetupErrorAction} so the notification seam opens it exactly like
+ * a doc link.
+ */
+export function getPythonSetupReportAction(
+    result: PythonSetupResult,
+    env: ReportEnvironment
+): PythonSetupErrorAction | undefined {
+    const repo = reportRepoForResult(result);
+    if (!repo) {
+        return undefined;
+    }
+    const err = result.error!;
+    return {
+        label: REPORT_ACTION_LABEL,
+        url: buildSetupReportUrl({
+            repo,
+            errorCode: err.code,
+            failurePhase: err.failurePhase,
+            envKey: result.compute?.envKey,
+            env,
+            redactedStderr: redactSetupStderr(
+                err.message,
+                REPORT_STDERR_BUDGET
+            ),
+        }),
+    };
+}
+
+/**
+ * The "Report this problem" action for an extension-side failure with no CLI
+ * result — a spawn/parse error or a post-CLI adopt failure. These are always
+ * the extension's own defect, so they route to `databricks/databricks-vscode`.
+ */
+export function buildExtensionFailureReportAction(
+    env: ReportEnvironment,
+    opts: {phase: string; message: string}
+): PythonSetupErrorAction {
+    return {
+        label: REPORT_ACTION_LABEL,
+        url: buildSetupReportUrl({
+            repo: "databricks/databricks-vscode",
+            failurePhase: opts.phase,
+            env,
+            redactedStderr: redactSetupStderr(
+                opts.message,
+                REPORT_STDERR_BUDGET
+            ),
+        }),
+    };
+}

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -1,9 +1,9 @@
-import {
+import type {
     PythonSetupResult,
     PythonSetupErrorCode,
 } from "../models/PythonSetupResult";
-import {PrimaryManager} from "../../language/packageManagerDetection";
-import {PythonSetupErrorAction} from "./errorMessages";
+import type {PrimaryManager} from "../../language/packageManagerDetection";
+import type {PythonSetupErrorAction} from "./errorMessages";
 
 /**
  * The two GitHub repositories a post-preflight setup-local failure can be
@@ -101,6 +101,12 @@ export function redactSetupStderr(
         // whole userinfo, keep the host. Runs first so a token here is gone
         // before the email rule could partially match around it.
         .replace(/(\bhttps?:\/\/)[^/\s@]+@/gi, "$1")
+        // Secret values passed as URL query parameters (private-index tokens,
+        // Azure SAS `sig=`, etc.): keep the key, drop the value.
+        .replace(
+            /([?&](?:token|password|passwd|pwd|secret|sig|signature|api[_-]?key|access[_-]?token|auth)=)[^&\s"']+/gi,
+            "$1<redacted>"
+        )
         // JWTs (three base64url segments) before the generic token rules.
         .replace(
             /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -197,14 +197,26 @@ function buildReportBody(ctx: {
     field("CLI version", ctx.env.cliVersion);
     field("OS", ctx.env.platform);
     if (ctx.redactedStderr !== undefined && ctx.redactedStderr.length > 0) {
+        // Plain label, not a `###` markdown heading: a `#` in the URL query is
+        // double-encoded on the way to the browser and renders as `%23`.
         lines.push(
             "",
-            "### CLI output (auto-redacted)",
+            "CLI output (auto-redacted):",
             "```",
             ctx.redactedStderr,
             "```"
         );
     }
+    // The pyproject.toml is the crux for merge/resolution failures but is not
+    // auto-collected (it can carry private dependencies), so ask the reporter to
+    // paste it. Kept free of `#` for the same encoding reason as above.
+    lines.push(
+        "",
+        "Your pyproject.toml (paste it below to help us reproduce — remove anything private):",
+        "```toml",
+        "(paste your pyproject.toml here)",
+        "```"
+    );
     return lines.join("\n");
 }
 

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -197,11 +197,11 @@ function buildReportBody(ctx: {
     field("CLI version", ctx.env.cliVersion);
     field("OS", ctx.env.platform);
     if (ctx.redactedStderr !== undefined && ctx.redactedStderr.length > 0) {
-        // Plain label, not a `###` markdown heading: a `#` in the URL query is
+        // Bold label, not a `###` markdown heading: a `#` in the URL query is
         // double-encoded on the way to the browser and renders as `%23`.
         lines.push(
             "",
-            "CLI output (auto-redacted):",
+            "**CLI output (auto-redacted):**",
             "```",
             ctx.redactedStderr,
             "```"
@@ -209,10 +209,10 @@ function buildReportBody(ctx: {
     }
     // The pyproject.toml is the crux for merge/resolution failures but is not
     // auto-collected (it can carry private dependencies), so ask the reporter to
-    // paste it. Kept free of `#` for the same encoding reason as above.
+    // paste it. Bold label (never `#`) for the same encoding reason as above.
     lines.push(
         "",
-        "Your pyproject.toml (paste it below to help us reproduce — remove anything private):",
+        "**Your pyproject.toml** (paste it below to help us reproduce — remove anything private):",
         "```toml",
         "(paste your pyproject.toml here)",
         "```"

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -96,6 +96,12 @@ export function redactSetupStderr(
     raw: string,
     maxLength: number = 2000
 ): string {
+    // A drifted CLI result can carry a non-string `message` (the parser
+    // validates only `ok`), so guard rather than let `.replace` throw and
+    // suppress the failure notification the caller is trying to show.
+    if (typeof raw !== "string" || raw.length === 0) {
+        return "";
+    }
     let out = raw
         // Credentials embedded in a URL (https://user:token@host): drop the
         // whole userinfo, keep the host. Runs first so a token here is gone

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -3,10 +3,7 @@ import {
     PythonSetupErrorCode,
 } from "../models/PythonSetupResult";
 import {PrimaryManager} from "../../language/packageManagerDetection";
-import {
-    PythonSetupErrorAction,
-    isIndexUnreachableFailure,
-} from "./errorMessages";
+import {PythonSetupErrorAction} from "./errorMessages";
 
 /**
  * The two GitHub repositories a post-preflight setup-local failure can be
@@ -27,14 +24,20 @@ export type ReportRepo =
  * is user- or environment-fixable and gets no report prompt.
  *
  * - Constraint-content defects → `databricks/environments`: the published
- *   constraints have no entry for the runtime, don't resolve, or don't validate.
+ *   constraints have no entry for the runtime (`E_ENV_UNSUPPORTED`) or don't
+ *   validate after provisioning (`E_VALIDATE`).
  * - Extension/CLI behaviour defects → `databricks/databricks-vscode`: merging
  *   into or writing the user's pyproject.toml broke.
+ *
+ * `E_PROVISION` is deliberately absent: a uv resolution conflict is usually the
+ * user's own declared dependencies (possibly private packages), not a constraint
+ * defect, so it gets no report button. The genuine "the published constraints
+ * conflict" case is served by a softer, conditional pointer in the output log
+ * (see `formatSetupFailureDetail`) instead of a prominent CTA.
  */
 /* eslint-disable @typescript-eslint/naming-convention */
 const REPORT_ROUTING: Partial<Record<PythonSetupErrorCode, ReportRepo>> = {
     E_ENV_UNSUPPORTED: "databricks/environments",
-    E_PROVISION: "databricks/environments",
     E_VALIDATE: "databricks/environments",
     E_MERGE: "databricks/databricks-vscode",
     E_WRITE: "databricks/databricks-vscode",
@@ -63,19 +66,15 @@ export const REPORT_ACTION_LABEL = "Report this problem";
 
 /**
  * The repo a failed result should be reported against, or `undefined` when the
- * failure is not report-worthy. A blocked package index arrives as `E_PROVISION`
- * but is a local network condition, not a constraint defect — so it is excluded
- * even though `E_PROVISION` is otherwise routed (matching the same distinction
- * {@link isIndexUnreachableFailure} draws for the error copy).
+ * failure is not report-worthy. Report-worthiness is a closed allowlist
+ * ({@link REPORT_ROUTING}); everything else — including every `E_PROVISION`
+ * resolution conflict, blocked-index or not — gets no report button.
  */
 export function reportRepoForResult(
     result: PythonSetupResult
 ): ReportRepo | undefined {
     const err = result.error;
     if (!err) {
-        return undefined;
-    }
-    if (isIndexUnreachableFailure(result)) {
         return undefined;
     }
     return REPORT_ROUTING[err.code];
@@ -98,18 +97,36 @@ export function redactSetupStderr(
     maxLength: number = 2000
 ): string {
     let out = raw
-        // Emails first: an address never spans a path separator, so running it
-        // ahead of the path rules can't be undone by them.
+        // Credentials embedded in a URL (https://user:token@host): drop the
+        // whole userinfo, keep the host. Runs first so a token here is gone
+        // before the email rule could partially match around it.
+        .replace(/(\bhttps?:\/\/)[^/\s@]+@/gi, "$1")
+        // JWTs (three base64url segments) before the generic token rules.
+        .replace(
+            /\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+            "<redacted-token>"
+        )
+        // Emails: an address never spans a path separator, so this can't be
+        // undone by the path rules below.
         .replace(
             /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
             "<redacted-email>"
         )
-        // Databricks personal access tokens and bearer credentials.
+        // Known token shapes: Databricks PAT, GitHub tokens, AWS access-key ids,
+        // and bearer credentials (any non-space run).
         .replace(/dapi[A-Za-z0-9]{10,}/gi, "<redacted-token>")
-        .replace(/Bearer\s+[A-Za-z0-9._-]+/gi, "Bearer <redacted-token>")
-        // Home-directory paths: keep the shape, drop the username segment.
+        .replace(/\bgh[pousr]_[A-Za-z0-9]{20,}\b/g, "<redacted-token>")
+        .replace(/\bAKIA[0-9A-Z]{12,}\b/g, "<redacted-token>")
+        .replace(/Bearer\s+\S+/gi, "Bearer <redacted-token>")
+        // Home-directory paths: drop the username segment, keeping the shape. A
+        // username can contain spaces (`/Users/Jane Doe/…`), so first take the
+        // whole segment up to the next path separator, then the trailing
+        // single-token segment (no following separator) as a fallback.
+        .replace(/([A-Za-z]:\\Users\\)([^\\\r\n]+)(?=[\\/])/gi, "$1<redacted>")
         .replace(/([A-Za-z]:\\Users\\)([^\\/\s"']+)/gi, "$1<redacted>")
+        .replace(/(\/Users\/)([^/\r\n]+)(?=\/)/g, "$1<redacted>")
         .replace(/(\/Users\/)([^/\s"']+)/g, "$1<redacted>")
+        .replace(/(\/home\/)([^/\r\n]+)(?=\/)/g, "$1<redacted>")
         .replace(/(\/home\/)([^/\s"']+)/g, "$1<redacted>");
 
     if (out.length > maxLength) {

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -500,6 +500,7 @@ export class EventTypes {
         envKey?: string;
         diskMutated?: boolean;
         indexUnreachable?: boolean;
+        reportOffered?: boolean;
         warningsCount?: number;
         // A code->count histogram, not a list: JSON-stringified into a property
         // by recordEvent (numbers alone become metrics). Keys are a closed
@@ -550,6 +551,14 @@ export class EventTypes {
                 "needing a proxy) rather than a dependency conflict — both arrive as E_PROVISION. Present " +
                 "on every CLI setup failure, so false is meaningful (a non-index failure, the rate's " +
                 "denominator); omitted with no CLI result and on post-CLI adopt/persist failures",
+        },
+        reportOffered: {
+            comment:
+                'Whether the failure surfaced a "Report this problem" affordance — a deep-link to file a ' +
+                "pre-filled issue against databricks/environments (constraint-content defect) or " +
+                "databricks/databricks-vscode (extension/CLI defect). true/false is meaningful on every " +
+                "post-preflight failure (the offer rate's denominator); omitted when the outcome is not a " +
+                "failure, or on the preflight/local/network codes that are never report-worthy",
         },
         warningsCount: {
             comment:

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -556,9 +556,11 @@ export class EventTypes {
             comment:
                 'Whether the failure surfaced a "Report this problem" affordance — a deep-link to file a ' +
                 "pre-filled issue against databricks/environments (constraint-content defect) or " +
-                "databricks/databricks-vscode (extension/CLI defect). true/false is meaningful on every " +
-                "post-preflight failure (the offer rate's denominator); omitted when the outcome is not a " +
-                "failure, or on the preflight/local/network codes that are never report-worthy",
+                "databricks/databricks-vscode (extension/CLI defect). Present on every failure outcome " +
+                "(failed / not_started): true when a report was offered, false otherwise (including the " +
+                "preflight/local/network codes that are never report-worthy — false is the offer rate's " +
+                "denominator). Omitted for non-failure outcomes; filter by failurePhase for the " +
+                "post-preflight population",
         },
         warningsCount: {
             comment:

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -74,9 +74,11 @@ export interface PythonSetupOutcomeReport {
     indexUnreachable?: boolean;
     /**
      * Whether a "Report this problem" affordance was surfaced for this failure.
-     * Meaningful on every post-preflight failure (`false` is the offer rate's
-     * denominator); omitted for non-failures and the never-report-worthy
-     * preflight/local/network codes.
+     * Present on every failure outcome (`failed` / `not_started`): `true` when a
+     * report was offered (a post-preflight defect), `false` otherwise (including
+     * the never-report-worthy preflight/local/network codes — `false` is the
+     * offer rate's denominator). Omitted for non-failure outcomes. Filter by
+     * `failurePhase` to isolate the post-preflight population.
      */
     reportOffered?: boolean;
     /**

--- a/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
+++ b/packages/databricks-vscode/src/telemetry/pythonSetupExtensions.ts
@@ -73,6 +73,13 @@ export interface PythonSetupOutcomeReport {
      */
     indexUnreachable?: boolean;
     /**
+     * Whether a "Report this problem" affordance was surfaced for this failure.
+     * Meaningful on every post-preflight failure (`false` is the offer rate's
+     * denominator); omitted for non-failures and the never-report-worthy
+     * preflight/local/network codes.
+     */
+    reportOffered?: boolean;
+    /**
      * The CLI's merge-phase warnings, verbatim from the result. Present whenever
      * the CLI produced a result (so `[]` reads as "a run happened with no
      * warnings"); absent when no result exists (cancelled / not_started /
@@ -287,6 +294,9 @@ Telemetry.prototype.recordPythonSetupAttempt = function (
                 : {}),
             ...(report.indexUnreachable !== undefined
                 ? {indexUnreachable: report.indexUnreachable}
+                : {}),
+            ...(report.reportOffered !== undefined
+                ? {reportOffered: report.reportOffered}
                 : {}),
             // A present `warnings` array means the CLI produced a result, so the
             // count is meaningful even at 0 (a clean merge) -- unlike the omitted


### PR DESCRIPTION
## Summary

When `databricks environments setup-local` fails **after** its pre-flight checks, the break almost always points at a defect we own — a bad published constraint, or an extension/CLI bug — not something the user can fix. Today those failures surface only a mapped message + "Show Logs", so the user has no clear path to report them.

This adds a **"Report this problem"** affordance that deep-links a pre-filled GitHub new-issue form, routed by error code to the repo that owns the defect.

## Behaviour

- **Report-worthy codes** get "Report this problem" as the notification's primary button; any doc link drops to the log, and a bare new-issue URL is always mirrored into the output channel too:
  - `E_ENV_UNSUPPORTED`, `E_PROVISION`, `E_VALIDATE` → `databricks/environments` (constraint-content defects)
  - `E_MERGE`, `E_WRITE`, and the no-result spawn/parse & adopt paths → `databricks/databricks-vscode` (extension/CLI defects)
- **Non-report-worthy codes are unchanged** — preflight/local/network codes (`E_UV_MISSING`, `E_USAGE`, `E_NO_TARGET`, `E_MANAGER_UNSUPPORTED`, `E_NOT_WRITABLE`, `E_PYTHON_INSTALL`, `E_FETCH`, `E_RESOLVE`) keep their existing doc-link button and message.
- The **blocked-index variant of `E_PROVISION`** stays non-report-worthy (it's a local network condition, not a constraint defect), matching the existing error-copy distinction.

## Surface

The report action reuses the existing `PythonSetupErrorAction` shape, so `showError` opens it exactly like a doc link — no new notification plumbing, and the button count stays at one primary action + "Show Logs".

## Privacy

Privacy by construction: the deep-link only **pre-fills** a form the user reviews and submits — nothing is sent automatically. The issue body carries build metadata (error code, phase, env key, package manager, extension/CLI versions, OS) plus CLI stderr that is scrubbed of usernames, home paths, tokens, and emails (defence-in-depth) and length-capped so the URL stays under GitHub's limit.

## Telemetry

New optional `reportOffered` boolean on `python_env.setup.result`, so we can measure the offer rate (meaningful `true`/`false` on every post-preflight failure).

## Testing

- TDD throughout; `yarn test:unit` green (943 passing, 0 failing).
- `yarn fix` + `test:lint` clean (0 errors); `generate-telemetry` emits the new field into the (gitignored) `telemetry.json`.

This pull request and its description were written by Isaac.