### PR TITLE
fix(python-setup): fix red main — align two lagging tests with the array showError signature

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -576,7 +576,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     it("prompts re-login (no report) when the CLI aborts telling the user to re-authenticate", async () => {
         const shownErrors: {
             message: string;
-            action?: PythonSetupErrorAction;
+            actions?: PythonSetupErrorAction[];
         }[] = [];
         let reauthPrompts = 0;
         const telemetry = makeTelemetryRecorder();
@@ -594,8 +594,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
                 showReauthPrompt: async () => {
                     reauthPrompts++;
                 },
-                showError: async (message, _detail, action) => {
-                    shownErrors.push({message, action});
+                showError: async (message, _detail, actions) => {
+                    shownErrors.push({message, actions});
                 },
             })
         );
@@ -613,7 +613,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
     });
 
     it("reports a spawn/parse defect (not re-login) when the abort has no reauth signal", async () => {
-        const shown: {action?: PythonSetupErrorAction}[] = [];
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
         let reauthPrompts = 0;
         const telemetry = makeTelemetryRecorder();
         const setup = new PythonSetupEnvironmentSetup(
@@ -625,8 +625,8 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
                 showReauthPrompt: async () => {
                     reauthPrompts++;
                 },
-                showError: async (_m, _detail, action) => {
-                    shown.push({action});
+                showError: async (_m, _detail, actions) => {
+                    shown.push({actions});
                 },
             })
         );
@@ -634,7 +634,7 @@ describe("PythonSetupEnvironmentSetup.setup", () => {
         await setup.setup();
 
         expect(reauthPrompts).to.equal(0);
-        expect(shown[0].action?.label).to.equal("Report this problem");
+        expect(shown[0].actions?.[0].label).to.equal("Report this problem");
         expect(telemetry.results[0]).to.include({
             outcome: "not_started",
             reportOffered: true,


### PR DESCRIPTION
## Why

`main` is red. Both **VSCode Extensions CI** and **Publish nightly release** fail at the packaging typecheck (`tsc --build --force`) at tip commit 3ebc920a (#2163) with:

```
PythonSetupEnvironmentSetup.test.ts(598,48): error TS2322:
  Type 'PythonSetupErrorAction[] | undefined' is not assignable to type 'PythonSetupErrorAction | undefined'.
PythonSetupEnvironmentSetup.test.ts(629,33): error TS2322: (same)
```

#2163 changed `showError`'s third parameter from a single `PythonSetupErrorAction` to `PythonSetupErrorAction[]`. Every sibling test in the file was migrated to the plural `actions` / `actions?.[0]` form, but two tests were missed and still typed the parameter as a single `PythonSetupErrorAction`. It's a test-only, compile-time type mismatch — no product code is involved.

## What

In the two lagging tests, adopt the exact array shape the rest of the file already uses:

- *"prompts re-login (no report)…"* — `shownErrors` field `action?: PythonSetupErrorAction` → `actions?: PythonSetupErrorAction[]`; callback param `action` → `actions`.
- *"reports a spawn/parse defect…"* — `shown` field likewise; callback param `action` → `actions`; assertion `shown[0].action?.label` → `shown[0].actions?.[0].label`.

No product behaviour changes.

## Verification

- `yarn build` (`tsc --build --force`) compiles clean — exit 0, no TS errors.
- All 53 `PythonSetupEnvironmentSetup` unit tests pass in the VS Code test host, including both previously-failing tests.

This pull request and its description were written by Isaac.