### PR TITLE
fix(run): preserve script stdout when an Upload-and-Run file fails

### DIFF
--- a/packages/databricks-vscode/resources/python/bootstrap.py
+++ b/packages/databricks-vscode/resources/python/bootstrap.py
@@ -1,12 +1,16 @@
 import runpy
 import sys
 import os
+import io
+import json
+import traceback
 
 # values will be injected by the runner
 python_file = "PYTHON_FILE"
 repo_path = "REPO_PATH"
 args = []
 env = {}
+stdout_error_boundary = "STDOUT_ERROR_BOUNDARY"
 
 # change working directory
 os.chdir(os.path.dirname(python_file))
@@ -44,5 +48,53 @@ except Exception as e:
     logging.debug("Failed to set py4j.java_gateway log level to ERROR", exc_info=True)
     pass
 
-runpy.run_path(python_file, run_name="__main__", init_globals=user_ns)
+# Capture the script's stdout while it runs. The 1.2 commands API returns only
+# the traceback (and drops stdout) when a command ends in error, so to still
+# surface output printed *before* a failure we buffer stdout and, on error,
+# emit it followed by a structured traceback that the extension renders and
+# remaps to local files. See DatabricksRuntime.ts / ErrorParser.ts.
+_real_stdout = sys.stdout
+_stdout_buffer = io.StringIO()
+sys.stdout = _stdout_buffer
+_handled = False
+try:
+    runpy.run_path(python_file, run_name="__main__", init_globals=user_ns)
+except Exception:
+    sys.stdout = _real_stdout
+    _captured = _stdout_buffer.getvalue()
+    if not _captured:
+        # Nothing was printed before the failure: let the platform produce its
+        # native (clickable) traceback exactly as before.
+        raise
+    _handled = True
+    _exc_type, _exc_value, _exc_tb = sys.exc_info()
+    _tb_frames = traceback.extract_tb(_exc_tb)
+    # Drop bootstrap's own frames: keep the stack from the user's script onward.
+    _start = 0
+    for _i, _frame in enumerate(_tb_frames):
+        if _frame.filename == python_file:
+            _start = _i
+            break
+    _payload = {
+        "type": _exc_type.__name__,
+        "message": str(_exc_value),
+        "frames": [
+            {
+                "file": _frame.filename,
+                "line": _frame.lineno,
+                "name": _frame.name,
+                "text": _frame.line or "",
+            }
+            for _frame in _tb_frames[_start:]
+        ],
+    }
+    sys.stdout.write(_captured)
+    sys.stdout.write("\n" + stdout_error_boundary + "\n")
+    sys.stdout.write(json.dumps(_payload))
+finally:
+    # Always restore stdout and replay the buffer unless we already emitted it
+    # (e.g. on success, or when a BaseException such as SystemExit propagates).
+    sys.stdout = _real_stdout
+    if not _handled:
+        sys.stdout.write(_stdout_buffer.getvalue())
 None

--- a/packages/databricks-vscode/src/run/DatabricksRuntime.ts
+++ b/packages/databricks-vscode/src/run/DatabricksRuntime.ts
@@ -26,7 +26,12 @@ import {
     promptForClusterStart,
 } from "./prompts";
 import * as fs from "node:fs/promises";
-import {parseErrorResult} from "./ErrorParser";
+import {
+    Frame,
+    parseErrorResult,
+    renderErrorEnvelope,
+    STDOUT_ERROR_BOUNDARY,
+} from "./ErrorParser";
 import path from "node:path";
 import {Time, TimeUnits} from "@databricks/sdk-experimental";
 import {BundleCommands} from "../ui/bundle-resource-explorer/BundleCommands";
