### PR TITLE
feat(python-setup): add manual mode to opt out of automated uv setup

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1823,6 +1823,19 @@
                         "default": "17.3",
                         "markdownDescription": "Default `databricks-connect` version for serverless compute. Determines required Python version and suggested package version. Minimum supported value is `15.4`."
                     },
+                    "databricks.python.environmentSetup": {
+                        "type": "string",
+                        "enum": [
+                            "auto",
+                            "manual"
+                        ],
+                        "enumDescriptions": [
+                            "Automatically set up a uv-managed Python environment matched to your Databricks compute for suitable uv projects.",
+                            "Never run automated Python environment setup; use your own interpreter and environment (for example an existing `.venv` with `databricks-connect`) as-is."
+                        ],
+                        "default": "auto",
+                        "markdownDescription": "Controls the extension's automated Python environment setup for uv projects. `auto` (default) offers and runs uv-native setup (`databricks environments setup-local`) for suitable projects. `manual` disables it entirely so your existing interpreter/environment is used as-is — useful when your network blocks `raw.githubusercontent.com`, which the automated setup requires to fetch runtime constraints."
+                    },
                     "databricks.ipythonDir": {
                         "type": "string",
                         "description": "Absolute path to a directory for storing IPython files. Defaults to IPYTHONDIR environment variable (if set) or ~/.ipython."

--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -595,6 +595,12 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.environment.useManualPythonSetup",
+                "title": "Use manual Python environment setup",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && !databricks.context.remoteMode",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.environment.rerunPythonEnv",
                 "title": "Re-run Python setup",
                 "icon": "$(sync)",

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1065,13 +1065,30 @@ export async function activate(
         // is used as-is. Workspace scope keeps it scoped and reversible; if no
         // folder is open we fall back to Global so the write still lands.
         telemetry.registerCommand(USE_MANUAL_SETUP_COMMAND_ID, async () => {
-            const target =
-                (workspace.workspaceFolders?.length ?? 0) > 0
-                    ? ConfigurationTarget.Workspace
-                    : ConfigurationTarget.Global;
-            await workspaceConfigs.setPythonEnvironmentSetup("manual", target);
+            const hasFolder = (workspace.workspaceFolders?.length ?? 0) > 0;
+            const target = hasFolder
+                ? ConfigurationTarget.Workspace
+                : ConfigurationTarget.Global;
+            try {
+                await workspaceConfigs.setPythonEnvironmentSetup(
+                    "manual",
+                    target
+                );
+            } catch (e) {
+                // Don't claim success if the write failed — the user would
+                // otherwise believe automated setup is off when it is not.
+                await window.showErrorMessage(
+                    `Could not update databricks.python.environmentSetup: ${
+                        e instanceof Error ? e.message : String(e)
+                    }`
+                );
+                return;
+            }
+            // Match the message to the scope actually written: "this project"
+            // for Workspace, "globally" for the no-folder Global fallback.
+            const scope = hasFolder ? "for this project" : "globally";
             await window.showInformationMessage(
-                'Automated Python environment setup is now off for this project ("databricks.python.environmentSetup": "manual"). Your existing interpreter will be used as-is.'
+                `Automated Python environment setup is now off ${scope} ("databricks.python.environmentSetup": "manual"). Your existing interpreter will be used as-is.`
             );
         })
     );

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1,5 +1,6 @@
 import {
     commands,
+    ConfigurationTarget,
     debug,
     env,
     ExtensionContext,
@@ -59,6 +60,7 @@ import {PythonSetupDriftManager} from "./python-setup/controllers/PythonSetupDri
 import {PythonSetupAdoptionManager} from "./python-setup/controllers/PythonSetupAdoptionManager";
 import {SetupCompute} from "./python-setup/controllers/PythonSetupEnvironmentSetup";
 import {venvInterpreterPath} from "./python-setup/utils/venvInterpreterPath";
+import {USE_MANUAL_SETUP_COMMAND_ID} from "./python-setup/utils/errorMessages";
 import {makeServerlessVersionPrompt} from "./python-setup/utils/serverlessVersionResolver";
 import {collectPackageManagerSignals} from "./language/packageManagerSignals";
 import {EnvironmentDependenciesVerifier} from "./language/EnvironmentDependenciesVerifier";
@@ -1057,7 +1059,21 @@ export async function activate(
             "databricks.environment.rerunPythonEnv",
             pythonSetupEnvironment.setup,
             pythonSetupEnvironment
-        )
+        ),
+        // One-click opt-out surfaced as the E_FETCH failure's action button:
+        // turn automated setup off for this project so an existing environment
+        // is used as-is. Workspace scope keeps it scoped and reversible; if no
+        // folder is open we fall back to Global so the write still lands.
+        telemetry.registerCommand(USE_MANUAL_SETUP_COMMAND_ID, async () => {
+            const target =
+                (workspace.workspaceFolders?.length ?? 0) > 0
+                    ? ConfigurationTarget.Workspace
+                    : ConfigurationTarget.Global;
+            await workspaceConfigs.setPythonEnvironmentSetup("manual", target);
+            await window.showInformationMessage(
+                'Automated Python environment setup is now off for this project ("databricks.python.environmentSetup": "manual"). Your existing interpreter will be used as-is.'
+            );
+        })
     );
     // Drives the config-view row's out-of-sync state: on compute/open/setup
     // triggers it silently resolves the selected compute's env key via a CLI

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -976,6 +976,7 @@ export async function activate(
                 }
             },
             detect: (projectRoot) => pythonSetupDetector.detect(projectRoot),
