### PR TITLE
Offer a one-click "Install uv" action when uv is missing

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -601,6 +601,12 @@
                 "category": "Databricks"
             },
             {
+                "command": "databricks.environment.installUv",
+                "title": "Install uv",
+                "enablement": "databricks.context.activated && databricks.context.loggedIn && !databricks.context.remoteMode",
+                "category": "Databricks"
+            },
+            {
                 "command": "databricks.environment.rerunPythonEnv",
                 "title": "Re-run Python setup",
                 "icon": "$(sync)",

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -60,7 +60,11 @@ import {PythonSetupDriftManager} from "./python-setup/controllers/PythonSetupDri
 import {PythonSetupAdoptionManager} from "./python-setup/controllers/PythonSetupAdoptionManager";
 import {SetupCompute} from "./python-setup/controllers/PythonSetupEnvironmentSetup";
 import {venvInterpreterPath} from "./python-setup/utils/venvInterpreterPath";
-import {USE_MANUAL_SETUP_COMMAND_ID} from "./python-setup/utils/errorMessages";
+import {
+    INSTALL_UV_COMMAND_ID,
+    USE_MANUAL_SETUP_COMMAND_ID,
+} from "./python-setup/utils/errorMessages";
+import {uvInstallTerminalCommand} from "./python-setup/utils/uvInstall";
 import {makeServerlessVersionPrompt} from "./python-setup/utils/serverlessVersionResolver";
 import {collectPackageManagerSignals} from "./language/packageManagerSignals";
 import {EnvironmentDependenciesVerifier} from "./language/EnvironmentDependenciesVerifier";
@@ -1090,6 +1094,16 @@ export async function activate(
             await window.showInformationMessage(
                 `Automated Python environment setup is now off ${scope} ("databricks.python.environmentSetup": "manual"). Your existing interpreter will be used as-is.`
             );
+        }),
+        // One-click install surfaced as the E_UV_MISSING failure's primary
+        // action button: run uv's official installer in a terminal so its
+        // step-by-step output stays in front of the user, who then re-runs setup.
+        // A terminal (over a silent spawn) needs no output capture and is the
+        // same pattern used for `az login` (see AzureCliCheck).
+        telemetry.registerCommand(INSTALL_UV_COMMAND_ID, async () => {
+            const terminal = window.createTerminal("Install uv");
+            terminal.show();
+            terminal.sendText(uvInstallTerminalCommand());
         })
     );
     // Drives the config-view row's out-of-sync state: on compute/open/setup

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -65,9 +65,9 @@ import {
     USE_MANUAL_SETUP_COMMAND_ID,
 } from "./python-setup/utils/errorMessages";
 import {
+    runUvInstall,
     UV_INSTALL_CONFIRM_ACTION,
     UV_INSTALL_CONFIRM_MESSAGE,
-    uvInstallTerminalSpec,
 } from "./python-setup/utils/uvInstall";
 import {makeServerlessVersionPrompt} from "./python-setup/utils/serverlessVersionResolver";
 import {collectPackageManagerSignals} from "./language/packageManagerSignals";
@@ -1103,23 +1103,25 @@ export async function activate(
         // terminal so its output stays visible (same pattern as `az login`).
         // A modal first makes the remote-install step an explicit, informed
         // choice; the terminal is pinned to PowerShell on Windows (see the spec).
-        telemetry.registerCommand(INSTALL_UV_COMMAND_ID, async () => {
-            const confirmed = await window.showWarningMessage(
-                UV_INSTALL_CONFIRM_MESSAGE,
-                {modal: true},
-                UV_INSTALL_CONFIRM_ACTION
-            );
-            if (confirmed !== UV_INSTALL_CONFIRM_ACTION) {
-                return;
-            }
-            const spec = uvInstallTerminalSpec();
-            const terminal = window.createTerminal({
-                name: spec.name,
-                shellPath: spec.shellPath,
-            });
-            terminal.show();
-            terminal.sendText(spec.command);
-        })
+        // The confirm→open gate lives in `runUvInstall` so it is unit-tested.
+        telemetry.registerCommand(INSTALL_UV_COMMAND_ID, () =>
+            runUvInstall({
+                confirm: async () =>
+                    (await window.showWarningMessage(
+                        UV_INSTALL_CONFIRM_MESSAGE,
+                        {modal: true},
+                        UV_INSTALL_CONFIRM_ACTION
+                    )) === UV_INSTALL_CONFIRM_ACTION,
+                openTerminal: (spec) => {
+                    const terminal = window.createTerminal({
+                        name: spec.name,
+                        shellPath: spec.shellPath,
+                    });
+                    terminal.show();
+                    terminal.sendText(spec.command);
+                },
+            })
+        )
     );
     // Drives the config-view row's out-of-sync state: on compute/open/setup
     // triggers it silently resolves the selected compute's env key via a CLI

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -64,7 +64,11 @@ import {
     INSTALL_UV_COMMAND_ID,
     USE_MANUAL_SETUP_COMMAND_ID,
 } from "./python-setup/utils/errorMessages";
-import {uvInstallTerminalCommand} from "./python-setup/utils/uvInstall";
+import {
+    UV_INSTALL_CONFIRM_ACTION,
+    UV_INSTALL_CONFIRM_MESSAGE,
+    uvInstallTerminalSpec,
+} from "./python-setup/utils/uvInstall";
 import {makeServerlessVersionPrompt} from "./python-setup/utils/serverlessVersionResolver";
 import {collectPackageManagerSignals} from "./language/packageManagerSignals";
 import {EnvironmentDependenciesVerifier} from "./language/EnvironmentDependenciesVerifier";
@@ -1097,10 +1101,24 @@ export async function activate(
         }),
         // E_UV_MISSING's "Install uv" button: run uv's official installer in a
         // terminal so its output stays visible (same pattern as `az login`).
+        // A modal first makes the remote-install step an explicit, informed
+        // choice; the terminal is pinned to PowerShell on Windows (see the spec).
         telemetry.registerCommand(INSTALL_UV_COMMAND_ID, async () => {
-            const terminal = window.createTerminal("Install uv");
+            const confirmed = await window.showWarningMessage(
+                UV_INSTALL_CONFIRM_MESSAGE,
+                {modal: true},
+                UV_INSTALL_CONFIRM_ACTION
+            );
+            if (confirmed !== UV_INSTALL_CONFIRM_ACTION) {
+                return;
+            }
+            const spec = uvInstallTerminalSpec();
+            const terminal = window.createTerminal({
+                name: spec.name,
+                shellPath: spec.shellPath,
+            });
             terminal.show();
-            terminal.sendText(uvInstallTerminalCommand());
+            terminal.sendText(spec.command);
         })
     );
     // Drives the config-view row's out-of-sync state: on compute/open/setup

--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1095,11 +1095,8 @@ export async function activate(
                 `Automated Python environment setup is now off ${scope} ("databricks.python.environmentSetup": "manual"). Your existing interpreter will be used as-is.`
             );
         }),