@@ -195,37 +200,41 @@ export class DatabricksRuntime implements Disposable {
             const result = response.result;
 
             if (result.results!.resultType === "text") {
-                this._onDidSendOutputEmitter.fire({
-                    type: "out",
-                    text: (result.results as any).data,
-                    filePath: program,
-                    line: 0,
-                    column: 0,
-                });
-            } else if (result.results!.resultType === "error") {
-                const frames = parseErrorResult(result.results!);
-                for (const frame of frames) {
-                    let localFile = "";
-                    try {
-                        if (frame.file) {
-                            localFile = syncDestinationMapper.remoteToLocal(
-                                new RemoteUri(path.posix.normalize(frame.file))
-                            ).path;
-
-                            frame.text = frame.text.replace(
-                                frame.file,
-                                localFile
-                            );
-                        }
-                    } catch {}
-
+                const data: string = (result.results as any).data ?? "";
+                const boundary = data.indexOf(STDOUT_ERROR_BOUNDARY);
+                if (boundary === -1) {
+                    // Plain successful output.
                     this._onDidSendOutputEmitter.fire({
                         type: "out",
-                        text: frame.text,
-                        filePath: localFile,
-                        line: frame.line || 0,
+                        text: data,
+                        filePath: program,
+                        line: 0,
                         column: 0,
                     });
+                } else {
+                    // The script printed and then failed: bootstrap.py sends the
+                    // captured stdout, the boundary, then a structured traceback
+                    // (the 1.2 API drops stdout on native error results).
+                    const stdout = data.slice(0, boundary);
+                    const payload = data.slice(
+                        boundary + STDOUT_ERROR_BOUNDARY.length
+                    );
+                    if (stdout.length > 0) {
+                        this._onDidSendOutputEmitter.fire({
+                            type: "out",
+                            text: stdout,
+                            filePath: program,
+                            line: 0,
+                            column: 0,
+                        });
+                    }
+                    for (const frame of renderErrorEnvelope(payload)) {
+                        this.emitTracebackFrame(frame, syncDestinationMapper);
+                    }
+                }
+            } else if (result.results!.resultType === "error") {
+                for (const frame of parseErrorResult(result.results!)) {
+                    this.emitTracebackFrame(frame, syncDestinationMapper);
                 }
             } else {
                 this._onDidSendOutputEmitter.fire({
@@ -254,6 +263,34 @@ export class DatabricksRuntime implements Disposable {
         } finally {
             this._onDidEndEmitter.fire();
         }
+    }
+
+    /**
+     * Remap a traceback frame's remote file to its local path (so the emitted
+     * output links to the user's file) and send it to the output channel.
+     */
+    private emitTracebackFrame(
+        frame: Frame,
+        syncDestinationMapper: SyncDestinationMapper
+    ) {
+        let localFile = "";
+        try {
+            if (frame.file) {
+                localFile = syncDestinationMapper.remoteToLocal(
+                    new RemoteUri(path.posix.normalize(frame.file))
+                ).path;
+
+                frame.text = frame.text.replace(frame.file, localFile);
+            }
+        } catch {}
+
+        this._onDidSendOutputEmitter.fire({
+            type: "out",
+            text: frame.text,
+            filePath: localFile,
+            line: frame.line || 0,
+            column: 0,
+        });
     }
 
     private async compileCommandString(
@@ -306,6 +343,10 @@ export class DatabricksRuntime implements Disposable {
         bootstrap = bootstrap.replace(
             "env = {}",
             `env = ${JSON.stringify(envVars)}`
+        );
+        bootstrap = bootstrap.replace(
+            '"STDOUT_ERROR_BOUNDARY"',
+            `"${STDOUT_ERROR_BOUNDARY}"`
         );
 
         return bootstrap;

--- a/packages/databricks-vscode/src/run/ErrorParser.test.ts
+++ b/packages/databricks-vscode/src/run/ErrorParser.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {parseErrorResult} from "./ErrorParser";
+import {parseErrorResult, renderErrorEnvelope} from "./ErrorParser";
 
 describe(__filename, () => {
     it("should parse error from SyntaxError", () => {
@@ -86,5 +86,37 @@ describe(__filename, () => {
         ];
 
         assert.deepStrictEqual(result, expected);
+    });
+
+    it("should render a structured error envelope into frames", () => {
+        const payload = JSON.stringify({
+            type: "ValueError",
+            message: "boom",
+            frames: [
+                {
+                    file: "/Workspace/Users/me/hello.py",
+                    line: 4,
+                    name: "<module>",
+                    text: 'raise ValueError("boom")',
+                },
+            ],
+        });
+
+        const result = renderErrorEnvelope(payload);
+
+        assert.deepStrictEqual(result, [
+            {text: "Traceback (most recent call last):"},
+            {
+                file: "/Workspace/Users/me/hello.py",
+                line: 4,
+                text: '  File "/Workspace/Users/me/hello.py", line 4, in <module>\n    raise ValueError("boom")',
+            },
+            {text: "\u001b[0;31mValueError: boom\u001b[0m"},
+        ]);
+    });
+
+    it("should surface a malformed envelope payload verbatim", () => {
+        const result = renderErrorEnvelope("  not json  ");
+        assert.deepStrictEqual(result, [{text: "not json"}]);
     });
 });

--- a/packages/databricks-vscode/src/run/ErrorParser.ts
+++ b/packages/databricks-vscode/src/run/ErrorParser.ts
@@ -2,10 +2,65 @@
 import {compute} from "@databricks/sdk-experimental";
 import * as assert from "node:assert";
 
-interface Frame {
+export interface Frame {
     file?: string;
     line?: number;
     text: string;
+}
+
+/**
+ * Boundary token separating the script's captured stdout from the structured
+ * error payload that `bootstrap.py` emits when a script fails after printing.
+ * The same literal is injected into `bootstrap.py` at command-assembly time.
+ */
+export const STDOUT_ERROR_BOUNDARY =
+    "__DATABRICKS_VSCODE_STDOUT_ERROR_BOUNDARY__";
+
+interface TracebackFrame {
+    file?: string;
+    line?: number;
+    name?: string;
+    text?: string;
+}
+
+interface ErrorEnvelope {
+    type: string;
+    message: string;
+    frames: Array<TracebackFrame>;
+}
+
+/**
+ * Render the structured error payload emitted by `bootstrap.py` (see
+ * {@link STDOUT_ERROR_BOUNDARY}) into frames shaped like {@link parseErrorResult}'s
+ * output, so the caller can remap each frame's `file` to a local path and emit
+ * it. Unlike `parseErrorResult`, this does not depend on the platform's IPython
+ * traceback formatting, which varies with runtime and source availability.
+ */
+export function renderErrorEnvelope(payload: string): Array<Frame> {
+    let envelope: ErrorEnvelope;
+    try {
+        envelope = JSON.parse(payload);
+    } catch {
+        // Malformed payload: surface it verbatim rather than dropping output.
+        return [{text: payload.trim()}];
+    }
+
+    const frames: Array<Frame> = [{text: "Traceback (most recent call last):"}];
+    for (const frame of envelope.frames ?? []) {
+        const where = frame.name ? `, in ${frame.name}` : "";
+        const location = `  File "${frame.file}", line ${frame.line}${where}`;
+        const source = frame.text ? `\n    ${frame.text}` : "";
+        frames.push({
+            file: frame.file,
+            line: frame.line,
+            text: location + source,
+        });
+    }
+    // Colour the final summary line red to match the platform's error styling.
+    frames.push({
+        text: `\u001b[0;31m${envelope.type}: ${envelope.message}\u001b[0m`,
+    });
+    return frames;
 }
 
 export function parseErrorResult(result: compute.Results): Array<Frame> {


### PR DESCRIPTION
## Problem

When running a Python file on a cluster ("Upload and Run File"), if the script raises an exception, any output it printed **before** failing is lost. The `1.2/commands` execution API returns only the traceback on an error result and drops the accumulated stdout, so the output panel shows the traceback with none of the preceding `print` output — making failures hard to debug.

## Fix

Because a single command yields a single result whose error variant has no stdout field, the captured output has to be preserved where it still exists — in the bootstrap that runs the file.

- **`resources/python/bootstrap.py`** buffers the script's stdout while it runs. On an exception that follows printed output, it emits the captured stdout, a boundary marker, then a structured JSON traceback containing only the user's frames. Errors with no prior output re-raise unchanged; successful runs and `SystemExit`/`KeyboardInterrupt` replay the buffer, so no output is lost.
- **`src/run/ErrorParser.ts`** adds `renderErrorEnvelope()` to turn that JSON payload into renderable frames (red-highlighted summary line), plus a shared boundary constant.
- **`src/run/DatabricksRuntime.ts`** splits the text result on the boundary — emitting the stdout first, then the traceback remapped to local files (so frames stay clickable) — and shares the frame-emit logic between the new path and the existing error path.

The new behaviour triggers **only** on print-then-crash. Successful runs and errors with no prior output render exactly as before.

## Verification

- `yarn build` (full `tsc`) clean; `eslint` and `prettier` clean; `bootstrap.py` compiles.
- Unit tests 4/4 pass (2 new for `renderErrorEnvelope`).
- End-to-end against a live cluster running the real `bootstrap.py`:
  - **print-then-crash** → stdout preserved, followed by a clickable traceback with only the user frame;
  - **success + output** → plain text output, unchanged;
  - **error with no prior output** → native error result, unchanged.

This pull request and its description were written by Isaac.