+            setupMode: () => workspaceConfigs.pythonEnvironmentSetup,
             attachedCompute: () => ({
                 serverless: connectionManager.serverless,
                 cluster: connectionManager.cluster

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -25,6 +25,7 @@ describe("makePythonSetupVisibility", () => {
         const isVisible = makePythonSetupVisibility({
             detect: async () => uvDetection,
             projectRoot: () => undefined,
+            setupMode: () => "auto",
         });
         expect(await isVisible()).to.equal(false);
     });
@@ -33,6 +34,7 @@ describe("makePythonSetupVisibility", () => {
         const isVisible = makePythonSetupVisibility({
             detect: async () => uvDetection,
             projectRoot: () => "/proj",
+            setupMode: () => "auto",
         });
         expect(await isVisible()).to.equal(true);
     });
@@ -45,8 +47,26 @@ describe("makePythonSetupVisibility", () => {
                 signals: ["requirements.txt" as const],
             }),
             projectRoot: () => "/proj",
+            setupMode: () => "auto",
         });
         expect(await isVisible()).to.equal(false);
+    });
+
+    it("is hidden for a clean uv project when setup mode is manual", async () => {
+        // The user's opt-out: `manual` disables uv-native setup outright, so a
+        // valid existing environment is used as-is and no fetch to GitHub is
+        // needed. It short-circuits before detection even runs.
+        let detected = false;
+        const isVisible = makePythonSetupVisibility({
+            detect: async () => {
+                detected = true;
+                return uvDetection;
+            },
+            projectRoot: () => "/proj",
+            setupMode: () => "manual",
+        });
+        expect(await isVisible()).to.equal(false);
+        expect(detected).to.equal(false);
     });
 });
 
@@ -156,6 +176,7 @@ function makeWiring(
             managers: ["uv" as const],
             signals: [],
         }),
