### PR TITLE
Stop reading the `valid` field from `auth profiles`

### DIFF
--- a/packages/databricks-vscode/src/cli/CliWrapper.ts
+++ b/packages/databricks-vscode/src/cli/CliWrapper.ts
@@ -166,7 +166,6 @@ export interface ConfigEntry {
     workspaceId?: string;
     cloud: Cloud;
     authType: string;
-    valid: boolean;
 }
 
 export type SyncType = "full" | "incremental";
@@ -479,6 +478,10 @@ export class CliWrapper {
     }
 
     private getListProfilesCommand(): Command {
+        // Keep --skip-validate: older CLIs still validate every profile here,
+        // which makes listing slow and can hang on an unreachable host. Newer
+        // CLIs never validate and accept the flag as a hidden no-op, so passing
+        // it is correct for both (see databricks/cli#5216).
         return {
             command: this.cliPath,
             args: [
@@ -544,7 +547,6 @@ export class CliWrapper {
                     workspaceId: profile.workspace_id,
                     cloud: profile.cloud,
                     authType: profile.auth_type,
-                    valid: profile.valid,
                 });
             } catch (e: unknown) {
                 let msg: string;


### PR DESCRIPTION
The Databricks CLI is making `auth profiles` a pure config-file listing: it will no longer validate credentials, so the `valid` field in the JSON output is going away (see databricks/cli#5216).

Drop `ConfigEntry.valid`. It was parsed out of the JSON but never read anywhere, so nothing behavioural changes — this just stops depending on a field that is disappearing.

`--skip-validate` is deliberately kept: older CLIs still validate every profile here, which is slow and can hang on an unreachable host, and newer CLIs accept the flag as a hidden no-op. Passing it stays correct across both.

`authType` also keeps working: the CLI infers auth_type from the config file keys, so profile auth types still render in the login wizard.

Co-authored-by: Isaac
