### PR TITLE
Migrate setup-local invocation to orthogonal --no-constraints/--no-dbconnect flags

### DIFF
--- a/packages/databricks-vscode/src/extension.ts
+++ b/packages/databricks-vscode/src/extension.ts
@@ -1170,7 +1170,6 @@ export async function activate(
             try {
                 const result = await pythonSetupClient.run(
                     {
-                        mode: "default",
                         dryRun: true,
                         compute: resolution.compute,
                     },

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -634,10 +634,8 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 targetType: compute.kind,
                 serverlessVersion:
                     compute.kind === "serverless" ? compute.version : undefined,
-                // The attempt event keeps its default/constraints-only mode
-                // dimension; derive it from the orthogonal flag that drops
-                // databricks-connect (the CLI treats --no-dbconnect and the old
-                // --constraints-only as the same mode).
+                // --no-dbconnect is the orthogonal spelling of the legacy
+                // --constraints-only, so it maps to that telemetry mode.
                 mode: invocation.skipDbconnect ? "constraints-only" : "default",
                 isGreenfield,
                 // A run against a project already marked ready this session is a

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -369,7 +369,6 @@ export class PythonSetupEnvironmentSetup implements Disposable {
         const compute = resolved.compute;
 
         const invocation: SetupLocalInvocation = {
-            mode: "default",
             compute,
         };
 
@@ -635,7 +634,11 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 targetType: compute.kind,
                 serverlessVersion:
                     compute.kind === "serverless" ? compute.version : undefined,
-                mode: invocation.mode,
+                // The attempt event keeps its default/constraints-only mode
+                // dimension; derive it from the orthogonal flag that drops
+                // databricks-connect (the CLI treats --no-dbconnect and the old
+                // --constraints-only as the same mode).
+                mode: invocation.skipDbconnect ? "constraints-only" : "default",
                 isGreenfield,
                 // A run against a project already marked ready this session is a
                 // re-run (the ready row's Re-run button / row click); anything

--- a/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
+++ b/packages/databricks-vscode/src/python-setup/gateways/PythonSetupCliClient.test.ts
@@ -63,7 +63,6 @@ function fakeSpawn(script: {
 }
 
 const inv = {
-    mode: "default" as const,
     compute: {kind: "serverless" as const, version: "5"},
 };
 

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.test.ts
@@ -4,7 +4,6 @@ import {buildSetupLocalArgs, SetupLocalInvocation} from "./setupLocalArgs";
 describe("buildSetupLocalArgs", () => {
     it("builds a default serverless invocation with JSON output", () => {
         const inv: SetupLocalInvocation = {
-            mode: "default",
             compute: {kind: "serverless", version: "5"},
         };
         expect(buildSetupLocalArgs(inv)).to.deep.equal([
@@ -19,7 +18,6 @@ describe("buildSetupLocalArgs", () => {
 
     it("uses --cluster-id for a cluster target", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
             compute: {kind: "cluster", clusterId: "0710-abc"},
         });
         const i = args.indexOf("--cluster-id");
@@ -28,25 +26,56 @@ describe("buildSetupLocalArgs", () => {
         expect(args).to.not.include("--serverless-version");
     });
 
-    it("adds --constraints-only in constraints-only mode", () => {
+    it("adds --no-constraints when constraints are skipped", () => {
         const args = buildSetupLocalArgs({
-            mode: "constraints-only",
+            skipConstraints: true,
             compute: {kind: "serverless", version: "5"},
         });
-        expect(args).to.include("--constraints-only");
+        expect(args).to.include("--no-constraints");
+        expect(args).to.not.include("--no-dbconnect");
     });
 
-    it("omits --constraints-only in default mode", () => {
+    it("adds --no-dbconnect when databricks-connect is skipped", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
+            skipDbconnect: true,
             compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.include("--no-dbconnect");
+        expect(args).to.not.include("--no-constraints");
+    });
+
+    it("adds both negative flags when both are skipped, --no-constraints first", () => {
+        const args = buildSetupLocalArgs({
+            skipConstraints: true,
+            skipDbconnect: true,
+            compute: {kind: "serverless", version: "5"},
+        });
+        const c = args.indexOf("--no-constraints");
+        const d = args.indexOf("--no-dbconnect");
+        expect(c).to.be.greaterThan(-1);
+        expect(d).to.be.greaterThan(-1);
+        expect(c).to.be.lessThan(d);
+    });
+
+    it("emits no behavioral flags for the default (full) invocation", () => {
+        const args = buildSetupLocalArgs({
+            compute: {kind: "serverless", version: "5"},
+        });
+        expect(args).to.not.include("--no-constraints");
+        expect(args).to.not.include("--no-dbconnect");
+    });
+
+    it("never emits the deprecated --constraints-only flag", () => {
+        const args = buildSetupLocalArgs({
+            skipConstraints: true,
+            skipDbconnect: true,
+            compute: {kind: "cluster", clusterId: "c"},
         });
         expect(args).to.not.include("--constraints-only");
     });
 
     it("never passes --profile (auth is forwarded via the environment)", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
             compute: {kind: "serverless", version: "5"},
         });
         expect(args).to.not.include("--profile");
@@ -54,7 +83,6 @@ describe("buildSetupLocalArgs", () => {
 
     it("passes the hidden --constraint-source-url when provided", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
             compute: {kind: "serverless", version: "5"},
             constraintSourceUrl: "http://localhost:8077",
         });
@@ -65,7 +93,8 @@ describe("buildSetupLocalArgs", () => {
 
     it("always ends with --output json", () => {
         const args = buildSetupLocalArgs({
-            mode: "constraints-only",
+            skipConstraints: true,
+            skipDbconnect: true,
             compute: {kind: "cluster", clusterId: "c"},
             constraintSourceUrl: "u",
         });
@@ -74,7 +103,6 @@ describe("buildSetupLocalArgs", () => {
 
     it("adds --dry-run when the invocation is a dry run", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
             compute: {kind: "serverless", version: "5"},
             dryRun: true,
         });
@@ -85,7 +113,6 @@ describe("buildSetupLocalArgs", () => {
 
     it("omits --dry-run by default", () => {
         const args = buildSetupLocalArgs({
-            mode: "default",
             compute: {kind: "serverless", version: "5"},
         });
         expect(args).to.not.include("--dry-run");

--- a/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupLocalArgs.ts
@@ -1,10 +1,8 @@
-import {PythonSetupMode} from "../models/PythonSetupResult";
-
 /**
- * A resolved `environments setup-local` invocation: the mode, the compute
- * target (cluster or serverless), and an optional dev-only constraint-source
- * override. This is the pure input to {@link buildSetupLocalArgs}; the gateway
- * turns the argv into a spawned process.
+ * A resolved `environments setup-local` invocation: the compute target (cluster
+ * or serverless), which of the two behavioral steps to skip, and an optional
+ * dev-only constraint-source override. This is the pure input to
+ * {@link buildSetupLocalArgs}; the gateway turns the argv into a spawned process.
  *
  * There is deliberately no profile here: authentication reaches the CLI through
  * the spawned process's environment (see `CliWrapper.getSetupLocalEnvVars`),
@@ -12,7 +10,6 @@ import {PythonSetupMode} from "../models/PythonSetupResult";
  * flag would be a redundant second source of truth.
  */
 export interface SetupLocalInvocation {
-    mode: PythonSetupMode;
     /**
      * When true, pass `--dry-run`: the CLI resolves compute and reports the
      * environment key without provisioning or writing to disk. Used by drift
@@ -24,6 +21,17 @@ export interface SetupLocalInvocation {
         | {kind: "cluster"; clusterId: string}
         | {kind: "serverless"; version: string};
     /**
+     * When true, pass `--no-constraints`: don't write the remote Python-version
+     * and dependency pins. Orthogonal to {@link skipDbconnect}.
+     */
+    skipConstraints?: boolean;
+    /**
+     * When true, pass `--no-dbconnect`: don't add the databricks-connect
+     * dependency. The orthogonal replacement for the deprecated
+     * `--constraints-only`. Orthogonal to {@link skipConstraints}.
+     */
+    skipDbconnect?: boolean;
+    /**
      * Hidden `--constraint-source-url` override (dev/testing only). The
      * serverless version is passed verbatim as a bare number, e.g. "5" — the
      * CLI normalizes it to `vN` in its output.
@@ -34,7 +42,8 @@ export interface SetupLocalInvocation {
 /**
  * Build the argv for `databricks environments setup-local --output json`.
  * Deterministic and side-effect-free so it is trivially unit-testable; the
- * order is fixed (compute → mode → source → output) for stable tests.
+ * order is fixed (compute → skip flags → dry-run → source → output) for stable
+ * tests.
  */
 export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
     const args = ["environments", "setup-local"];
@@ -45,8 +54,11 @@ export function buildSetupLocalArgs(inv: SetupLocalInvocation): string[] {
         args.push("--serverless-version", inv.compute.version);
     }
 
-    if (inv.mode === "constraints-only") {
-        args.push("--constraints-only");
+    if (inv.skipConstraints) {
+        args.push("--no-constraints");
+    }
+    if (inv.skipDbconnect) {
+        args.push("--no-dbconnect");
     }
     if (inv.dryRun) {
         args.push("--dry-run");


### PR DESCRIPTION
## Summary

`databricks environments setup-local` has replaced the single behavioral flag
`--constraints-only` with two **orthogonal** negative flags:

| Flag | Effect |
|---|---|
| `--no-constraints` | Skip writing the remote Python-version / dependency pins. |
| `--no-dbconnect` | Skip adding the `databricks-connect` dependency. |

The extension still modeled the old single `mode` enum and only emitted
`--constraints-only`. This migrates the invocation to the new flags so the
setup-options picker (a follow-up) can map its tiers straight onto composable
capabilities.

## Changes

- Replace `SetupLocalInvocation.mode` with two orthogonal optional booleans —
  `skipConstraints` → `--no-constraints`, `skipDbconnect` → `--no-dbconnect`.
  `buildSetupLocalArgs` stays pure and deterministic (fixed flag order); the
  `--constraints-only` emission is dropped.
- Update the two call sites (the real setup run and the drift dry-run) to the
  flag-free default, and derive the attempt telemetry's `mode` dimension from
  `skipDbconnect` so that event is unchanged.
- Rework the arg unit tests around the new mapping (each flag alone, both
  together, default emits neither, and never `--constraints-only`).

## No behavior change

Both callers run the default (Full) setup, which emits **no** behavioral flags —
exactly as before. `--constraints-only` was only ever emitted in a mode no caller
used, so nothing changes in the argv sent to the CLI today; the new flags become
reachable only when the picker is introduced.

## Draft / follow-up

Kept as a **draft** pending the bundled-CLI dependency: the `cli.version` bump +
re-fetch will land here once a CLI **release** carrying the new flags is
available (they are merged to CLI `main` but not yet in a tagged release). The
change is safe to run against the currently bundled CLI in the meantime because
it emits no new flags.

## Testing

- `tsc --noEmit`: clean.
- Unit suite: `buildSetupLocalArgs`, `PythonSetupCliClient`, and
  `PythonSetupEnvironmentSetup` (setup + telemetry) all green.
- eslint + prettier: clean on all changed files.

This pull request and its description were written by Isaac.