+        setupMode: () => "auto",
         attachedCompute: () => ({
             serverless: false,
             cluster: undefined,
@@ -447,6 +468,7 @@ describe("makePythonSetupVisibility error handling", () => {
                 throw new Error("signal collection blew up");
             },
             projectRoot: () => "/proj",
+            setupMode: () => "auto",
         });
         // Must resolve false, not reject: a throwing gate would blank the
         // Environment section instead of showing the legacy checklist.
@@ -458,6 +480,18 @@ describe("makePythonSetupVisibility error handling", () => {
             detect: async () => uvDetection,
             projectRoot: () => {
                 throw new Error("no active project folder");
+            },
+            setupMode: () => "auto",
+        });
+        expect(await isVisible()).to.equal(false);
+    });
+
+    it("degrades to not-visible when the setup-mode read throws", async () => {
+        const isVisible = makePythonSetupVisibility({
+            detect: async () => uvDetection,
+            projectRoot: () => "/proj",
+            setupMode: () => {
+                throw new Error("config read blew up");
             },
         });
         expect(await isVisible()).to.equal(false);

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -5,6 +5,7 @@ import {PackageManagerDetection} from "../../language/packageManagerDetection";
 import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
 import {PythonSetupState} from "../../vscode-objs/StateStorage";
+import type {PythonEnvironmentSetupMode} from "../../vscode-objs/WorkspaceConfigs";
 import {openExternal} from "../../utils/urlUtils";
 import {PythonSetupErrorAction} from "../utils/errorMessages";
 import {ReportEnvironment} from "../utils/reportSetupIssue";
@@ -95,13 +96,24 @@ export function resolveComputeFrom(
  * empty. Note the classification itself still fails *open*: `detect` maps a
  * signal-collection failure to `unknown`/`[]`, which reads as greenfield and so
  * shows the entry -- an unclassifiable project is treated as safe to offer.
+ *
+ * `setupMode` is the user's opt-out: `manual` hides the uv flow outright (before
+ * any detection), so a valid existing interpreter is used as-is and no project
+ * ever needs to reach `raw.githubusercontent.com` for runtime constraints. This
+ * is the single gate every entry point reads (config view, the setup command's
+ * routing, and the serverless-version prompt), so honoring it here covers them
+ * all.
  */
 export function makePythonSetupVisibility(deps: {
     detect: (projectRoot: string) => Promise<Detection>;
     projectRoot: () => string | undefined;
+    setupMode: () => PythonEnvironmentSetupMode;
 }): () => Promise<boolean> {
     return async () => {
         try {
+            if (deps.setupMode() === "manual") {
+                return false;
+            }
             const root = deps.projectRoot();
             if (root === undefined) {
                 return false;
@@ -123,6 +135,11 @@ export interface PythonSetupWiringDeps {
     cli: CliRunner;
     projectRoot: () => string | undefined;
     detect: (projectRoot: string) => Promise<Detection>;
+    /**
+     * The user's `databricks.python.environmentSetup` choice. `manual` opts the
+     * project out of uv-native setup entirely (see {@link makePythonSetupVisibility}).
+     */
+    setupMode: () => PythonEnvironmentSetupMode;
     attachedCompute: () => AttachedCompute;
     /**
      * Ask the user which serverless version to provision, for a serverless

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -1,6 +1,6 @@
 import {existsSync} from "fs";
 import path from "path";
-import {ProgressLocation, Uri, window} from "vscode";
+import {commands, ProgressLocation, Uri, window} from "vscode";
 import {PackageManagerDetection} from "../../language/packageManagerDetection";
 import {Telemetry} from "../../telemetry";
 import "../../telemetry/pythonSetupExtensions";
@@ -280,18 +280,28 @@ export function makePythonSetupDeps(
                 wiring.log.show();
             } else if (remediation && picked === remediation.label) {
                 // showError is the failure-reporting path and its one caller does
-                // not wrap it, so neither a rejected launch nor a false "could not
-                // open" result may escape here — contain both and record them.
+                // not wrap it, so nothing thrown here may escape — contain and
+                // record any failure.
                 try {
-                    const opened = await openExternal(remediation.url);
-                    if (!opened) {
-                        wiring.log.append(
-                            `\nCould not open ${remediation.url} in a browser.\n`
-                        );
+                    if (remediation.command) {
+                        // A command-action (e.g. E_FETCH "Use manual setup")
+                        // runs a registered VS Code command instead of opening a
+                        // URL.
+                        await commands.executeCommand(remediation.command);
+                    } else if (remediation.url) {
+                        const opened = await openExternal(remediation.url);
+                        if (!opened) {
+                            wiring.log.append(
+                                `\nCould not open ${remediation.url} in a browser.\n`
+                            );
+                        }
                     }
                 } catch (e) {
+                    const what = remediation.command
+                        ? `run ${remediation.command}`
+                        : `open ${remediation.url}`;
                     wiring.log.append(
-                        `\nFailed to open ${remediation.url}: ${
+                        `\nFailed to ${what}: ${
                             e instanceof Error ? e.message : String(e)
                         }\n`
                     );

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -4,6 +4,7 @@ import {
     getPythonSetupErrorAction,
     getPythonSetupErrorMessage,
     isIndexUnreachableFailure,
+    USE_MANUAL_SETUP_COMMAND_ID,
 } from "./errorMessages";
 import {
     PythonSetupResult,
@@ -353,14 +354,17 @@ describe("getPythonSetupErrorAction", () => {
         });
     });
 
-    it("offers no action for E_FETCH (deliberately message-only)", () => {
-        // A generic network/cache failure has no single doc that reliably helps,
-        // so we avoid pointing the user at an unclear page.
+    it("offers a one-click 'Use manual setup' command action for E_FETCH", () => {
+        // The blocked-GitHub case: rather than a doc link, the button runs the
+        // command that flips the setting to manual for the project.
         expect(
             getPythonSetupErrorAction(
                 failure("E_FETCH", {failurePhase: "fetch"})
             )
-        ).to.equal(undefined);
+        ).to.deep.equal({
+            label: "Use manual setup",
+            command: USE_MANUAL_SETUP_COMMAND_ID,
+        });
     });
 
     it("offers no action for codes with no clear remediation doc", () => {
@@ -466,6 +470,9 @@ describe("formatSetupFailureDetail", () => {
         expect(detail).to.contain("allowlist");
         expect(detail).to.contain("databricks.python.environmentSetup");
         expect(detail).to.match(/manual/i);
+        // E_FETCH's action is a command (no URL), so the log must not print a
+        // "label: undefined" line for it.
+        expect(detail).to.not.contain("undefined");
     });
 
     it("adds no E_FETCH remediation block for another code", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -132,6 +132,18 @@ describe("getPythonSetupErrorMessage", () => {
         );
     });
 
+    it("E_FETCH names the GitHub Raw host and the manual-mode escape hatch", () => {
+        // The regression from issue #2149: a network that blocks GitHub Raw
+        // dead-ends here, so the message must name the host to allowlist and the
+        // setting that skips automated setup entirely.
+        const msg = getPythonSetupErrorMessage(
+            failure("E_FETCH", {failurePhase: "fetch"})
+        );
+        expect(msg).to.contain("raw.githubusercontent.com");
+        expect(msg).to.contain("databricks.python.environmentSetup");
+        expect(msg).to.match(/manual/i);
+    });
+
     it("maps E_VALIDATE to a mismatch message", () => {
         expect(getPythonSetupErrorMessage(failure("E_VALIDATE"))).to.match(
             /match|mismatch/i
@@ -444,6 +456,22 @@ describe("formatSetupFailureDetail", () => {
         expect(detail).to.contain("UV_INDEX_URL");
         expect(detail).to.contain("index-url");
         expect(detail).to.contain("extra-index-url");
+    });
+
+    it("spells out the allowlist + manual-mode fixes for E_FETCH", () => {
+        const detail = formatSetupFailureDetail(
+            failure("E_FETCH", {failurePhase: "fetch"})
+        );
+        expect(detail).to.contain("raw.githubusercontent.com");
+        expect(detail).to.contain("allowlist");
+        expect(detail).to.contain("databricks.python.environmentSetup");
+        expect(detail).to.match(/manual/i);
+    });
+
+    it("adds no E_FETCH remediation block for another code", () => {
+        const detail = formatSetupFailureDetail(failure("E_MERGE"));
+        expect(detail).to.not.contain("raw.githubusercontent.com");
+        expect(detail).to.not.contain("databricks.python.environmentSetup");
     });
 
     it("adds no remediation block for a non-connectivity E_PROVISION", () => {

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -133,13 +133,26 @@ export function isIndexUnreachableFailure(result: PythonSetupResult): boolean {
 }
 
 /**
- * An optional remediation button to attach to a failure popup: a label and the
- * external URL it opens. Kept alongside {@link getPythonSetupErrorMessage} so the
- * copy and its call-to-action live together.
+ * Command that flips `databricks.python.environmentSetup` to `manual` for the
+ * current project. Surfaced as the E_FETCH remediation button so a user whose
+ * network blocks the constraints host can opt out in one click. Defined here
+ * (next to the action that references it) and reused by the command registration
+ * so the two cannot drift.
+ */
+export const USE_MANUAL_SETUP_COMMAND_ID =
+    "databricks.environment.useManualPythonSetup";
+
+/**
+ * An optional remediation button to attach to a failure popup. Exactly one of
+ * `url` / `command` is set: `url` opens an external page (docs, issue), while
+ * `command` runs a VS Code command (e.g. the one-click switch to manual setup).
+ * Kept alongside {@link getPythonSetupErrorMessage} so the copy and its
+ * call-to-action live together.
  */
 export interface PythonSetupErrorAction {
     label: string;
-    url: string;
+    url?: string;
+    command?: string;
 }
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -270,6 +283,14 @@ export function getPythonSetupErrorAction(
     if (isIndexUnreachableFailure(result)) {
         return {label: "Configure package index", url: UV_INDEX_DOCS_URL};
     }
+    // E_FETCH is the blocked-GitHub case (see the message/detail copy). Rather
+    // than only pointing at the setting, offer a one-click switch to manual mode.
+    if (err.code === "E_FETCH") {
+        return {
+            label: "Use manual setup",
+            command: USE_MANUAL_SETUP_COMMAND_ID,
+        };
+    }
     return DOC_LINKS[err.code];
 }
 
@@ -358,15 +379,17 @@ export function formatSetupFailureDetail(
         );
     }
     // The same doc link the popup offers as a button, spelled out here so the URL
-    // is reachable from the log even after the notification is dismissed.
+    // is reachable from the log even after the notification is dismissed. Only
+    // url-actions have something to print; a command-action (e.g. the E_FETCH
+    // "Use manual setup" button) has its guidance in the block above instead.
     const action = getPythonSetupErrorAction(result);
-    if (action) {
+    if (action && action.url) {
         lines.push("", `${action.label}: ${action.url}`);
     }
     // The report link is mirrored here too (a bare new-issue URL, not the popup's
     // long pre-filled deep-link) so it survives the notification being dismissed.
     // It is additive to the doc link above: a report-worthy code can carry both.
-    if (reportLink) {
+    if (reportLink && reportLink.url) {
         lines.push("", `${reportLink.label}: ${reportLink.url}`);
     }
     // Bracket with blank lines so the block stands apart from any streamed CLI

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -167,8 +167,9 @@ const BASE_MESSAGE: Record<
         );
     },
     E_FETCH: () =>
-        "Could not reach the environment constraints repository and no local cache is available. " +
-        "Check your network connection and try again.",
+        "Could not reach the runtime constraints on raw.githubusercontent.com, and no local cache is available. " +
+        'If your network blocks it, allowlist that host — or set "databricks.python.environmentSetup" to ' +
+        '"manual" to skip automated setup and use your existing environment.',
     E_WRITE: () => "Failed to write pyproject.toml.",
     E_MERGE: () =>
         "Failed to merge the runtime constraints into your existing pyproject.toml.",
@@ -326,6 +327,22 @@ export function formatSetupFailureDetail(
             "       [global]",
             "       index-url = https://<your-proxy>/simple",
             "     Use index-url (not extra-index-url) so pypi.org is replaced, not merely supplemented."
+        );
+    }
+    // E_FETCH means the published runtime constraints (on GitHub) were
+    // unreachable and nothing was cached — most often a corporate network that
+    // blocks raw.githubusercontent.com. Spell out both fixes here; the popup only
+    // summarises them.
+    if (err.code === "E_FETCH") {
+        lines.push(
+            "",
+            "Automated setup downloads runtime constraints from raw.githubusercontent.com " +
+                "(the databricks/environments repository), which your network appears to block. " +
+                "You have two options:",
+            "",
+            "  1. Ask your network admin to allowlist raw.githubusercontent.com, then re-run setup.",
+            '  2. Or skip automated setup and manage the environment yourself: set the "databricks.python.environmentSetup" ' +
+                'setting to "manual". The extension then uses your existing interpreter/.venv (with its databricks-connect) as-is.'
         );
     }
     // A genuine E_PROVISION conflict gets no report button (it is usually the

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -144,16 +144,16 @@ export const USE_MANUAL_SETUP_COMMAND_ID =
 
 /**
  * An optional remediation button to attach to a failure popup. Exactly one of
- * `url` / `command` is set: `url` opens an external page (docs, issue), while
- * `command` runs a VS Code command (e.g. the one-click switch to manual setup).
- * Kept alongside {@link getPythonSetupErrorMessage} so the copy and its
- * call-to-action live together.
+ * `url` / `command` is set — a discriminated union (`?: never` on the other arm)
+ * forbids both/neither at compile time, while still letting callers read
+ * `action.url` / `action.command` as `string | undefined` without narrowing.
+ * `url` opens an external page (docs, issue); `command` runs a VS Code command
+ * (e.g. the one-click switch to manual setup). Kept alongside
+ * {@link getPythonSetupErrorMessage} so the copy and its call-to-action live together.
  */
-export interface PythonSetupErrorAction {
-    label: string;
-    url?: string;
-    command?: string;
-}
+export type PythonSetupErrorAction =
+    | {label: string; url: string; command?: never}
+    | {label: string; command: string; url?: never};
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const BASE_MESSAGE: Record<

--- a/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/reportSetupIssue.test.ts
@@ -348,7 +348,7 @@ describe("getPythonSetupReportAction", () => {
             ENV
         );
         expect(action).to.not.equal(undefined);
-        expect(action!.url.length).to.be.lessThan(8000);
+        expect(action!.url!.length).to.be.lessThan(8000);
     });
 
     it("does not leak PII from stderr into the prefilled body", () => {
@@ -358,7 +358,7 @@ describe("getPythonSetupReportAction", () => {
             }),
             ENV
         );
-        const body = decodeURIComponent(action!.url.split("body=")[1]);
+        const body = decodeURIComponent(action!.url!.split("body=")[1]);
         expect(body).to.not.contain("grigory.panov");
     });
 });
@@ -373,7 +373,7 @@ describe("buildExtensionFailureReportAction", () => {
         expect(action.url).to.contain(
             "databricks/databricks-vscode/issues/new"
         );
-        const body = decodeURIComponent(action.url.split("body=")[1]);
+        const body = decodeURIComponent(action.url!.split("body=")[1]);
         expect(body).to.contain("adopt");
         expect(body).to.not.contain("jdoe");
     });

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.test.ts
@@ -6,6 +6,7 @@ import {ConnectionManager} from "../../configuration/ConnectionManager";
 import {ConfigModel} from "../../configuration/models/ConfigModel";
 import {ConfigurationTreeItem} from "./types";
 import {PythonSetupEntry} from "./pythonSetupEntry";
+import {workspaceConfigs} from "../../vscode-objs/WorkspaceConfigs";
 
 const ENVIRONMENT_COMPONENT_ID = "ENVIRONMENT";
 const ENVIRONMENT_ROOT = {
@@ -107,5 +108,50 @@ describe("EnvironmentComponent dispatch", () => {
         // Being a leaf, it has no children — so the checklist never renders.
         const children = await component.getChildren(root[0]);
         expect(children).to.have.length(0);
+    });
+
+    describe("environmentSetup change refresh", () => {
+        // Stub the adapter's change subscription so the test drives the callback
+        // deterministically, without mutating real VS Code config or firing a
+        // live workspace event.
+        let captured: (() => void) | undefined;
+        let restore: () => void;
+
+        beforeEach(() => {
+            captured = undefined;
+            const original = workspaceConfigs.onDidChangePythonEnvironmentSetup;
+            workspaceConfigs.onDidChangePythonEnvironmentSetup = (
+                listener: () => void
+            ) => {
+                captured = listener;
+                return {dispose() {}};
+            };
+            restore = () => {
+                workspaceConfigs.onDidChangePythonEnvironmentSetup = original;
+            };
+        });
+
+        afterEach(() => restore());
+
+        it("repaints the tree when the setting changes", () => {
+            const component = make(
+                stubPythonSetup({visible: true, ready: false})
+            );
+            let fired = 0;
+            component.onDidChange(() => fired++);
+
+            expect(captured, "subscribed to the setting change").to.be.a(
+                "function"
+            );
+            captured!();
+            expect(fired).to.equal(1);
+        });
+
+        it("does not subscribe when no python-setup entry is wired", () => {
+            // The setting only governs the uv entry, so the legacy-only
+            // construction has nothing to refresh for.
+            make(undefined);
+            expect(captured).to.equal(undefined);
+        });
     });
 });

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -1,10 +1,6 @@
-import {
-    ThemeColor,
-    ThemeIcon,
-    TreeItemCollapsibleState,
-    workspace,
-} from "vscode";
+import {ThemeColor, ThemeIcon, TreeItemCollapsibleState} from "vscode";
 import {FeatureManager} from "../../feature-manager/FeatureManager";
