### PR TITLE
feat(aitools): record install error categories from CLI JSON output

### DIFF
--- a/packages/databricks-vscode/src/aitools/AiToolsManager.test.ts
+++ b/packages/databricks-vscode/src/aitools/AiToolsManager.test.ts
@@ -6,6 +6,7 @@ import {commands, Uri} from "vscode";
 import path from "path";
 import {
     AiToolsAgent,
+    AiToolsInstallOutput,
     AiToolsListResult,
     CliWrapper,
     ProcessError,
@@ -66,6 +67,17 @@ function listResult(
         agents,
     };
 }
+
+const installSuccessOutput: AiToolsInstallOutput = {
+    scope: "global",
+    agents: [
+        {
+            name: "claude-code",
+            delivery: "plugin",
+            status: "installed",
+        },
+    ],
+};
 
 // The project root the WorkspaceFolderManager mock reports; the global root is
 // the real home dir (the manager derives it from getHomedir()). The injected
@@ -421,6 +433,7 @@ describe(__filename, () => {
             mockCli.aitoolsInstall("global", anything(), anything(), anything())
         ).thenCall(async () => {
             loaders.global = loadSuccess;
+            return {output: installSuccessOutput, error: undefined};
         });
         when(mockCli.aitoolsList(anything())).thenResolve(
             listResult([
@@ -437,6 +450,223 @@ describe(__filename, () => {
         verify(
             mockCli.aitoolsInstall("global", anything(), anything(), anything())
         ).once();
+        assert.strictEqual(manager.model.state.installLocation, "global");
+        assert.strictEqual(manager.model.state.updateStatus, "upToDate");
+    });
+
+    it("records a clean success from the CLI's JSON result", async () => {
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli, stubTelemetry} = setup(loaders);
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenCall(async () => {
+            loaders.global = loadSuccess;
+            return {output: installSuccessOutput, error: undefined};
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(listResult([]));
+
+        await manager.install("global", "sidePane", ["claude-code"]);
+
+        const [installEvent] = stubTelemetry.eventsOfType(
+            Events.AITOOLS_INSTALL
+        );
+        assert.strictEqual(installEvent.props.result, "success");
+        // No error fields on a clean install.
+        assert.strictEqual(installEvent.props.globalErrorCategory, undefined);
+        assert.strictEqual(installEvent.props.agentErrors, undefined);
+    });
+
+    it("records per-agent error categories and surfaces a JSON-reported failure", async () => {
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli, stubTelemetry} = setup(loaders);
+        // The CLI exits non-zero on failure but still prints the structured
+        // result, so aitoolsInstall resolves with it rather than throwing.
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenResolve({
+            output: {
+                scope: "global",
+                agents: [
+                    {
+                        name: "claude-code",
+                        delivery: "plugin",
+                        status: "installed",
+                    },
+                    {
+                        name: "copilot",
+                        delivery: "plugin",
+                        status: "failed",
+                        error_category: "PLUGIN_INSTALL_FAILED",
+                        message: "gh CLI is not on PATH",
+                    },
+                ],
+            },
+            error: new Error("Command failed"),
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(listResult([]));
+
+        // A reported failure is surfaced to the command layer as a ProcessError
+        // whose (local-only) message folds in the failing agent's CLI message, so
+        // "Show Logs" has real detail even though --output json leaves stderr empty.
+        await assert.rejects(
+            () =>
+                manager.install("global", "sidePane", [
+                    "claude-code",
+                    "copilot",
+                ]),
+            (e: unknown) =>
+                e instanceof ProcessError &&
+                e.message.includes("copilot: gh CLI is not on PATH")
+        );
+
+        const [installEvent] = stubTelemetry.eventsOfType(
+            Events.AITOOLS_INSTALL
+        );
+        assert.strictEqual(installEvent.props.result, "error");
+        // Only the failing agent's category is recorded, keyed by agent id, with
+        // no free-form message.
+        assert.deepStrictEqual(installEvent.props.agentErrors, {
+            copilot: "PLUGIN_INSTALL_FAILED",
+        });
+        assert.strictEqual(installEvent.props.globalErrorCategory, undefined);
+    });
+
+    it("records a top-level error category from the CLI's JSON result", async () => {
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli, stubTelemetry} = setup(loaders);
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenResolve({
+            output: {
+                scope: "global",
+                agents: [],
+                error: 'skill "__nope__" not found',
+                error_category: "SKILL_NOT_FOUND",
+            },
+            error: new Error("Command failed"),
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(listResult([]));
+
+        await assert.rejects(
+            () => manager.install("global", "sidePane", ["claude-code"]),
+            (e: unknown) =>
+                e instanceof ProcessError &&
+                e.message.includes('skill "__nope__" not found')
+        );
+
+        const [installEvent] = stubTelemetry.eventsOfType(
+            Events.AITOOLS_INSTALL
+        );
+        assert.strictEqual(installEvent.props.result, "error");
+        assert.strictEqual(
+            installEvent.props.globalErrorCategory,
+            "SKILL_NOT_FOUND"
+        );
+        assert.strictEqual(installEvent.props.agentErrors, undefined);
+    });
+
+    it("handles unparseable JSON output (success)", async () => {
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli, stubTelemetry} = setup(loaders);
+        // An older CLI ignores --output json and prints text; aitoolsInstall
+        // resolves with undefined on its success exit.
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenCall(async () => {
+            loaders.global = loadSuccess;
+            return {output: undefined, error: undefined};
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(listResult([]));
+
+        await manager.install("global", "sidePane", ["claude-code"]);
+
+        const [installEvent] = stubTelemetry.eventsOfType(
+            Events.AITOOLS_INSTALL
+        );
+        assert.strictEqual(installEvent.props.result, "success");
+        assert.strictEqual(installEvent.props.agentErrors, undefined);
+    });
+
+    it("handles unparseable JSON output (failure)", async () => {
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli, stubTelemetry} = setup(loaders);
+        // An older CLI ignores --output json and prints text; aitoolsInstall
+        // resolves with undefined on its success exit.
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenCall(async () => {
+            loaders.global = loadSuccess;
+            return {output: undefined, error: new Error("Command failed")};
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(listResult([]));
+
+        await assert.rejects(
+            () => manager.install("global", "sidePane", ["claude-code"]),
+            (e: unknown) =>
+                e instanceof Error && e.message.includes("Command failed")
+        );
+
+        const [installEvent] = stubTelemetry.eventsOfType(
+            Events.AITOOLS_INSTALL
+        );
+        assert.strictEqual(installEvent.props.result, "error");
+        assert.strictEqual(installEvent.props.agentErrors, undefined);
+    });
+
+    it("reconciles per-agent state after a JSON-reported partial failure", async () => {
+        // A partial failure still lands some tools, so the panel must be
+        // reconciled afterwards. `loaders.global` resolving means the install
+        // wrote its state file (some agent succeeded); the manager's `finally`
+        // should then run detect + resolve and pick up the CLI's real state.
+        const loaders: ScopeLoaders = {};
+        const {manager, mockCli} = setup(loaders);
+        when(
+            mockCli.aitoolsInstall("global", anything(), anything(), anything())
+        ).thenCall(async () => {
+            loaders.global = loadSuccess;
+            return {
+                output: {
+                    scope: "global",
+                    agents: [
+                        {
+                            name: "claude-code",
+                            delivery: "plugin",
+                            status: "installed",
+                        },
+                        {
+                            name: "copilot",
+                            delivery: "plugin",
+                            status: "failed",
+                            error_category: "PLUGIN_INSTALL_FAILED",
+                        },
+                    ],
+                },
+                error: new Error("Command failed"),
+            };
+        });
+        when(mockCli.aitoolsList(anything())).thenResolve(
+            listResult([
+                {
+                    name: "databricks-core",
+                    latest_version: "0.1.0",
+                    installed: {global: "0.1.0"},
+                },
+            ])
+        );
+
+        await assert.rejects(
+            () =>
+                manager.install("global", "sidePane", [
+                    "claude-code",
+                    "copilot",
+                ]),
+            ProcessError
+        );
+
+        // The reconcile ran despite the throw: `aitoolsList` was consumed and the
+        // model reflects the CLI's real post-install state rather than staying
+        // stale.
+        verify(mockCli.aitoolsList(anything())).atLeast(1);
         assert.strictEqual(manager.model.state.installLocation, "global");
         assert.strictEqual(manager.model.state.updateStatus, "upToDate");
     });
@@ -478,7 +708,7 @@ describe(__filename, () => {
                     anything(),
                     anything()
                 )
-            ).thenResolve();
+            ).thenResolve({output: installSuccessOutput, error: undefined});
             when(mockCli.aitoolsList(anything())).thenResolve(
                 listResult([
                     {
@@ -561,7 +791,7 @@ describe(__filename, () => {
                     anything(),
                     anything()
                 )
-            ).thenResolve();
+            ).thenResolve({output: installSuccessOutput, error: undefined});
             when(mockCli.aitoolsList(anything())).thenResolve(
                 listResult([
                     {
@@ -634,7 +864,7 @@ describe(__filename, () => {
                 anything(),
                 anything()
             )
-        ).thenResolve();
+        ).thenResolve({output: installSuccessOutput, error: undefined});
         when(mockCli.aitoolsList(anything())).thenResolve(
             listResult([
                 {
@@ -691,7 +921,7 @@ describe(__filename, () => {
                 anything(),
                 anything()
             )
-        ).thenReject(new ProcessError("boom", 1));
+        ).thenResolve({output: undefined, error: new Error("boom!")});
         when(mockCli.aitoolsList(anything())).thenResolve(
             listResult([
                 {
@@ -716,9 +946,8 @@ describe(__filename, () => {
         when(
             mockCli.aitoolsInstall("global", anything(), anything(), anything())
         ).thenCall(async () => {
-            // Simulate a partial install: some tools landed before the failure.
             loaders.global = loadSuccess;
-            throw new ProcessError("boom", 1);
+            return {output: undefined, error: new Error("boom")};
         });
         when(mockCli.aitoolsList(anything())).thenResolve(
             listResult([
@@ -1008,6 +1237,7 @@ describe(__filename, () => {
                 )
             ).thenCall(async () => {
                 loaders.global = loadSuccess;
+                return {output: installSuccessOutput, error: undefined};
             });
             when(mockCli.aitoolsList(anything())).thenResolve(
                 listResult([

--- a/packages/databricks-vscode/src/aitools/AiToolsManager.ts
+++ b/packages/databricks-vscode/src/aitools/AiToolsManager.ts
@@ -6,7 +6,12 @@ import {
     AiToolsScope,
     AiToolsSkill,
     CliWrapper,
+    ProcessError,
 } from "../cli/CliWrapper";
+import {
+    describeAiToolsInstallFailure,
+    summarizeAiToolsInstallErrors,
+} from "./aiToolsInstallOutput";
 import {Mutex} from "../locking";
 import {StateStorage} from "../vscode-objs/StateStorage";
 import {WorkspaceFolderManager} from "../vscode-objs/WorkspaceFolderManager";
@@ -15,6 +20,7 @@ import {Telemetry} from "../telemetry";
 import {
     AiToolsCursorPluginSource,
     AiToolsInstallSource,
+    EventReporter,
     Events,
 } from "../telemetry/constants";
 import {Loggers} from "../logger";
@@ -469,28 +475,13 @@ export class AiToolsManager implements Disposable {
 
         const recordEvent = this.telemetry.start(Events.AITOOLS_INSTALL);
         try {
-            await this.cli.aitoolsInstall(
+            await this.runInstallCli(
                 scope,
-                this.cwdForScope(scope),
-                token,
-                agentsToInstall
+                agentsToInstall,
+                recordEvent,
+                {source, cursorPlugin},
+                token
             );
-            recordEvent({
-                result: "success",
-                scope,
-                source,
-                agents: agentsToInstall,
-                cursorPlugin,
-            });
-        } catch (e) {
-            recordEvent({
-                result: "error",
-                scope,
-                source,
-                agents: agentsToInstall,
-                cursorPlugin,
-            });
-            throw e;
         } finally {
             // Always reconcile: a failed install often still installed some
             // tools (e.g. one agent's CLI was missing), so refresh the panel to
@@ -498,6 +489,68 @@ export class AiToolsManager implements Disposable {
             // Call the `*Impl` helpers directly — we already hold the mutex.
             await this.detectInstallImpl();
             await this.resolveInstalledImpl();
+        }
+    }
+
+    /**
+     * Run `aitools install` for `agents` in `scope`, record the AITOOLS_INSTALL
+     * outcome (success/error plus any error categories), and — on a non-zero exit
+     * — throw a {@link ProcessError} so {@link AiToolsCommands} surfaces it,
+     * folding in and logging the CLI's own JSON detail when it explains the
+     * failure. `recordEvent` is the caller's already-started reporter (so
+     * `duration` covers the whole flow); `baseProps` carries the source and, for
+     * the batch install, the Cursor-plugin flag. The caller reconciles model
+     * state in its own `finally`.
+     */
+    private async runInstallCli(
+        scope: AiToolsScope,
+        agents: string[],
+        recordEvent: EventReporter<Events.AITOOLS_INSTALL>,
+        baseProps: {source: AiToolsInstallSource; cursorPlugin?: boolean},
+        token?: CancellationToken
+    ): Promise<void> {
+        const {output, error} = await this.cli.aitoolsInstall(
+            scope,
+            this.cwdForScope(scope),
+            token,
+            agents
+        );
+
+        const summarizedErrors = summarizeAiToolsInstallErrors(output);
+        recordEvent({
+            result: error !== undefined ? "error" : "success",
+            scope,
+            agents,
+            source: baseProps.source,
+            ...(baseProps.cursorPlugin !== undefined
+                ? {cursorPlugin: baseProps.cursorPlugin}
+                : {}),
+            ...(summarizedErrors.globalErrorCategory !== undefined
+                ? {globalErrorCategory: summarizedErrors.globalErrorCategory}
+                : {}),
+            ...(summarizedErrors.agentErrors !== undefined
+                ? {agentErrors: summarizedErrors.agentErrors}
+                : {}),
+        });
+
+        if (error !== undefined) {
+            const errorCode =
+                "code" in error && typeof error.code === "number"
+                    ? error.code
+                    : null;
+            const message = describeAiToolsInstallFailure(output);
+            if (message) {
+                // The CLI reported the install failed in its JSON (non-zero exit, but
+                // a parseable result). Under `--output json` the CLI's stderr is empty,
+                // so log the folded detail here, then surface it to the UI by throwing.
+                logging.NamedLogger.getOrCreate(Loggers.Extension).error(
+                    `Databricks AI tools install failed:\n${message}`
+                );
+                throw new ProcessError(message, errorCode);
+            }
+            // There was no parseable JSON output, so fallback to the pre-JSON behaviour
+            // of throwing a `ProcessError`
+            throw new ProcessError(error.message, errorCode);
         }
     }
 
@@ -519,26 +572,13 @@ export class AiToolsManager implements Disposable {
         }
         const recordEvent = this.telemetry.start(Events.AITOOLS_INSTALL);
         try {
-            await this.cli.aitoolsInstall(
+            await this.runInstallCli(
                 scope,
-                this.cwdForScope(scope),
-                token,
-                [agentId]
+                [agentId],
+                recordEvent,
+                {source: "sidePane"},
+                token
             );
-            recordEvent({
-                result: "success",
-                scope,
-                source: "sidePane",
-                agents: [agentId],
-            });
-        } catch (e) {
-            recordEvent({
-                result: "error",
-                scope,
-                source: "sidePane",
-                agents: [agentId],
-            });
-            throw e;
         } finally {
             // Reconcile the row even on failure: the install may have partially
             // succeeded. Call the `*Impl` helper directly — we already hold the

--- a/packages/databricks-vscode/src/aitools/aiToolsInstallOutput.test.ts
+++ b/packages/databricks-vscode/src/aitools/aiToolsInstallOutput.test.ts
@@ -1,0 +1,183 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import assert from "assert";
+import {AiToolsInstallOutput} from "../cli/CliWrapper";
+import {
+    describeAiToolsInstallFailure,
+    summarizeAiToolsInstallErrors,
+} from "./aiToolsInstallOutput";
+
+const success: AiToolsInstallOutput = {
+    scope: "global",
+    agents: [{name: "claude-code", delivery: "plugin", status: "installed"}],
+};
+const perAgentSkip: AiToolsInstallOutput = {
+    scope: "project",
+    agents: [
+        {
+            name: "codex",
+            delivery: "skip",
+            status: "skipped",
+            error_category: "UNSUPPORTED_SCOPE",
+            message: "Codex CLI is user-only; project scope is not supported",
+        },
+    ],
+};
+const topLevelError: AiToolsInstallOutput = {
+    scope: "global",
+    agents: [],
+    error: 'skill "__nope__" not found',
+    error_category: "SKILL_NOT_FOUND",
+};
+
+describe(__filename, () => {
+    describe("summarizeAiToolsInstallErrors", () => {
+        it("returns nothing for undefined", () => {
+            assert.deepStrictEqual(
+                summarizeAiToolsInstallErrors(undefined),
+                {}
+            );
+        });
+
+        it("returns nothing on a clean success", () => {
+            assert.deepStrictEqual(summarizeAiToolsInstallErrors(success), {});
+        });
+
+        it("maps each non-installed agent to its category, without the message", () => {
+            assert.deepStrictEqual(
+                summarizeAiToolsInstallErrors(perAgentSkip),
+                {agentErrors: {codex: "UNSUPPORTED_SCOPE"}}
+            );
+        });
+
+        it("maps several failed agents each to its own category", () => {
+            assert.deepStrictEqual(
+                summarizeAiToolsInstallErrors({
+                    scope: "global",
+                    agents: [
+                        {
+                            name: "copilot",
+                            delivery: "plugin",
+                            status: "failed",
+                            error_category: "PLUGIN_INSTALL_FAILED",
+                        },
+                        {
+                            name: "codex",
+                            delivery: "plugin",
+                            status: "failed",
+                            error_category: "PLUGIN_INSTALL_FAILED",
+                        },
+                        {
+                            name: "goose",
+                            delivery: "skip",
+                            status: "skipped",
+                            error_category: "UNSUPPORTED_SCOPE",
+                        },
+                    ],
+                }),
+                {
+                    agentErrors: {
+                        copilot: "PLUGIN_INSTALL_FAILED",
+                        codex: "PLUGIN_INSTALL_FAILED",
+                        goose: "UNSUPPORTED_SCOPE",
+                    },
+                }
+            );
+        });
+
+        it("reports a top-level category and no agent map", () => {
+            assert.deepStrictEqual(
+                summarizeAiToolsInstallErrors(topLevelError),
+                {globalErrorCategory: "SKILL_NOT_FOUND"}
+            );
+        });
+
+        it("reports both a top-level and per-agent errors together", () => {
+            assert.deepStrictEqual(
+                summarizeAiToolsInstallErrors({
+                    scope: "global",
+                    agents: [
+                        {
+                            name: "codex",
+                            delivery: "skip",
+                            status: "skipped",
+                            error_category: "UNSUPPORTED_SCOPE",
+                        },
+                    ],
+                    error: "boom",
+                    error_category: "UNCATEGORIZED",
+                }),
+                {
+                    globalErrorCategory: "UNCATEGORIZED",
+                    agentErrors: {codex: "UNSUPPORTED_SCOPE"},
+                }
+            );
+        });
+    });
+
+    describe("describeAiToolsInstallFailure", () => {
+        it("returns undefined for undefined", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure(undefined),
+                undefined
+            );
+        });
+
+        it("returns undefined when nothing actually failed", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure(success),
+                undefined
+            );
+        });
+
+        it("folds a per-agent message in", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure(perAgentSkip),
+                "codex: Codex CLI is user-only; project scope is not supported"
+            );
+        });
+
+        it("uses the top-level error", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure(topLevelError),
+                'skill "__nope__" not found'
+            );
+        });
+
+        it("uses fallback for per-agent errors when there is no message", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure({
+                    scope: "global",
+                    agents: [
+                        {
+                            name: "copilot",
+                            delivery: "plugin",
+                            status: "failed",
+                            error_category: "PLUGIN_INSTALL_FAILED",
+                        },
+                        {name: "codex", delivery: "skip", status: "skipped"},
+                    ],
+                }),
+                "copilot: failed to install\ncodex: failed to install"
+            );
+        });
+
+        it("joins the top-level error and per-agent messages", () => {
+            assert.strictEqual(
+                describeAiToolsInstallFailure({
+                    scope: "global",
+                    agents: [
+                        {
+                            name: "codex",
+                            delivery: "skip",
+                            status: "skipped",
+                            message: "user-only",
+                        },
+                    ],
+                    error: "boom",
+                }),
+                "boom\ncodex: user-only"
+            );
+        });
+    });
+});

--- a/packages/databricks-vscode/src/aitools/aiToolsInstallOutput.ts
+++ b/packages/databricks-vscode/src/aitools/aiToolsInstallOutput.ts
@@ -1,0 +1,61 @@
+import {AiToolsInstallOutput} from "../cli/CliWrapper";
+
+/**
+ * The categorical error fields recorded on the AITOOLS_INSTALL event, derived
+ * from an `aitools install --output json` result
+ */
+export interface AiToolsInstallErrorSummary {
+    globalErrorCategory?: string;
+    agentErrors?: Record<string, string>;
+}
+
+/**
+ * A local-only, human-readable description of a failed install, folding the
+ * top-level `error` and each non-installed agent's `message` into one string
+ */
+export function describeAiToolsInstallFailure(
+    output: AiToolsInstallOutput | undefined
+): string | undefined {
+    if (output === undefined) {
+        return undefined;
+    }
+    const lines: string[] = [];
+    if (output.error) {
+        lines.push(output.error);
+    }
+    for (const agent of output.agents) {
+        if (agent.status !== "installed") {
+            const detail = agent.message ?? "failed to install";
+            lines.push(`${agent.name}: ${detail}`);
+        }
+    }
+    return lines.length > 0 ? lines.join("\n") : undefined;
+}
+
+/**
+ * Reduce an install result to the categorical error fields telemetry records:
+ * the top-level failure category (if any), and a per-agent map of the agents that
+ * did not install (failed or skipped) to their categorical error. Only
+ * categories are emitted — never the CLI's free-form `error`/`message` strings.
+ */
+export function summarizeAiToolsInstallErrors(
+    output: AiToolsInstallOutput | undefined
+): AiToolsInstallErrorSummary {
+    if (output === undefined) {
+        return {};
+    }
+    const summary: AiToolsInstallErrorSummary = {};
+    if (output.error_category !== undefined) {
+        summary.globalErrorCategory = output.error_category;
+    }
+    const agentErrors: Record<string, string> = {};
+    for (const agent of output.agents) {
+        if (agent.error_category !== undefined) {
+            agentErrors[agent.name] = agent.error_category;
+        }
+    }
+    if (Object.keys(agentErrors).length > 0) {
+        summary.agentErrors = agentErrors;
+    }
+    return summary;
+}

--- a/packages/databricks-vscode/src/cli/CliWrapper.test.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.test.ts
@@ -11,6 +11,7 @@ import {
     CliWrapper,
     ProcessError,
     getSshConnectCommand,
+    parseAiToolsInstallOutput,
 } from "./CliWrapper";
 import path from "node:path";
 import os from "node:os";
@@ -103,6 +104,59 @@ describe(__filename, function () {
         } finally {
             await rm(tmpDir, {recursive: true, force: true});
         }
+    });
+
+    it("parseAiToolsInstallOutput parses the install result shapes", () => {
+        // Success: every agent installed, no error fields.
+        assert.deepStrictEqual(
+            parseAiToolsInstallOutput(
+                '{"scope":"global","agents":[{"name":"claude-code","delivery":"plugin","status":"installed"}]}'
+            ),
+            {
+                scope: "global",
+                agents: [
+                    {
+                        name: "claude-code",
+                        delivery: "plugin",
+                        status: "installed",
+                    },
+                ],
+            }
+        );
+
+        // Per-agent failure carries a category and a (local-only) message.
+        const skip = parseAiToolsInstallOutput(
+            '{"scope":"project","agents":[{"name":"codex","delivery":"skip","status":"skipped","error_category":"UNSUPPORTED_SCOPE","message":"user-only"}]}'
+        );
+        assert.strictEqual(skip?.agents[0].error_category, "UNSUPPORTED_SCOPE");
+
+        // Top-level failure: empty agents plus error/error_category.
+        const topLevel = parseAiToolsInstallOutput(
+            '{"scope":"global","agents":[],"error":"skill not found","error_category":"SKILL_NOT_FOUND"}'
+        );
+        assert.strictEqual(topLevel?.error_category, "SKILL_NOT_FOUND");
+
+        // A top-level failure may omit `agents` entirely (Go's omitempty on a nil
+        // slice); it is still a result, with agents defaulted to [].
+        const noAgents = parseAiToolsInstallOutput(
+            '{"scope":"global","error":"skill not found","error_category":"SKILL_NOT_FOUND"}'
+        );
+        assert.deepStrictEqual(noAgents?.agents, []);
+        assert.strictEqual(noAgents?.error_category, "SKILL_NOT_FOUND");
+    });
+
+    it("parseAiToolsInstallOutput returns undefined for non-result output", () => {
+        // A CLI old enough to ignore `--output json` prints human text.
+        assert.strictEqual(
+            parseAiToolsInstallOutput("Installed the plugin for 1 agent."),
+            undefined
+        );
+        // Valid JSON that is neither an install result nor an error document.
+        assert.strictEqual(
+            parseAiToolsInstallOutput('{"release":"0.1.0"}'),
+            undefined
+        );
+        assert.strictEqual(parseAiToolsInstallOutput(""), undefined);
     });
 
     it("should resolve the platform-specific CLI binary name", () => {

--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -223,6 +223,94 @@ export interface AiToolsListResult {
     agents: AiToolsAgent[];
 }
 
+/**
+ * Delivery method for an agent in `aitools install --output json`, mirroring the
+ * CLI's `delivery` enum: the databricks `plugin`, raw `skills`, or `skip` (the
+ * agent was not acted on).
+ */
+export type AiToolsInstallDelivery = "plugin" | "skills" | "skip";
+
+/** Per-agent outcome status in `aitools install --output json`. */
+export type AiToolsInstallStatus = "installed" | "skipped" | "failed";
+
+/** A single agent entry from `databricks aitools install --output json`. */
+export interface AiToolsInstallAgentResult {
+    name: string;
+    delivery: AiToolsInstallDelivery;
+    status: AiToolsInstallStatus;
+    /**
+     * Present only for a non-installed agent (skipped/failed); a closed category
+     * token. The sibling `message` is free-form and must never reach telemetry.
+     */
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    error_category?: string;
+    message?: string;
+}
+
+/**
+ * Parsed output of `databricks aitools install --output json`, mirroring the
+ * CLI's `installOutput` struct. On success every agent is `installed` and both
+ * `error` fields are absent; on failure the CLI exits non-zero but still prints
+ * this document — a top-level failure (skills group, ref lookup) populates
+ * `error`/`error_category`, while a per-agent failure stays in `agents` and
+ * leaves the top-level fields empty.
+ *
+ * `agents` is normalized to `[]` by {@link parseAiToolsInstallOutput}: a
+ * top-level failure has no per-agent entries, and Go's `omitempty` can drop the
+ * key entirely, so it is not safe to assume the wire document carries it.
+ */
+export interface AiToolsInstallOutput {
+    scope: string;
+    agents: AiToolsInstallAgentResult[];
+    error?: string;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    error_category?: string;
+}
+
+/**
+ * Parse the JSON document `aitools install --output json` prints on stdout,
+ * returning undefined when stdout is not a parseable install result. Two callers
+ * rely on the undefined case: a success exit from a CLI old enough to ignore
+ * `--output json` (it prints human-readable text — a successful install with no
+ * structured result), and a non-zero exit with no JSON (a hard failure the caller
+ * turns into a {@link ProcessError}).
+ *
+ * A document counts as a result when it carries an `agents` array *or* a string
+ * `error`/`error_category` — a top-level failure marshals its nil `agents` slice
+ * away under Go's `omitempty`, so an error document may omit the key entirely;
+ * `agents` is defaulted to `[]` in that case. This is enough to tell a result
+ * from stray text without rejecting the very error shapes this parsing feeds.
+ */
+export function parseAiToolsInstallOutput(
+    stdout: string
+): AiToolsInstallOutput | undefined {
+    let obj: unknown;
+    try {
+        obj = JSON.parse(stdout);
+    } catch {
+        return undefined;
+    }
+    if (typeof obj !== "object" || obj === null) {
+        return undefined;
+    }
+    const rec = obj as {
+        agents?: unknown;
+        error?: unknown;
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        error_category?: unknown;
+    };
+    const hasAgents = Array.isArray(rec.agents);
+    const hasError =
+        typeof rec.error === "string" || typeof rec.error_category === "string";
+    if (!hasAgents && !hasError) {
+        return undefined;
+    }
+    return {
+        ...(obj as AiToolsInstallOutput),
+        agents: hasAgents ? (rec.agents as AiToolsInstallAgentResult[]) : [],
+    };
+}
+
 export class ProcessError extends Error {
     constructor(
         message: string,
@@ -600,10 +688,18 @@ export class CliWrapper {
      *
      * `cwd` selects the install root: the project root for `--scope project`
      * (installs into `.databricks/aitools/skills` under the workspace) or the
-     * home dir for `--scope global` (see AiToolsManager.cwdForScope). The CLI
-     * prints human-readable text (it ignores `--output json` for this
-     * subcommand), so success/failure is determined by the exit code (a non-zero
-     * exit rejects with a {@link ProcessError}).
+     * home dir for `--scope global` (see AiToolsManager.cwdForScope).
+     *
+     * Runs with `--output json` and never throws: it resolves with `{output,
+     * error}` and leaves it to the caller ({@link AiToolsManager}) to record the
+     * categories and decide how to surface a failure. `output` is the parsed
+     * {@link AiToolsInstallOutput}, or `undefined` when stdout carries no
+     * structured result — an empty `agents` request, or a success from a CLI old
+     * enough to ignore `--output json` (human text on stdout). `error` is the
+     * non-zero-exit error (`undefined` on a success exit); a JSON-capable CLI
+     * still prints the structured result on a failing exit, so both `output` and
+     * `error` can be present, letting per-agent and top-level failures reach
+     * telemetry with their categories.
      */
     @withLogContext(Loggers.Extension)
     public async aitoolsInstall(
@@ -612,9 +708,12 @@ export class CliWrapper {
         cancellationToken: CancellationToken | undefined,
         agents: string[],
         @context ctx?: Context
-    ): Promise<void> {
+    ): Promise<{
+        output: AiToolsInstallOutput | undefined;
+        error: Error | undefined;
+    }> {
         if (agents.length === 0) {
-            return;
+            return {output: undefined, error: undefined};
         }
 
         const args = [
@@ -624,18 +723,34 @@ export class CliWrapper {
             scope,
             "--agents",
             agents.join(","),
+            "--output",
+            "json",
         ];
         try {
-            await execFile(
+            const res = await execFile(
                 this.cliPath,
                 args,
                 {cwd, env: this.aitoolsEnv()},
                 cancellationToken,
                 {closeStdin: true}
             );
-        } catch (e: any) {
-            ctx?.logger?.error("Failed to install Databricks AI tools", e);
-            throw new ProcessError(e.message, e.code ?? null);
+            return {
+                output: parseAiToolsInstallOutput(res.stdout),
+                error: undefined,
+            };
+        } catch (error: unknown) {
+            ctx?.logger?.error("Failed to install Databricks AI tools", error);
+            if (!(error instanceof Error)) {
+                return {output: undefined, error: new Error(String(error))};
+            }
+            // A JSON-capable CLI prints the structured result on stdout even when
+            // the install fails (non-zero exit). Hand it back for the caller to
+            // inspect and record.
+            const output =
+                "stdout" in error && typeof error.stdout === "string"
+                    ? parseAiToolsInstallOutput(error.stdout)
+                    : undefined;
+            return {output, error};
         }
     }
 
@@ -690,13 +805,16 @@ export class CliWrapper {
     }
 
     /**
-     * List Databricks AI tools components as structured JSON.
-     *
-     * `aitools list` is the only aitools subcommand that emits real JSON
-     * (`aitools update --check` and `install` print text). We use it both to
+     * List Databricks AI tools components as structured JSON. We use it both to
      * detect whether an update is available (any installed skill whose
      * `installed[scope]` differs from `latest_version`) and to read the current
      * release.
+     *
+     * `aitools list` output is trusted and cast directly (`aitools update --check`
+     * still prints text). `aitools install` also emits JSON under `--output json`,
+     * but on a non-zero exit and from a CLI old enough to ignore the flag, so
+     * {@link aitoolsInstall} parses it defensively via
+     * {@link parseAiToolsInstallOutput} instead of casting.
      */
     @withLogContext(Loggers.Extension)
     public async aitoolsList(

--- a/packages/databricks-vscode/src/telemetry/constants.ts
+++ b/packages/databricks-vscode/src/telemetry/constants.ts
@@ -397,6 +397,8 @@ export class EventTypes {
             source?: AiToolsInstallSource;
             agents?: string[];
             cursorPlugin?: boolean;
+            globalErrorCategory?: string;
+            agentErrors?: Record<string, string>;
         } & DurationMeasurement
     > = {
         comment: "Install Databricks AI tools",
@@ -418,6 +420,25 @@ export class EventTypes {
         cursorPlugin: {
             comment:
                 "In Cursor, whether the Databricks marketplace plugin (a superset of the Cursor skills) was installed as part of this flow, rather than the cursor skills via the CLI",
+        },
+        globalErrorCategory: {
+            comment:
+                "The CLI's classification of a top-level install failure that has no per-agent " +
+                "entry (e.g. a skills-group install or reference-lookup failure), from " +
+                "'aitools install --output json'. A closed category token (e.g. SKILL_NOT_FOUND, " +
+                "PLUGIN_INSTALL_FAILED); an unrecognised token collapses to 'other'. Never the " +
+                "CLI's free-form error message. Omitted when there was no top-level failure, or " +
+                "when the bundled CLI predates JSON install output",
+        },
+        agentErrors: {
+            comment:
+                "Per-agent install errors as a map of agent id to its categorical error, for " +
+                'each requested agent that did not install (failed or skipped) — e.g. {"codex":' +
+                '"UNSUPPORTED_SCOPE"}. Keyed on the agent id so a category can be attributed to a ' +
+                "specific agent (exploded into one row per agent downstream). Categories are the " +
+                "CLI's closed set; an unrecognised token collapses to 'other'. Never the free-form " +
+                "per-agent message. JSON-stringified into a property by recordEvent. Omitted when " +
+                "every requested agent installed, or when the bundled CLI predates JSON install output",
         },
     };
     [Events.AITOOLS_UPDATE]: EventType<


### PR DESCRIPTION
## Changes

Run `aitools install` with `--output json` and parse the result so the AITOOLS_INSTALL telemetry event carries the CLI's error categories: a top-level `globalErrorCategory` and a per-agent `agentErrors` map, both category tokens only (never the free-form error/message strings)

## Tests

updated / added unit tests
