### PR TITLE
Report title: prefix post-preflight setup-local failures with "Unexpected"

### DIFF
--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -248,6 +248,19 @@ describe("buildSetupReportUrl", () => {
         );
     });
 
+    it("titles the issue as an unexpected failure with the code and phase", () => {
+        const url = buildSetupReportUrl({
+            repo: "databricks/databricks-vscode",
+            errorCode: "E_MERGE",
+            failurePhase: "merge",
+            env: ENV,
+        });
+        const title = decodeURIComponent(url.split("title=")[1].split("&")[0]);
+        expect(title).to.equal(
+            "[setup-local] Unexpected E_MERGE in the merge phase"
+        );
+    });
+
     it("URL-encodes the title and body (no raw spaces or newlines)", () => {
         const url = buildSetupReportUrl({
             repo: "databricks/databricks-vscode",

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.ts
@@ -235,7 +235,9 @@ export function buildSetupReportUrl(ctx: {
     const phasePart = ctx.failurePhase
         ? ` in the ${ctx.failurePhase} phase`
         : "";
-    const title = `[setup-local] ${ctx.errorCode ?? "failure"}${phasePart}`;
+    const title = `[setup-local] Unexpected ${
+        ctx.errorCode ?? "failure"
+    }${phasePart}`;
     const body = buildReportBody(ctx);
     return (
         `${reportNewIssueBaseUrl(ctx.repo)}?title=${encodeURIComponent(


### PR DESCRIPTION
## Summary

Fast follow-up to #2153. Wording-only change to the pre-filled GitHub issue title for post-preflight `setup-local` failures.

**Before:** `[setup-local] E_MERGE in the merge phase`
**After:** `[setup-local] Unexpected E_MERGE in the merge phase`

A post-preflight failure indicates a defect we own (bad published constraint or extension/CLI bug), so "Unexpected" makes that framing explicit at a glance in the issue list. Applies to every report title (`[setup-local] Unexpected <code|failure> in the <phase> phase`).

## Testing
- Added a test asserting the exact title.
- `yarn test:unit` green (984 passing, 0 failing); `yarn fix` + `test:lint` clean.

This pull request and its description were written by Isaac.