+import {workspaceConfigs} from "../../vscode-objs/WorkspaceConfigs";
 import {BaseComponent} from "./BaseComponent";
 import {ConfigurationTreeItem} from "./types";
 import {ConnectionManager} from "../../configuration/ConnectionManager";
@@ -44,15 +40,9 @@ export class EnvironmentComponent extends BaseComponent {
             // (and a manual-mode click on a leftover uv row silently no-ops)
             // until an unrelated event happens to refresh it.
             this.disposables.push(
-                workspace.onDidChangeConfiguration((e) => {
-                    if (
-                        e.affectsConfiguration(
-                            "databricks.python.environmentSetup"
-                        )
-                    ) {
-                        this.onDidChangeEmitter.fire();
-                    }
-                })
+                workspaceConfigs.onDidChangePythonEnvironmentSetup(() =>
+                    this.onDidChangeEmitter.fire()
+                )
             );
         }
     }

--- a/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
+++ b/packages/databricks-vscode/src/ui/configuration-view/EnvironmentComponent.ts
@@ -1,4 +1,9 @@
-import {ThemeColor, ThemeIcon, TreeItemCollapsibleState} from "vscode";
+import {
+    ThemeColor,
+    ThemeIcon,
+    TreeItemCollapsibleState,
+    workspace,
+} from "vscode";
 import {FeatureManager} from "../../feature-manager/FeatureManager";
 import {BaseComponent} from "./BaseComponent";
 import {ConfigurationTreeItem} from "./types";