-        // One-click install surfaced as the E_UV_MISSING failure's primary
-        // action button: run uv's official installer in a terminal so its
-        // step-by-step output stays in front of the user, who then re-runs setup.
-        // A terminal (over a silent spawn) needs no output capture and is the
-        // same pattern used for `az login` (see AzureCliCheck).
+        // E_UV_MISSING's "Install uv" button: run uv's official installer in a
+        // terminal so its output stays visible (same pattern as `az login`).
         telemetry.registerCommand(INSTALL_UV_COMMAND_ID, async () => {
             const terminal = window.createTerminal("Install uv");
             terminal.show();

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -344,7 +344,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     it("offers an Install uv action when the CLI reports uv is missing", async () => {
         const shown: {
             message: string;
-            action?: PythonSetupErrorAction;
+            actions?: PythonSetupErrorAction[];
         }[] = [];
         const uvMissing: PythonSetupResult = {
             schemaVersion: 1,
@@ -366,8 +366,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli: makeCli({resolve: uvMissing}),
-                showError: async (message, _detail, action) => {
-                    shown.push({message, action});
+                showError: async (message, _detail, actions) => {
+                    shown.push({message, actions});
                 },
             })
         );
@@ -375,19 +375,24 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         await setup.setup();
 
         expect(shown).to.have.length(1);
-        expect(shown[0].action).to.deep.equal({
-            label: "Install uv",
-            url: "https://docs.astral.sh/uv/getting-started/installation/",
-        });
+        // Two buttons: the one-click installer command leads, the manual guide
+        // follows.
+        expect(shown[0].actions).to.deep.equal([
+            {label: "Install uv", command: "databricks.environment.installUv"},
+            {
+                label: "Installation guide",
+                url: "https://docs.astral.sh/uv/getting-started/installation/",
+            },
+        ]);
     });
 
     it("offers the mapped documentation action for a doc-linked failure", async () => {
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli: makeCli({resolve: ERROR_NO_TARGET}),
-                showError: async (_message, _detail, action) => {
-                    shown.push({action});
+                showError: async (_message, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
@@ -395,20 +400,22 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         await setup.setup();
 
         expect(shown).to.have.length(1);
-        expect(shown[0].action).to.deep.equal({
-            label: "Configure compute",
-            url: "https://docs.databricks.com/aws/en/dev-tools/vscode-ext/configure#cluster",
-        });
+        expect(shown[0].actions).to.deep.equal([
+            {
+                label: "Configure compute",
+                url: "https://docs.databricks.com/aws/en/dev-tools/vscode-ext/configure#cluster",
+            },
+        ]);
     });
 
     it("passes no remediation action for a message-only failure", async () => {
         // E_USAGE has no doc that reliably helps, so it surfaces the message alone.
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli: makeCli({resolve: ERROR_USAGE}),
-                showError: async (_message, _detail, action) => {
-                    shown.push({action});
+                showError: async (_message, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
@@ -416,11 +423,12 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         await setup.setup();
 
         expect(shown).to.have.length(1);
-        expect(shown[0].action).to.equal(undefined);
+        expect(shown[0].actions).to.deep.equal([]);
     });
 
     it("makes Report this problem the button for a report-worthy CLI failure", async () => {
-        const shown: {detail?: string; action?: PythonSetupErrorAction}[] = [];
+        const shown: {detail?: string; actions?: PythonSetupErrorAction[]}[] =
+            [];
         const telemetry = makeTelemetryRecorder();
         const mergeFailure: PythonSetupResult = {
             schemaVersion: 1,
@@ -443,16 +451,17 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
             makeDeps({
                 cli: makeCli({resolve: mergeFailure}),
                 recordSetupAttempt: telemetry.recordSetupAttempt,
-                showError: async (_m, detail, action) => {
-                    shown.push({detail, action});
+                showError: async (_m, detail, actions) => {
+                    shown.push({detail, actions});
                 },
             })
         );
 
         await setup.setup();
 
-        expect(shown[0].action?.label).to.equal("Report this problem");
-        expect(shown[0].action?.url).to.contain(
+        expect(shown[0].actions).to.have.length(1);
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].url).to.contain(
             "databricks/databricks-vscode/issues/new"
         );
         // The bare new-issue URL is mirrored into the log too.
@@ -465,7 +474,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     it("keeps Report as the button while mirroring the doc link into the log", async () => {
         // E_ENV_UNSUPPORTED is report-worthy AND has a doc link: report wins the
         // button; the doc link still appears in the log.
-        const shown: {detail?: string; action?: PythonSetupErrorAction}[] = [];
+        const shown: {detail?: string; actions?: PythonSetupErrorAction[]}[] =
+            [];
         const envUnsupported: PythonSetupResult = {
             schemaVersion: 1,
             command: "environments setup-local",
@@ -487,16 +497,16 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli: makeCli({resolve: envUnsupported}),
-                showError: async (_m, detail, action) => {
-                    shown.push({detail, action});
+                showError: async (_m, detail, actions) => {
+                    shown.push({detail, actions});
                 },
             })
         );
 
         await setup.setup();
 
-        expect(shown[0].action?.label).to.equal("Report this problem");
-        expect(shown[0].action?.url).to.contain(
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].url).to.contain(
             "databricks/environments/issues/new"
         );
         expect(shown[0].detail).to.contain("Databricks Runtime versions");
@@ -538,22 +548,22 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     });
 
     it("offers a Report this problem action on a spawn/parse rejection", async () => {
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         const telemetry = makeTelemetryRecorder();
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 cli: makeCli({reject: new Error("spawn databricks ENOENT")}),
                 recordSetupAttempt: telemetry.recordSetupAttempt,
-                showError: async (_m, _detail, action) => {
-                    shown.push({action});
+                showError: async (_m, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
 
         await setup.setup();
 
-        expect(shown[0].action?.label).to.equal("Report this problem");
-        expect(shown[0].action?.url).to.contain(
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].url).to.contain(
             "databricks/databricks-vscode/issues/new"
         );
         expect(telemetry.results[0]).to.include({
@@ -563,7 +573,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     });
 
     it("handles a non-Error rejection without throwing on the spawn path", async () => {
-        const shown: {message: string; action?: PythonSetupErrorAction}[] = [];
+        const shown: {message: string; actions?: PythonSetupErrorAction[]}[] =
+            [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 // A rejection that is not an Error instance: `.message` would be
@@ -573,8 +584,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
                         throw "spawn failed as a bare string";
                     },
                 },
-                showError: async (message, _detail, action) => {
-                    shown.push({message, action});
+                showError: async (message, _detail, actions) => {
+                    shown.push({message, actions});
                 },
             })
         );
@@ -584,11 +595,11 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
 
         expect(shown).to.have.length(1);
         expect(shown[0].message).to.contain("spawn failed as a bare string");
-        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
     });
 
     it("offers a Report this problem action when interpreter adoption fails", async () => {
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         const telemetry = makeTelemetryRecorder();
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
@@ -597,16 +608,16 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
                     throw new Error("adopt failed");
                 },
                 recordSetupAttempt: telemetry.recordSetupAttempt,
-                showError: async (_m, _detail, action) => {
-                    shown.push({action});
+                showError: async (_m, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
 
         await setup.setup();
 
-        expect(shown[0].action?.label).to.equal("Report this problem");
-        expect(shown[0].action?.url).to.contain(
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].url).to.contain(
             "databricks/databricks-vscode/issues/new"
         );
         expect(telemetry.results[0]).to.include({
@@ -1281,15 +1292,15 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
 
     it("does not report ok when the post-adoption state bookkeeping throws", async () => {
         const telemetry = makeTelemetryRecorder();
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         const setup = new PythonSetupEnvironmentSetup(
             makeDeps({
                 ...telemetry,
                 saveState: () => {
                     throw new Error("workspaceState write failed");
                 },
-                showError: async (_m, _detail, action) => {
-                    shown.push({action});
+                showError: async (_m, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
@@ -1306,8 +1317,8 @@ describe("PythonSetupEnvironmentSetup telemetry", () => {
         expect(rejected).to.equal(true);
         // The user is still told the run failed and offered a report — a persist
         // break is the extension's own defect, like adopt.
-        expect(shown[0].action?.label).to.equal("Report this problem");
-        expect(shown[0].action?.url).to.contain(
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].url).to.contain(
             "databricks/databricks-vscode/issues/new"
         );
         expect(telemetry.results).to.deep.equal([

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -12,7 +12,7 @@ import {
 } from "../models/PythonSetupResult";
 import {
     formatSetupFailureDetail,
-    getPythonSetupErrorAction,
+    getPythonSetupErrorActions,
     getPythonSetupErrorMessage,
     isIndexUnreachableFailure,
     NO_COMPUTE_TARGET_MESSAGE,
@@ -143,14 +143,15 @@ export interface PythonSetupSetupDeps {
      * action that reveals the setup output channel. `detail`, when given, is
      * written to that channel first (see `formatSetupFailureDetail`), so the
      * button leads to the CLI's full explanation instead of an empty log.
-     * `action`, when given, adds one more button that opens an external URL —
-     * e.g. "Install uv" pointing at uv's install guide (see
-     * `getPythonSetupErrorAction`).
+     * `actions`, when non-empty, add remediation buttons ahead of "Show Logs" —
+     * each opens an external URL or runs a VS Code command. Most failures carry
+     * one; `E_UV_MISSING` carries two ("Install uv" + "Installation guide", see
+     * `getPythonSetupErrorActions`).
      */
     showError: (
         message: string,
         detail?: string,
-        action?: PythonSetupErrorAction
+        actions?: PythonSetupErrorAction[]
     ) => Promise<void>;
 
     showSuccess: (result: PythonSetupResult) => Promise<void>;
@@ -405,7 +406,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 this.deps.showError(
                     message,
                     reportLogMirror("databricks/databricks-vscode"),
-                    reportAction
+                    [reportAction]
                 )
             );
             return;
@@ -434,7 +435,9 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                         result,
                         reportRepo ? reportLogLink(reportRepo) : undefined
                     ),
-                    reportAction ?? getPythonSetupErrorAction(result)
+                    reportAction
+                        ? [reportAction]
+                        : getPythonSetupErrorActions(result)
                 )
             );
             return;
@@ -472,7 +475,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 this.deps.showError(
                     message,
                     reportLogMirror("databricks/databricks-vscode"),
-                    reportAction
+                    [reportAction]
                 )
             );
             return;
@@ -507,10 +510,12 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 this.deps.showError(
                     message,
                     reportLogMirror("databricks/databricks-vscode"),
-                    buildExtensionFailureReportAction(reportEnv, {
-                        phase: "persist",
-                        message,
-                    })
+                    [
+                        buildExtensionFailureReportAction(reportEnv, {
+                            phase: "persist",
+                            message,
+                        }),
+                    ]
                 )
             );
             throw e;

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import {env, Uri, window} from "vscode";
+import {commands, env, Uri, window} from "vscode";
 import {
     makePythonSetupDeps,
     makePythonSetupVisibility,
@@ -640,10 +640,12 @@ describe("makePythonSetupDeps showError", () => {
             );
             reply = "Install uv";
 
-            await deps.showError("uv missing", "detail", {
-                label: "Install uv",
-                url: "https://docs.astral.sh/uv/getting-started/installation/",
-            });
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Install uv",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
 
             // Order matters: the remediation button leads, "Show Logs" follows.
             expect(shownWith[0].actions).to.deep.equal([
@@ -678,10 +680,12 @@ describe("makePythonSetupDeps showError", () => {
             );
             reply = "Show Logs";
 
-            await deps.showError("uv missing", "detail", {
-                label: "Show Logs",
-                url: "https://docs.astral.sh/uv/getting-started/installation/",
-            });
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Show Logs",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
 
             // Only the single, unambiguous Show Logs button is offered...
             expect(shownWith[0].actions).to.deep.equal(["Show Logs"]);
@@ -708,10 +712,12 @@ describe("makePythonSetupDeps showError", () => {
             );
             reply = "Install uv";
 
-            await deps.showError("uv missing", "detail", {
-                label: "Install uv",
-                url: "https://docs.astral.sh/uv/getting-started/installation/",
-            });
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Install uv",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
 
             expect(appended.join("")).to.match(/could not open/i);
         } finally {
@@ -737,10 +743,12 @@ describe("makePythonSetupDeps showError", () => {
             reply = "Install uv";
 
             // Must resolve, not throw.
-            await deps.showError("uv missing", "detail", {
-                label: "Install uv",
-                url: "https://docs.astral.sh/uv/getting-started/installation/",
-            });
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Install uv",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
 
             // The failure is recorded to the log channel rather than swallowed
             // silently.
@@ -766,13 +774,81 @@ describe("makePythonSetupDeps showError", () => {
             );
             reply = "Show Logs";
 
-            await deps.showError("uv missing", "detail", {
-                label: "Install uv",
-                url: "https://docs.astral.sh/uv/getting-started/installation/",
-            });
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Install uv",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
 
             expect(opened).to.have.length(0);
         } finally {
+            (env as unknown as {openExternal: unknown}).openExternal =
+                originalOpen;
+        }
+    });
+
+    it("renders two remediation buttons in order, then Show Logs", async () => {
+        const deps = makePythonSetupDeps(
+            makeWiring({log: {append: () => {}, show: () => {}}})
+        );
+        reply = undefined; // dismissed — we only assert on the offered buttons
+
+        await deps.showError("uv missing", "detail", [
+            {label: "Install uv", command: "databricks.environment.installUv"},
+            {
+                label: "Installation guide",
+                url: "https://docs.astral.sh/uv/getting-started/installation/",
+            },
+        ]);
+
+        expect(shownWith[0].actions).to.deep.equal([
+            "Install uv",
+            "Installation guide",
+            "Show Logs",
+        ]);
+    });
+
+    it("runs the VS Code command when a command-action button is picked", async () => {
+        const original = commands.executeCommand;
+        const executed: string[] = [];
+        (commands as unknown as {executeCommand: unknown}).executeCommand =
+            async (command: string) => {
+                executed.push(command);
+            };
+        const originalOpen = env.openExternal;
+        const opened: string[] = [];
+        (env as unknown as {openExternal: unknown}).openExternal = async (
+            uri: Uri
+        ) => {
+            opened.push(uri.toString(true));
+            return true;
+        };
+        try {
+            const deps = makePythonSetupDeps(
+                makeWiring({log: {append: () => {}, show: () => {}}})
+            );
+            reply = "Install uv";
+
+            await deps.showError("uv missing", "detail", [
+                {
+                    label: "Install uv",
+                    command: "databricks.environment.installUv",
+                },
+                {
+                    label: "Installation guide",
+                    url: "https://docs.astral.sh/uv/getting-started/installation/",
+                },
+            ]);
+
+            // The command runs; the sibling URL action is untouched.
+            expect(executed).to.deep.equal([
+                "databricks.environment.installUv",
+            ]);
+            expect(opened).to.have.length(0);
+        } finally {
+            (commands as unknown as {executeCommand: unknown}).executeCommand =
+                original;
             (env as unknown as {openExternal: unknown}).openExternal =
                 originalOpen;
         }

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -250,7 +250,7 @@ export function makePythonSetupDeps(
         showError: async (
             message: string,
             detail?: string,
-            action?: PythonSetupErrorAction
+            actions: PythonSetupErrorAction[] = []
         ) => {
             // The mapped one-liner is deliberately concise and drops the CLI's
             // own explanation; write that detail into the channel so the log the
@@ -266,46 +266,57 @@ export function makePythonSetupDeps(
             const showLogs = "Show Logs";
             // `showErrorMessage` hands the picked value back as a bare label
             // string, so two buttons sharing a label are indistinguishable. Drop
-            // a remediation action that reuses the reserved "Show Logs" label
-            // rather than offer an ambiguous button whose URL branch is dead.
-            const remediation =
-                action && action.label !== showLogs ? action : undefined;
-            // Lead with the remediation button (e.g. "Install uv") when one is
-            // attached, so the action the user most likely wants comes first.
-            const actions = remediation
-                ? [remediation.label, showLogs]
-                : [showLogs];
-            const picked = await window.showErrorMessage(message, ...actions);
+            // any remediation reusing the reserved "Show Logs" label, and any
+            // later duplicate label (first wins), rather than offer an ambiguous
+            // button whose dispatch would be dead.
+            const seen = new Set<string>([showLogs]);
+            const remediations = actions.filter((a) => {
+                if (seen.has(a.label)) {
+                    return false;
+                }
+                seen.add(a.label);
+                return true;
+            });
+            // Lead with the remediation buttons (e.g. "Install uv", then
+            // "Installation guide") in order, so the action the user most likely
+            // wants comes first; "Show Logs" always trails.
+            const buttons = [...remediations.map((a) => a.label), showLogs];
+            const picked = await window.showErrorMessage(message, ...buttons);
             if (picked === showLogs) {
                 wiring.log.show();
-            } else if (remediation && picked === remediation.label) {
-                // showError is the failure-reporting path and its one caller does
-                // not wrap it, so nothing thrown here may escape — contain and
-                // record any failure.
-                try {
-                    if (remediation.command) {
-                        // A command-action (e.g. E_FETCH "Use manual setup")
-                        // runs a registered VS Code command instead of opening a
-                        // URL.
-                        await commands.executeCommand(remediation.command);
-                    } else if (remediation.url) {
-                        const opened = await openExternal(remediation.url);
-                        if (!opened) {
-                            wiring.log.append(
-                                `\nCould not open ${remediation.url} in a browser.\n`
-                            );
-                        }
+                return;
+            }
+            const chosen = remediations.find((a) => a.label === picked);
+            if (chosen === undefined) {
+                // Dismissed, or a label we did not render.
+                return;
+            }
+            // showError is the failure-reporting path and its one caller does not
+            // wrap it, so nothing thrown here may escape — contain and record any
+            // failure.
+            try {
+                if (chosen.command) {
+                    // A command-action (e.g. "Install uv", E_FETCH "Use manual
+                    // setup") runs a registered VS Code command instead of
+                    // opening a URL.
+                    await commands.executeCommand(chosen.command);
+                } else if (chosen.url) {
+                    const opened = await openExternal(chosen.url);
+                    if (!opened) {
+                        wiring.log.append(
+                            `\nCould not open ${chosen.url} in a browser.\n`
+                        );
                     }
-                } catch (e) {
-                    const what = remediation.command
-                        ? `run ${remediation.command}`
-                        : `open ${remediation.url}`;
-                    wiring.log.append(
-                        `\nFailed to ${what}: ${
-                            e instanceof Error ? e.message : String(e)
-                        }\n`
-                    );
                 }
+            } catch (e) {
+                const what = chosen.command
+                    ? `run ${chosen.command}`
+                    : `open ${chosen.url}`;
+                wiring.log.append(
+                    `\nFailed to ${what}: ${
+                        e instanceof Error ? e.message : String(e)
+                    }\n`
+                );
             }
         },
         showSuccess: async (result) => {

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.test.ts
@@ -2,7 +2,9 @@ import {expect} from "chai";
 import {
     formatSetupFailureDetail,
     getPythonSetupErrorAction,
+    getPythonSetupErrorActions,
     getPythonSetupErrorMessage,
+    INSTALL_UV_COMMAND_ID,
     isIndexUnreachableFailure,
     USE_MANUAL_SETUP_COMMAND_ID,
 } from "./errorMessages";
@@ -270,12 +272,14 @@ describe("getPythonSetupErrorMessage", () => {
 });
 
 describe("getPythonSetupErrorAction", () => {
-    it("offers an Install uv action pointing at the uv docs for E_UV_MISSING", () => {
+    it("offers an Installation guide link pointing at the uv docs for E_UV_MISSING", () => {
+        // The singular action is the manual fallback (and the log mirror); the
+        // one-click installer button is added by getPythonSetupErrorActions.
         const action = getPythonSetupErrorAction(
             failure("E_UV_MISSING", {failurePhase: "preflight"})
         );
         expect(action).to.deep.equal({
-            label: "Install uv",
+            label: "Installation guide",
             url: "https://docs.astral.sh/uv/getting-started/installation/",
         });
     });
@@ -385,6 +389,45 @@ describe("getPythonSetupErrorAction", () => {
         const ok = failure("E_UV_MISSING");
         ok.error = null;
         expect(getPythonSetupErrorAction(ok)).to.equal(undefined);
+    });
+});
+
+describe("getPythonSetupErrorActions", () => {
+    it("leads E_UV_MISSING with a one-click installer, then the manual guide", () => {
+        const actions = getPythonSetupErrorActions(
+            failure("E_UV_MISSING", {failurePhase: "preflight"})
+        );
+        expect(actions).to.deep.equal([
+            {label: "Install uv", command: INSTALL_UV_COMMAND_ID},
+            {
+                label: "Installation guide",
+                url: "https://docs.astral.sh/uv/getting-started/installation/",
+            },
+        ]);
+    });
+
+    it("wraps a non-uv code's single action in a one-element list", () => {
+        expect(
+            getPythonSetupErrorActions(failure("E_PYTHON_INSTALL"))
+        ).to.deep.equal([
+            {
+                label: "Install a Python version",
+                url: "https://docs.astral.sh/uv/guides/install-python/",
+            },
+        ]);
+    });
+
+    it("returns an empty list for a code with no actionable button", () => {
+        // E_USAGE has no doc link and is not E_UV_MISSING.
+        expect(getPythonSetupErrorActions(failure("E_USAGE"))).to.deep.equal(
+            []
+        );
+    });
+
+    it("returns an empty list when the result carries no error", () => {
+        const ok = failure("E_UV_MISSING");
+        ok.error = null;
+        expect(getPythonSetupErrorActions(ok)).to.deep.equal([]);
     });
 });
 

--- a/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/errorMessages.ts
@@ -143,6 +143,14 @@ export const USE_MANUAL_SETUP_COMMAND_ID =
     "databricks.environment.useManualPythonSetup";
 
 /**
+ * Command that runs uv's official installer in a terminal for the current
+ * platform, surfaced as the primary E_UV_MISSING remediation button (see
+ * {@link getPythonSetupErrorActions}). Defined here — next to the action that
+ * references it — and reused by the command registration so the two cannot drift.
+ */
+export const INSTALL_UV_COMMAND_ID = "databricks.environment.installUv";
+
+/**
  * An optional remediation button to attach to a failure popup. Exactly one of
  * `url` / `command` is set — a discriminated union (`?: never` on the other arm)
  * forbids both/neither at compile time, while still letting callers read
@@ -229,14 +237,16 @@ export function getPythonSetupErrorMessage(result: PythonSetupResult): string {
  * (E_USAGE, E_NOT_WRITABLE, E_WRITE, E_MERGE, E_VALIDATE, E_FETCH) are absent and
  * get the message alone rather than a link that might misdirect.
  *
- * `E_UV_MISSING` lives here so every code-keyed link takes one path; the
- * blocked-index variant of `E_PROVISION` cannot — it is told apart by the CLI's
- * message, not its code — so it is resolved ahead of this map (see below).
+ * `E_UV_MISSING`'s manual "Installation guide" link lives here so every code-keyed
+ * link takes one path (its one-click "Install uv" companion is added by
+ * {@link getPythonSetupErrorActions}); the blocked-index variant of `E_PROVISION`
+ * cannot — it is told apart by the CLI's message, not its code — so it is resolved
+ * ahead of this map (see below).
  */
 /* eslint-disable @typescript-eslint/naming-convention */
 const DOC_LINKS: Partial<Record<PythonSetupErrorCode, PythonSetupErrorAction>> =
     {
-        E_UV_MISSING: {label: "Install uv", url: UV_INSTALL_DOCS_URL},
+        E_UV_MISSING: {label: "Installation guide", url: UV_INSTALL_DOCS_URL},
         E_MANAGER_UNSUPPORTED: {
             label: "Set up a uv project",
             url: UV_PROJECTS_DOCS_URL,
@@ -292,6 +302,28 @@ export function getPythonSetupErrorAction(
         };
     }
     return DOC_LINKS[err.code];
+}
+
+/**
+ * The ordered remediation buttons for a failure popup. Most codes carry a single
+ * doc/command action (from {@link getPythonSetupErrorAction}), so this returns a
+ * one- or zero-element list. `E_UV_MISSING` is the exception: it leads with a
+ * one-click "Install uv" that runs uv's official installer in a terminal
+ * (`INSTALL_UV_COMMAND_ID`), then keeps the manual "Installation guide" link as a
+ * fallback for users who would rather install it themselves. Reuses the singular
+ * action for that fallback so the guide's label/URL are single-sourced.
+ */
+export function getPythonSetupErrorActions(
+    result: PythonSetupResult
+): PythonSetupErrorAction[] {
+    const action = getPythonSetupErrorAction(result);
+    if (result.error?.code === "E_UV_MISSING") {
+        return [
+            {label: "Install uv", command: INSTALL_UV_COMMAND_ID},
+            ...(action ? [action] : []),
+        ];
+    }
+    return action ? [action] : [];
 }
 
 /**

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
@@ -6,34 +6,62 @@ import {
 } from "./uvInstall";
 
 describe("uvInstallTerminalCommand", () => {
-    it("curls the official install.sh into sh on POSIX shells", () => {
-        const cmd = uvInstallTerminalCommand("posix");
-        expect(cmd).to.contain(
-            `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
-        );
-        // POSIX chains commands with "; ".
-        expect(cmd).to.contain("; ");
+    it("curls the official install.sh into sh on macOS/Linux", () => {
+        for (const platform of ["darwin", "linux"] as const) {
+            const cmd = uvInstallTerminalCommand("posix", platform);
+            expect(cmd).to.contain(
+                `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
+            );
+            // POSIX chains commands with "; ".
+            expect(cmd).to.contain("; ");
+            expect(cmd).to.not.contain("install.ps1");
+        }
     });
 
-    it("runs install.ps1 through irm | iex directly in PowerShell", () => {
-        const cmd = uvInstallTerminalCommand("powershell");
+    it("runs install.ps1 through irm | iex directly in a Windows PowerShell terminal", () => {
+        const cmd = uvInstallTerminalCommand("powershell", "win32");
         expect(cmd).to.contain(`irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`);
         // A PowerShell session runs iex directly — no nested powershell.exe.
-        expect(cmd).to.not.contain("powershell -ExecutionPolicy");
+        expect(cmd).to.not.contain("powershell.exe");
+        expect(cmd).to.not.contain("install.sh");
     });
 
-    it("shells out to PowerShell from cmd (which has no irm)", () => {
-        const cmd = uvInstallTerminalCommand("cmd");
+    it("shells out to powershell.exe from a Windows cmd terminal (which has no irm)", () => {
+        const cmd = uvInstallTerminalCommand("cmd", "win32");
         expect(cmd).to.contain(
-            `powershell -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`
+            `powershell.exe -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`
         );
         // cmd chains with "& ", not ";".
         expect(cmd).to.contain("& ");
     });
 
-    it("explains the step and points back at the setup entry, in every dialect", () => {
-        for (const kind of ["posix", "powershell", "cmd"] as const) {
-            const cmd = uvInstallTerminalCommand(kind);
+    it("installs the Windows uv even from a POSIX-dialect terminal on Windows (Git Bash / WSL)", () => {
+        // The installer OS follows the host (process.platform), not the shell
+        // dialect: a Git Bash / WSL default profile is posix *syntax*, but the
+        // extension host and setup-local still run on Windows — so uv must be
+        // the Windows build (reached via powershell.exe interop), never the
+        // POSIX install.sh, which would land uv where Windows setup can't see it.
+        const cmd = uvInstallTerminalCommand("posix", "win32");
+        expect(cmd).to.contain(
+            `powershell.exe -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`
+        );
+        expect(cmd).to.not.contain("install.sh");
+        expect(cmd).to.not.contain("curl ");
+        // POSIX syntax still chains with "; ".
+        expect(cmd).to.contain("; ");
+    });
+
+    const allShapes = [
+        ["posix", "darwin"],
+        ["posix", "linux"],
+        ["powershell", "win32"],
+        ["cmd", "win32"],
+        ["posix", "win32"],
+    ] as const;
+
+    it("explains the step and points back at the setup entry, in every shape", () => {
+        for (const [kind, platform] of allShapes) {
+            const cmd = uvInstallTerminalCommand(kind, platform);
             // A human-readable banner naming the official installer…
             expect(cmd.toLowerCase()).to.contain("uv");
             expect(cmd).to.contain("astral.sh");
@@ -46,8 +74,8 @@ describe("uvInstallTerminalCommand", () => {
         // Unlike the az-login flow, we do not close the terminal on completion:
         // the installer's own step-by-step output (and any error) must remain
         // visible for the user to read before they re-run setup.
-        for (const kind of ["posix", "powershell", "cmd"] as const) {
-            const cmd = uvInstallTerminalCommand(kind);
+        for (const [kind, platform] of allShapes) {
+            const cmd = uvInstallTerminalCommand(kind, platform);
             expect(cmd).to.not.match(/(^|\s|;|&)exit(\s|;|&|$)/);
         }
     });

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
@@ -52,9 +52,22 @@ describe("uvInstallTerminalCommand", () => {
         expect(cmd).to.contain("; ");
     });
 
+    it("still curls the POSIX installer, in PowerShell syntax, for pwsh on macOS/Linux", () => {
+        // A pwsh default profile on macOS/Linux: the installer stays the POSIX
+        // curl | sh (uv is a *nix build there), but the banner must be
+        // PowerShell syntax so the whole line parses.
+        const cmd = uvInstallTerminalCommand("powershell", "darwin");
+        expect(cmd).to.contain(
+            `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
+        );
+        expect(cmd).to.contain("Write-Host");
+        expect(cmd).to.not.contain("install.ps1");
+    });
+
     const allShapes = [
         ["posix", "darwin"],
         ["posix", "linux"],
+        ["powershell", "darwin"],
         ["powershell", "win32"],
         ["cmd", "win32"],
         ["posix", "win32"],
@@ -96,13 +109,26 @@ describe("uvInstallTerminalSpec", () => {
         expect(spec.command).to.not.contain("install.sh");
     });
 
-    it("uses the default (POSIX) profile on macOS/Linux", () => {
+    it("uses the default profile on macOS/Linux (POSIX shell)", () => {
         for (const platform of ["darwin", "linux"] as const) {
-            const spec = uvInstallTerminalSpec(platform);
+            const spec = uvInstallTerminalSpec(platform, "posix");
             expect(spec.shellPath).to.equal(undefined);
             expect(spec.command).to.contain(
                 `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
             );
         }
+    });
+
+    it("matches the dialect when the default macOS/Linux profile is pwsh", () => {
+        // A pwsh default profile on macOS/Linux runs PowerShell syntax; the
+        // command must use it (Write-Host, not printf) while still curling the
+        // POSIX installer — otherwise the banner lines fail to parse.
+        const spec = uvInstallTerminalSpec("darwin", "powershell");
+        expect(spec.shellPath).to.equal(undefined);
+        expect(spec.command).to.contain(
+            `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
+        );
+        expect(spec.command).to.contain("Write-Host");
+        expect(spec.command).to.not.contain("printf");
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
@@ -1,0 +1,54 @@
+import {expect} from "chai";
+import {
+    UV_INSTALL_SCRIPT_POSIX_URL,
+    UV_INSTALL_SCRIPT_WINDOWS_URL,
+    uvInstallTerminalCommand,
+} from "./uvInstall";
+
+describe("uvInstallTerminalCommand", () => {
+    it("curls the official install.sh into sh on POSIX shells", () => {
+        const cmd = uvInstallTerminalCommand("posix");
+        expect(cmd).to.contain(
+            `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
+        );
+        // POSIX chains commands with "; ".
+        expect(cmd).to.contain("; ");
+    });
+
+    it("runs install.ps1 through irm | iex directly in PowerShell", () => {
+        const cmd = uvInstallTerminalCommand("powershell");
+        expect(cmd).to.contain(`irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`);
+        // A PowerShell session runs iex directly — no nested powershell.exe.
+        expect(cmd).to.not.contain("powershell -ExecutionPolicy");
+    });
+
+    it("shells out to PowerShell from cmd (which has no irm)", () => {
+        const cmd = uvInstallTerminalCommand("cmd");
+        expect(cmd).to.contain(
+            `powershell -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`
+        );
+        // cmd chains with "& ", not ";".
+        expect(cmd).to.contain("& ");
+    });
+
+    it("explains the step and points back at the setup entry, in every dialect", () => {
+        for (const kind of ["posix", "powershell", "cmd"] as const) {
+            const cmd = uvInstallTerminalCommand(kind);
+            // A human-readable banner naming the official installer…
+            expect(cmd.toLowerCase()).to.contain("uv");
+            expect(cmd).to.contain("astral.sh");
+            // …and a follow-up pointing at the action to take once it finishes.
+            expect(cmd).to.contain("Set up Python environment");
+        }
+    });
+
+    it("leaves the terminal open so the installer output stays readable", () => {
+        // Unlike the az-login flow, we do not close the terminal on completion:
+        // the installer's own step-by-step output (and any error) must remain
+        // visible for the user to read before they re-run setup.
+        for (const kind of ["posix", "powershell", "cmd"] as const) {
+            const cmd = uvInstallTerminalCommand(kind);
+            expect(cmd).to.not.match(/(^|\s|;|&)exit(\s|;|&|$)/);
+        }
+    });
+});

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
@@ -1,7 +1,9 @@
 import {expect} from "chai";
 import {
+    runUvInstall,
     UV_INSTALL_SCRIPT_POSIX_URL,
     UV_INSTALL_SCRIPT_WINDOWS_URL,
+    UvInstallTerminalSpec,
     uvInstallTerminalCommand,
     uvInstallTerminalSpec,
 } from "./uvInstall";
@@ -130,5 +132,28 @@ describe("uvInstallTerminalSpec", () => {
         );
         expect(spec.command).to.contain("Write-Host");
         expect(spec.command).to.not.contain("printf");
+    });
+});
+
+describe("runUvInstall", () => {
+    it("opens the install terminal after the user confirms", async () => {
+        const opened: UvInstallTerminalSpec[] = [];
+        await runUvInstall({
+            confirm: async () => true,
+            openTerminal: (spec) => opened.push(spec),
+        });
+        expect(opened).to.have.length(1);
+        expect(opened[0].name).to.equal("Install uv");
+    });
+
+    it("opens nothing when the user dismisses the confirmation", async () => {
+        let opened = false;
+        await runUvInstall({
+            confirm: async () => false,
+            openTerminal: () => {
+                opened = true;
+            },
+        });
+        expect(opened).to.equal(false);
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.test.ts
@@ -3,6 +3,7 @@ import {
     UV_INSTALL_SCRIPT_POSIX_URL,
     UV_INSTALL_SCRIPT_WINDOWS_URL,
     uvInstallTerminalCommand,
+    uvInstallTerminalSpec,
 } from "./uvInstall";
 
 describe("uvInstallTerminalCommand", () => {
@@ -77,6 +78,31 @@ describe("uvInstallTerminalCommand", () => {
         for (const [kind, platform] of allShapes) {
             const cmd = uvInstallTerminalCommand(kind, platform);
             expect(cmd).to.not.match(/(^|\s|;|&)exit(\s|;|&|$)/);
+        }
+    });
+});
+
+describe("uvInstallTerminalSpec", () => {
+    it("pins a PowerShell terminal on Windows so it does not depend on the default profile", () => {
+        // A WSL / Git Bash default profile can have Windows interop disabled,
+        // which would strand the Windows uv. Pinning powershell.exe sidesteps
+        // that, and the command is the direct PowerShell irm | iex.
+        const spec = uvInstallTerminalSpec("win32");
+        expect(spec.shellPath).to.equal("powershell.exe");
+        expect(spec.name).to.equal("Install uv");
+        expect(spec.command).to.contain(
+            `irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`
+        );
+        expect(spec.command).to.not.contain("install.sh");
+    });
+
+    it("uses the default (POSIX) profile on macOS/Linux", () => {
+        for (const platform of ["darwin", "linux"] as const) {
+            const spec = uvInstallTerminalSpec(platform);
+            expect(spec.shellPath).to.equal(undefined);
+            expect(spec.command).to.contain(
+                `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`
+            );
         }
     });
 });

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
@@ -84,3 +84,48 @@ export function uvInstallTerminalCommand(
         ),
     ].join(sep);
 }
+
+/** Label on the confirm button of the install-uv modal (also its return value). */
+export const UV_INSTALL_CONFIRM_ACTION = "Install uv";
+
+/**
+ * Modal body shown before the installer runs. The user already clicked
+ * "Install uv", but running a remote install script is worth one explicit,
+ * informed confirmation — it names the source and says code will execute.
+ */
+export const UV_INSTALL_CONFIRM_MESSAGE =
+    "This downloads and runs uv's official installer from astral.sh in a " +
+    "terminal, executing its script on your machine. Continue?";
+
+/**
+ * How to open the "Install uv" terminal: VS Code `createTerminal` options plus
+ * the matching command line. Pure (platform-only) so the extension's command
+ * handler stays thin and the Windows/POSIX split is unit-tested.
+ *
+ * On Windows the terminal is pinned to `powershell.exe` rather than the user's
+ * default profile: a WSL / Git Bash default can have Windows interop disabled,
+ * which would strand the Windows uv the extension host needs. A throwaway
+ * install terminal needs no profile args, so pinning is safe here. On
+ * macOS/Linux the default profile is used (always POSIX syntax).
+ */
+export interface UvInstallTerminalSpec {
+    name: string;
+    shellPath?: string;
+    command: string;
+}
+
+export function uvInstallTerminalSpec(
+    platform: NodeJS.Platform = process.platform
+): UvInstallTerminalSpec {
+    if (platform === "win32") {
+        return {
+            name: "Install uv",
+            shellPath: "powershell.exe",
+            command: uvInstallTerminalCommand("powershell", platform),
+        };
+    }
+    return {
+        name: "Install uv",
+        command: uvInstallTerminalCommand("posix", platform),
+    };
+}

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
@@ -14,32 +14,37 @@ export const UV_INSTALL_SCRIPT_POSIX_URL = "https://astral.sh/uv/install.sh";
 /** uv's official Windows install script, run through PowerShell's `irm | iex`. */
 export const UV_INSTALL_SCRIPT_WINDOWS_URL = "https://astral.sh/uv/install.ps1";
 
-/** The installer's script URL for the platform a shell dialect implies. */
-function installerScriptUrl(kind: ShellKind): string {
-    return kind === "posix"
-        ? UV_INSTALL_SCRIPT_POSIX_URL
-        : UV_INSTALL_SCRIPT_WINDOWS_URL;
+/** The installer's script URL for the host platform (used only in the banner). */
+function installerScriptUrl(platform: NodeJS.Platform): string {
+    return platform === "win32"
+        ? UV_INSTALL_SCRIPT_WINDOWS_URL
+        : UV_INSTALL_SCRIPT_POSIX_URL;
 }
 
 /**
- * The bare installer invocation for a shell dialect — the command that actually
- * downloads and runs uv's official installer.
+ * The bare installer invocation — the command that actually downloads and runs
+ * uv's official installer.
  *
- * POSIX curls install.sh into `sh`. In PowerShell we `irm | iex` the script
- * directly (execution policy governs script *files*, not a piped string). From
- * cmd there is no `irm`, so we shell out to PowerShell with the documented
- * `-ExecutionPolicy ByPass`, so a restrictive machine default does not block the
- * one-off install.
+ * The installer OS is chosen by the host `platform`, NOT the shell dialect: on
+ * Windows a Git Bash / WSL default terminal is posix *syntax* but the extension
+ * host (and `setup-local`) still run on Windows, so uv must be the Windows build
+ * or the newly-installed binary would be invisible to setup. From such a posix
+ * shell — and from cmd — we reach the Windows installer through `powershell.exe`
+ * (`.exe` so WSL interop resolves it) with the documented `-ExecutionPolicy
+ * ByPass`, so a restrictive machine default does not block the one-off install.
+ * Inside PowerShell itself we `irm | iex` directly (execution policy governs
+ * script *files*, not a piped string). On macOS/Linux we curl install.sh into sh.
  */
-function uvInstallerInvocation(kind: ShellKind): string {
-    switch (kind) {
-        case "posix":
-            return `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`;
-        case "powershell":
-            return `irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`;
-        case "cmd":
-            return `powershell -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`;
+function uvInstallerInvocation(
+    kind: ShellKind,
+    platform: NodeJS.Platform
+): string {
+    if (platform !== "win32") {
+        return `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`;
     }
+    return kind === "powershell"
+        ? `irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`
+        : `powershell.exe -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`;
 }
 
 /**
@@ -52,23 +57,25 @@ function uvInstallerInvocation(kind: ShellKind): string {
  * is nothing to capture or parse. We do not append `exit`, so that output
  * remains readable after the script completes.
  *
- * The command line is written in the dialect of the shell that will parse it
- * (created without `shellPath`, so `currentShellKind` reports it). Reusing the
- * shared `shellUtils` builders keeps the `curl | sh` / `irm | iex` split and the
- * `;` vs `&` separator correct across macOS, Linux and Windows.
+ * Two independent axes: the command-line *syntax* (separator, echo) follows the
+ * shell dialect `kind` (created without `shellPath`, so `currentShellKind`
+ * reports it), while the installer *OS* follows the host `platform` — see
+ * {@link uvInstallerInvocation}. Reusing the shared `shellUtils` builders keeps
+ * both correct across macOS, Linux and Windows.
  */
 export function uvInstallTerminalCommand(
-    kind: ShellKind = currentShellKind()
+    kind: ShellKind = currentShellKind(),
+    platform: NodeJS.Platform = process.platform
 ): string {
     const sep = commandSeparator(kind);
     return [
         echoLine(
             `Installing uv using the official installer (${installerScriptUrl(
-                kind
+                platform
             )}) ...`,
             kind
         ),
-        uvInstallerInvocation(kind),
+        uvInstallerInvocation(kind, platform),
         echoLine("", kind),
         echoLine(
             'When it finishes, re-run "Set up Python environment". You may ' +

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
@@ -132,3 +132,27 @@ export function uvInstallTerminalSpec(
         command: uvInstallTerminalCommand(kind, platform),
     };
 }
+
+/**
+ * Seams for {@link runUvInstall}, so the confirm→open gate is testable without a
+ * VS Code host. The extension wires `confirm` to a modal warning and
+ * `openTerminal` to `window.createTerminal(...).show()/.sendText(...)`.
+ */
+export interface InstallUvDeps {
+    /** Ask the user to confirm the remote install; resolves true to proceed. */
+    confirm: () => Promise<boolean>;
+    /** Open the install terminal for the given spec. */
+    openTerminal: (spec: UvInstallTerminalSpec) => void;
+}
+
+/**
+ * The "Install uv" command body: confirm first, and only then open the installer
+ * terminal — so a dismissed confirmation runs nothing. Kept out of `extension.ts`
+ * so the gate is unit-tested rather than living untested in `activate()`.
+ */
+export async function runUvInstall(deps: InstallUvDeps): Promise<void> {
+    if (!(await deps.confirm())) {
+        return;
+    }
+    deps.openTerminal(uvInstallTerminalSpec());
+}

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
@@ -1,0 +1,79 @@
+import {
+    commandSeparator,
+    currentShellKind,
+    echoLine,
+    ShellKind,
+} from "../../utils/shellUtils";
+
+/**
+ * uv's official POSIX install script (macOS/Linux), piped into `sh`. Single-
+ * sourced here so the terminal command and its test point at the same URL.
+ */
+export const UV_INSTALL_SCRIPT_POSIX_URL = "https://astral.sh/uv/install.sh";
+
+/** uv's official Windows install script, run through PowerShell's `irm | iex`. */
+export const UV_INSTALL_SCRIPT_WINDOWS_URL = "https://astral.sh/uv/install.ps1";
+
+/** The installer's script URL for the platform a shell dialect implies. */
+function installerScriptUrl(kind: ShellKind): string {
+    return kind === "posix"
+        ? UV_INSTALL_SCRIPT_POSIX_URL
+        : UV_INSTALL_SCRIPT_WINDOWS_URL;
+}
+
+/**
+ * The bare installer invocation for a shell dialect — the command that actually
+ * downloads and runs uv's official installer.
+ *
+ * POSIX curls install.sh into `sh`. In PowerShell we `irm | iex` the script
+ * directly (execution policy governs script *files*, not a piped string). From
+ * cmd there is no `irm`, so we shell out to PowerShell with the documented
+ * `-ExecutionPolicy ByPass`, so a restrictive machine default does not block the
+ * one-off install.
+ */
+function uvInstallerInvocation(kind: ShellKind): string {
+    switch (kind) {
+        case "posix":
+            return `curl -LsSf ${UV_INSTALL_SCRIPT_POSIX_URL} | sh`;
+        case "powershell":
+            return `irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex`;
+        case "cmd":
+            return `powershell -ExecutionPolicy ByPass -c "irm ${UV_INSTALL_SCRIPT_WINDOWS_URL} | iex"`;
+    }
+}
+
+/**
+ * The full command line to send to a fresh terminal for the "Install uv" action:
+ * a short banner explaining what runs, the official installer invocation, then a
+ * follow-up telling the user to re-run setup once it finishes.
+ *
+ * A terminal (not a silent background spawn) is deliberate: the installer's own
+ * step-by-step output — and any failure — stays in front of the user, and there
+ * is nothing to capture or parse. We do not append `exit`, so that output
+ * remains readable after the script completes.
+ *
+ * The command line is written in the dialect of the shell that will parse it
+ * (created without `shellPath`, so `currentShellKind` reports it). Reusing the
+ * shared `shellUtils` builders keeps the `curl | sh` / `irm | iex` split and the
+ * `;` vs `&` separator correct across macOS, Linux and Windows.
+ */
+export function uvInstallTerminalCommand(
+    kind: ShellKind = currentShellKind()
+): string {
+    const sep = commandSeparator(kind);
+    return [
+        echoLine(
+            `Installing uv using the official installer (${installerScriptUrl(
+                kind
+            )}) ...`,
+            kind
+        ),
+        uvInstallerInvocation(kind),
+        echoLine("", kind),
+        echoLine(
+            'When it finishes, re-run "Set up Python environment". You may ' +
+                "need to restart VS Code first so uv is found on your PATH.",
+            kind
+        ),
+    ].join(sep);
+}

--- a/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/uvInstall.ts
@@ -106,7 +106,9 @@ export const UV_INSTALL_CONFIRM_MESSAGE =
  * default profile: a WSL / Git Bash default can have Windows interop disabled,
  * which would strand the Windows uv the extension host needs. A throwaway
  * install terminal needs no profile args, so pinning is safe here. On
- * macOS/Linux the default profile is used (always POSIX syntax).
+ * macOS/Linux the default profile is used, and its actual dialect drives the
+ * command syntax — `kind` is `powershell` when the user runs `pwsh`, not just
+ * `posix` — so the command parses in whatever shell that profile launches.
  */
 export interface UvInstallTerminalSpec {
     name: string;
@@ -115,7 +117,8 @@ export interface UvInstallTerminalSpec {
 }
 
 export function uvInstallTerminalSpec(
-    platform: NodeJS.Platform = process.platform
+    platform: NodeJS.Platform = process.platform,
+    kind: ShellKind = currentShellKind()
 ): UvInstallTerminalSpec {
     if (platform === "win32") {
         return {
@@ -126,6 +129,6 @@ export function uvInstallTerminalSpec(
     }
     return {
         name: "Install uv",
-        command: uvInstallTerminalCommand("posix", platform),
+        command: uvInstallTerminalCommand(kind, platform),
     };
 }


### PR DESCRIPTION
## Why

When `environments setup-local` fails with `E_UV_MISSING`, the failure popup offered a single **Install uv** button that only opened uv's docs page — the label promised an install but delivered documentation. Users had to leave the editor, read the guide, pick the right installer for their OS, and run it by hand.

## What

The `E_UV_MISSING` popup now shows two remediation buttons:

- **Install uv** — runs uv's official installer in a VS Code terminal for the current platform:
  - macOS/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
  - Windows: `irm https://astral.sh/uv/install.ps1 | iex` (via PowerShell; cmd shells out to it)
  
  A short banner explains the step and points the user back at *Set up Python environment*; the terminal stays open so the installer's own step-by-step output remains readable.
- **Installation guide** — opens the docs page (the previous behavior), for users who prefer to install uv themselves.

### Implementation

- New pure `uvInstall.ts` builds the per-shell command line from the shared `shellUtils` helpers, so the `curl`/`irm` split and the `;`/`&` separator are correct across macOS, Linux and Windows.
- New `databricks.environment.installUv` command runs it in a terminal, mirroring the existing `az login` terminal pattern (`AzureCliCheck`).
- `showError` now takes an ordered list of remediation actions instead of one; `getPythonSetupErrorActions` returns two for `E_UV_MISSING` and one (or none) for every other code. The docs link is single-sourced from the existing per-code action.

## Verification

- New unit tests: `uvInstall` command per shell dialect; `getPythonSetupErrorActions` two-button / one-button / empty cases; wiring renders both buttons in order and dispatches the command-action.
- `yarn build` (typecheck) clean; full unit suite **1029 passing**; `test:lint` clean.

This pull request and its description were written by Isaac.