@@ -32,6 +37,22 @@ export class EnvironmentComponent extends BaseComponent {
                 this.pythonSetup.onDidChangeState(() =>
                     this.onDidChangeEmitter.fire()
                 )
+            );
+            // `databricks.python.environmentSetup` decides whether this section
+            // shows the uv entry or the legacy checklist, and getRoot reads it
+            // live — so a change must repaint the tree, or the stale row lingers
+            // (and a manual-mode click on a leftover uv row silently no-ops)
+            // until an unrelated event happens to refresh it.
+            this.disposables.push(
+                workspace.onDidChangeConfiguration((e) => {
+                    if (
+                        e.affectsConfiguration(
+                            "databricks.python.environmentSetup"
+                        )
+                    ) {
+                        this.onDidChangeEmitter.fire();
+                    }
+                })
             );
         }
     }

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -1,6 +1,13 @@
 import {ConfigurationTarget, workspace} from "vscode";
 import {Time, TimeUnits} from "@databricks/sdk-experimental";
 
+/**
+ * How the extension provisions the local Python environment. `auto` runs the
+ * uv-native setup (`databricks environments setup-local`) for suitable projects;
+ * `manual` disables it so an existing interpreter/environment is used as-is.
+ */
+export type PythonEnvironmentSetupMode = "auto" | "manual";
+
 export const workspaceConfigs = {
     get maxFieldLength() {
         return (
@@ -129,6 +136,17 @@ export const workspaceConfigs = {
                 .getConfiguration("databricks")
                 .get<string>("connect.serverlessDbconnectVersion") ?? "17.3"
         );
+    },
+
+    // Any value other than "manual" (unset, "auto", or an unexpected string)
+    // resolves to "auto" so the default and malformed configs both keep the
+    // automated setup — the historical behavior.
+    get pythonEnvironmentSetup(): PythonEnvironmentSetupMode {
+        return workspace
+            .getConfiguration("databricks")
+            .get<string>("python.environmentSetup") === "manual"
+            ? "manual"
+            : "auto";
     },
 
     get bundleRemoteStateRefreshInterval(): number {

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -1,4 +1,4 @@
-import {ConfigurationTarget, workspace} from "vscode";
+import {ConfigurationTarget, Disposable, workspace} from "vscode";
 import {Time, TimeUnits} from "@databricks/sdk-experimental";
 
 /**
@@ -147,6 +147,18 @@ export const workspaceConfigs = {
             .get<string>("python.environmentSetup") === "manual"
             ? "manual"
             : "auto";
+    },
+
+    // Notify on changes to `python.environmentSetup`. Kept in the adapter so
+    // both reading the setting and observing its changes stay behind the
+    // vscode-objs seam, instead of feature/UI code reaching into `workspace`.
+    // The caller owns the returned Disposable.
+    onDidChangePythonEnvironmentSetup(listener: () => void): Disposable {
+        return workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration("databricks.python.environmentSetup")) {
+                listener();
+            }
+        });
     },
 
     get bundleRemoteStateRefreshInterval(): number {

--- a/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
+++ b/packages/databricks-vscode/src/vscode-objs/WorkspaceConfigs.ts
@@ -161,6 +161,18 @@ export const workspaceConfigs = {
         });
     },
 
+    // Write `python.environmentSetup` — the one-click "Use manual setup" escape
+    // hatch on a failed setup writes "manual" here. Returns the update Thenable
+    // so the caller can await/handle it.
+    setPythonEnvironmentSetup(
+        mode: PythonEnvironmentSetupMode,
+        target: ConfigurationTarget
+    ): Thenable<void> {
+        return workspace
+            .getConfiguration("databricks")
+            .update("python.environmentSetup", mode, target);
+    },
+
     get bundleRemoteStateRefreshInterval(): number {
         const config =
             workspace


### PR DESCRIPTION
## Why

Since 2.14.0 the uv-native "Set up Python environment" flow runs automatically for every uv-suitable project, and its `databricks environments setup-local` step must fetch runtime constraints from `raw.githubusercontent.com`. On corporate networks that block GitHub Raw this dead-ends at `E_FETCH` — even when the project already has a valid local `.venv` with a compatible `databricks-connect` — and there is currently no way to opt out. Reported in #2149.

## What

- Add a **`databricks.python.environmentSetup`** setting (`auto` | `manual`, default `auto`). `manual` makes the uv flow's visibility gate return `false`, so `routeEnvironmentSetup` falls back to the legacy path and the existing interpreter/environment is used as-is — no GitHub Raw fetch required.
- Gate the single shared `makePythonSetupVisibility` factory, which every entry point reads (config-view entry, the `databricks.environment.setup` command routing, and `ConnectionCommands`' serverless-version prompt), so one check covers them all. The setting is read via a new `pythonEnvironmentSetup` getter on `WorkspaceConfigs` (the adapter layer), and short-circuits before any package-manager detection runs.
- Improve the `E_FETCH` message to name `raw.githubusercontent.com` and point at the `manual` setting, and add an `E_FETCH` detail block in the output channel spelling out the allowlist and manual-mode fixes.

## Backward compatibility

- Default stays `auto`, so existing behavior is unchanged.
- Does **not** resurrect the removed `experiments.optInto` / `environment.pythonSetup` flag (retired in #2124); this is a new, purpose-built setting.

## Verification

- `yarn workspace databricks run test:unit`: **989 passing, 0 failing, 10 pending**. New unit tests cover manual-mode hiding a clean uv project (and skipping detection), the setup-mode read failing closed, and the `E_FETCH` copy/detail.
- `yarn fix` + `test:lint`: clean (0 errors).

Fixes #2149

---
This pull request and its description were written by Isaac.
