### PR TITLE
fix(python-setup): report the chosen preset in the setup success panel

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -1877,6 +1877,36 @@ describe("PythonSetupEnvironmentSetup constraint-conflict recovery", () => {
         expect(setup.ready).to.equal(true);
     });
 
+    it("hands showSuccess the DB Connect flags after a Full-preset conflict retry, so the panel omits the pins line", async () => {
+        const cli = makeScriptedCli([conflictResult(), SUCCESS_REAL_RUN]);
+        let successFlags: SetupPresetFlags | undefined;
+        let retryAction: PythonSetupErrorAction | undefined;
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                pickSetupPreset: async () => "full",
+                showSuccess: async (_r, flags) => {
+                    successFlags = flags;
+                },
+                showError: async (_message, _detail, actions) => {
+                    retryAction = actions?.find(
+                        (a) => a.label === "Retry DB Connect setup"
+                    );
+                },
+            })
+        );
+
+        await setup.setup();
+        await (retryAction as {run: () => Promise<void>}).run();
+
+        // The success panel must describe the retry that actually ran (DB
+        // Connect, no pins), not the user's original Full pick. showSuccess
+        // fires only on the successful retry, and its flags come from the same
+        // presetToFlags the retry invocation used — this locks the regression
+        // the whole fix guards against.
+        expect(successFlags).to.deep.equal({skipConstraints: true});
+    });
+
     it("records the retry as a dbconnect run with the conflict_retry trigger", async () => {
         const cli = makeScriptedCli([conflictResult(), SUCCESS_REAL_RUN]);
         const telemetry = makeTelemetryRecorder();

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -17,7 +17,7 @@ import {
 } from "../models/fixtures/setupLocalResults";
 import {PythonSetupErrorAction} from "../utils/errorMessages";
 import {SetupLocalInvocation} from "../utils/setupLocalArgs";
-import {SetupPreset} from "../utils/pythonSetupPresetPicker";
+import {SetupPreset, SetupPresetFlags} from "../utils/pythonSetupPresetPicker";
 import {
     PythonSetupAttempt,
     PythonSetupOutcomeReport,
@@ -1627,6 +1627,37 @@ describe("PythonSetupEnvironmentSetup.setup preset selection", () => {
         const invocation = await invocationFor("python");
         expect(invocation.skipConstraints).to.equal(true);
         expect(invocation.skipDbconnect).to.equal(true);
+    });
+
+    /** Capture the flags handed to showSuccess on a successful run. */
+    function flagsAtShowSuccess(preset: SetupPreset) {
+        let seen: SetupPresetFlags | undefined;
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                pickSetupPreset: async () => preset,
+                showSuccess: async (_r, flags) => {
+                    seen = flags;
+                },
+            })
+        );
+        return setup.setup().then(() => seen);
+    }
+
+    it("hands showSuccess the Full preset's flags so the panel reports the pins", async () => {
+        expect(await flagsAtShowSuccess("full")).to.deep.equal({});
+    });
+
+    it("hands showSuccess the DB Connect preset's flags so the panel omits the pins", async () => {
+        expect(await flagsAtShowSuccess("dbconnect")).to.deep.equal({
+            skipConstraints: true,
+        });
+    });
+
+    it("hands showSuccess the Python preset's flags so the panel omits pins and databricks-connect", async () => {
+        expect(await flagsAtShowSuccess("python")).to.deep.equal({
+            skipConstraints: true,
+            skipDbconnect: true,
+        });
     });
 
     it("passes the resolved compute to the preset picker", async () => {

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -29,7 +29,11 @@ import {
 } from "../utils/reportSetupIssue";
 import {isReauthRequiredError} from "../utils/authErrors";
 import {SetupLocalInvocation} from "../utils/setupLocalArgs";
-import {presetToFlags, SetupPreset} from "../utils/pythonSetupPresetPicker";
+import {
+    presetToFlags,
+    SetupPreset,
+    SetupPresetFlags,
+} from "../utils/pythonSetupPresetPicker";
 import {
     PythonSetupAttempt,
     PythonSetupResultReporter,
@@ -205,7 +209,10 @@ export interface PythonSetupSetupDeps {
         options?: {includeShowLogs?: boolean}
     ) => Promise<void>;
 
-    showSuccess: (result: PythonSetupResult) => Promise<void>;
+    showSuccess: (
+        result: PythonSetupResult,
+        flags: SetupPresetFlags
+    ) => Promise<void>;
 
     /**
      * Static build context (extension/CLI versions, OS) stamped into a
@@ -446,9 +453,10 @@ export class PythonSetupEnvironmentSetup implements Disposable {
     ): Promise<void> {
         const {cli, withProgress} = this.deps;
 
+        const flags = presetToFlags(preset);
         const invocation: SetupLocalInvocation = {
             compute,
-            ...presetToFlags(preset),
+            ...flags,
         };
 
         // From here a run really happens, so the attempt is recorded and every
@@ -683,7 +691,7 @@ export class PythonSetupEnvironmentSetup implements Disposable {
             warnings: result.warnings,
         });
 
-        this.present(this.deps.showSuccess(result));
+        this.present(this.deps.showSuccess(result, flags));
     }
 
     /**

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -209,6 +209,14 @@ export interface PythonSetupSetupDeps {
         options?: {includeShowLogs?: boolean}
     ) => Promise<void>;
 
+    /**
+     * Present the success outcome. `flags` are the resolved skip flags of the
+     * run that actually happened (from {@link presetToFlags}), passed
+     * explicitly because `PythonSetupResult` alone cannot say which preset ran:
+     * `result.mode` encodes only the databricks-connect axis, so a Full and a
+     * DB Connect run are indistinguishable in it. The panel needs them to state
+     * truthfully whether constraints were written.
+     */
     showSuccess: (
         result: PythonSetupResult,
         flags: SetupPresetFlags

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.test.ts
@@ -1192,7 +1192,7 @@ describe("makePythonSetupDeps showSuccess", () => {
             })
         );
 
-        await deps.showSuccess(SUCCESS_DEFAULT);
+        await deps.showSuccess(SUCCESS_DEFAULT, {});
 
         expect(appended.join("")).to.have.length.greaterThan(0);
         // The automatic reveal fires regardless of what the user clicks.
@@ -1205,7 +1205,7 @@ describe("makePythonSetupDeps showSuccess", () => {
     it("raises an info toast (never a warning) when the run had warnings", async () => {
         const deps = makePythonSetupDeps(makeWiring());
 
-        await deps.showSuccess(SUCCESS_WITH_WARNINGS);
+        await deps.showSuccess(SUCCESS_WITH_WARNINGS, {});
 
         // A successful run is informational even when it carried warnings;
         // the warning count is in the message and the details behind it.
@@ -1229,7 +1229,7 @@ describe("makePythonSetupDeps showSuccess", () => {
         );
         reply = "View Details";
 
-        await deps.showSuccess(SUCCESS_DEFAULT);
+        await deps.showSuccess(SUCCESS_DEFAULT, {});
 
         // Once on the automatic reveal, again when the button is picked.
         expect(shown).to.equal(2);

--- a/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/pythonSetupDeps.ts
@@ -434,7 +434,7 @@ export function makePythonSetupDeps(
                 );
             }
         },
-        showSuccess: async (result) => {
+        showSuccess: async (result, flags) => {
             // Write the full breakdown to the log channel: in --output json
             // mode the CLI streams little or nothing to stderr on success, so
             // the channel would otherwise be empty. This is where the details
@@ -444,7 +444,7 @@ export function makePythonSetupDeps(
             const projectName = result.venvPath
                 ? await readVenvProjectName(result.venvPath)
                 : undefined;
-            wiring.log.append(formatSetupLog(result, projectName));
+            wiring.log.append(formatSetupLog(result, flags, projectName));
             // Reveal the output channel automatically so those details are in
             // front of the user, then still raise the notification (with its
             // "View Details" button) as before.

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.test.ts
@@ -1,11 +1,20 @@
 import {expect} from "chai";
 import {formatSetupLog, formatSetupNotification} from "./setupSummary";
 import {PythonSetupResult} from "../models/PythonSetupResult";
+import {SetupPresetFlags} from "./pythonSetupPresetPicker";
 import {
     SUCCESS_DEFAULT,
     SUCCESS_CONSTRAINTS_ONLY,
     SUCCESS_REAL_RUN,
 } from "../models/fixtures/setupLocalResults";
+
+// The three presets the picker resolves to, as the skip flags formatSetupLog
+// keys its output off (see presetToFlags). Full writes constraints and adds
+// databricks-connect; DB Connect adds databricks-connect but no pins; Python
+// does neither.
+const FULL: SetupPresetFlags = {};
+const DB_CONNECT: SetupPresetFlags = {skipConstraints: true};
+const PYTHON: SetupPresetFlags = {skipConstraints: true, skipDbconnect: true};
 
 describe("formatSetupNotification", () => {
     it("is a concise, use-case-neutral one-liner with no warnings", () => {
@@ -55,21 +64,21 @@ describe("formatSetupNotification", () => {
 
 describe("formatSetupLog", () => {
     it("is non-empty and self-delimited with leading/trailing newlines", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT);
+        const log = formatSetupLog(SUCCESS_DEFAULT, FULL);
         expect(log.startsWith("\n")).to.equal(true);
         expect(log.endsWith("\n")).to.equal(true);
         expect(log.trim().length).to.be.greaterThan(0);
     });
 
     it("includes the versions and capitalized compute label", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT);
+        const log = formatSetupLog(SUCCESS_DEFAULT, FULL);
         expect(log).to.contain("Python:             3.12");
         expect(log).to.contain("databricks-connect: 17.2.0");
         expect(log).to.contain("Compute:            Serverless v4");
     });
 
     it("lists what was done, falling back to the bare .venv name", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT);
+        const log = formatSetupLog(SUCCESS_DEFAULT, FULL);
         expect(log).to.contain(
             "  • Added matching Databricks constraints to pyproject.toml"
         );
@@ -82,7 +91,12 @@ describe("formatSetupLog", () => {
     });
 
     it("shows the project name beside .venv when one is resolved", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project", "linux");
+        const log = formatSetupLog(
+            SUCCESS_DEFAULT,
+            FULL,
+            "my-project",
+            "linux"
+        );
         expect(log).to.contain(
             "  • Built a new virtual environment with uv sync called " +
                 ".venv (my-project)"
@@ -96,7 +110,9 @@ describe("formatSetupLog", () => {
     });
 
     it("tells the user how to run notebooks with the venv", () => {
-        expect(formatSetupLog(SUCCESS_DEFAULT, undefined, "linux")).to.contain(
+        expect(
+            formatSetupLog(SUCCESS_DEFAULT, FULL, undefined, "linux")
+        ).to.contain(
             "To run notebooks using this virtual environment, click Select " +
                 "Kernel in the upper right of a notebook and ensure that the " +
                 "virtual environment is selected (`.venv/bin/python`)."
@@ -104,7 +120,12 @@ describe("formatSetupLog", () => {
     });
 
     it("uses the Windows interpreter path in the notebook hint", () => {
-        const log = formatSetupLog(SUCCESS_DEFAULT, "my-project", "win32");
+        const log = formatSetupLog(
+            SUCCESS_DEFAULT,
+            FULL,
+            "my-project",
+            "win32"
+        );
         expect(log).to.contain(
             "virtual environment is selected: my-project " +
                 "(`.venv\\Scripts\\python.exe`)."
@@ -112,16 +133,43 @@ describe("formatSetupLog", () => {
         expect(log).to.not.contain(".venv/bin/python");
     });
 
-    it("drops databricks-connect in constraints-only mode", () => {
-        const log = formatSetupLog(SUCCESS_CONSTRAINTS_ONLY);
+    it("headlines the Full preset for Databricks Connect and reports its pins", () => {
+        const log = formatSetupLog(SUCCESS_DEFAULT, FULL);
         expect(log).to.contain(
-            "Python environment ready — constraints applied."
+            "Python environment ready for Databricks Connect."
         );
+        expect(log).to.contain("databricks-connect: 17.2.0");
+        expect(log).to.contain(
+            "  • Added matching Databricks constraints to pyproject.toml"
+        );
+    });
+
+    it("keeps databricks-connect but drops the pins line for the DB Connect preset", () => {
+        // --no-constraints: same CLI result shape as Full (mode "default",
+        // databricks-connect resolved), so only the flags tell the panel no
+        // pins were written.
+        const log = formatSetupLog(SUCCESS_DEFAULT, DB_CONNECT);
+        expect(log).to.contain(
+            "Python environment ready for Databricks Connect."
+        );
+        expect(log).to.contain("databricks-connect: 17.2.0");
+        expect(log).to.not.contain(
+            "Added matching Databricks constraints to pyproject.toml"
+        );
+    });
+
+    it("drops databricks-connect and the pins line for the Python preset", () => {
+        const log = formatSetupLog(SUCCESS_CONSTRAINTS_ONLY, PYTHON);
+        expect(log).to.contain("Python environment ready.");
+        expect(log).to.not.contain("for Databricks Connect");
         expect(log).to.not.contain("databricks-connect");
+        expect(log).to.not.contain(
+            "Added matching Databricks constraints to pyproject.toml"
+        );
     });
 
     it("shows the backup file on a real run", () => {
-        const log = formatSetupLog(SUCCESS_REAL_RUN);
+        const log = formatSetupLog(SUCCESS_REAL_RUN, FULL);
         expect(log).to.contain(
             "  • Backed up your previous pyproject.toml (pyproject.toml.bak)"
         );
@@ -132,7 +180,7 @@ describe("formatSetupLog", () => {
             ...SUCCESS_REAL_RUN,
             backupPath: undefined,
         };
-        expect(formatSetupLog(noBackup)).to.not.contain("Backed up");
+        expect(formatSetupLog(noBackup, FULL)).to.not.contain("Backed up");
     });
 
     it("lists full warning messages when present", () => {
@@ -140,7 +188,7 @@ describe("formatSetupLog", () => {
             ...SUCCESS_DEFAULT,
             warnings: [{code: "W_X", message: "pinned an older wheel"}],
         };
-        const log = formatSetupLog(warned);
+        const log = formatSetupLog(warned, FULL);
         expect(log).to.contain("Warnings:");
         expect(log).to.contain("  • pinned an older wheel");
     });

--- a/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
+++ b/packages/databricks-vscode/src/python-setup/utils/setupSummary.ts
@@ -3,6 +3,7 @@ import {
     PythonSetupComputeInfo,
     PythonSetupResult,
 } from "../models/PythonSetupResult";
+import {SetupPresetFlags} from "./pythonSetupPresetPicker";
 import {venvInterpreterPath} from "./venvInterpreterPath";
 
 /**
@@ -39,6 +40,14 @@ export function formatSetupNotification(result: PythonSetupResult): string {
  * messages) — necessary because in `--output json` mode the CLI streams little
  * or nothing to stderr on success, so without this the channel would be empty.
  *
+ * `flags` are the run's two orthogonal skip flags, resolved from the preset the
+ * user picked. They — not `result.mode` — decide what the panel claims was done:
+ * `mode` encodes only the databricks-connect axis (`default` vs
+ * `constraints-only`), so a DB Connect run (`--no-constraints`) is byte-identical
+ * to a Full run in that field and reading it would mis-report the constraints
+ * axis. `skipDbconnect` selects the databricks-connect vs plain-Python wording;
+ * `skipConstraints` gates the "added constraints" line.
+ *
  * `projectName` is the human-readable name uv associated with the venv (from
  * pyproject's `[project].name`, else the project folder name), surfaced by the
  * caller from `.venv/pyvenv.cfg`. It is shown in parentheses beside the venv
@@ -53,23 +62,25 @@ export function formatSetupNotification(result: PythonSetupResult): string {
  */
 export function formatSetupLog(
     result: PythonSetupResult,
+    flags: SetupPresetFlags,
     projectName?: string,
     platform: NodeJS.Platform = process.platform
 ): string {
-    const isDefault = result.mode === "default";
+    const withDbconnect = !flags.skipDbconnect;
+    const constraintsApplied = !flags.skipConstraints;
     // The venv folder is always `.venv`; when the caller resolved the project
     // name, show it alongside so the line reads like the label VS Code puts on
     // the interpreter (e.g. ".venv (my-project)").
     const venvLabel = projectName ? `.venv (${projectName})` : ".venv";
     const lines: string[] = [
-        isDefault
+        withDbconnect
             ? "Python environment ready for Databricks Connect."
-            : "Python environment ready — constraints applied.",
+            : "Python environment ready.",
         "",
     ];
 
     lines.push(`Python:             ${result.resolved?.pythonVersion ?? ""}`);
-    if (isDefault && result.resolved?.dbconnectVersion) {
+    if (withDbconnect && result.resolved?.dbconnectVersion) {
         lines.push(`databricks-connect: ${result.resolved.dbconnectVersion}`);
     }
     const compute = computeLabel(result.compute);
@@ -78,7 +89,11 @@ export function formatSetupLog(
     }
 
     lines.push("", "What was done:");
-    lines.push("  • Added matching Databricks constraints to pyproject.toml");
+    if (constraintsApplied) {
+        lines.push(
+            "  • Added matching Databricks constraints to pyproject.toml"
+        );
+    }
     lines.push(
         `  • Built a new virtual environment with uv sync called ${venvLabel}`
     );


### PR DESCRIPTION
## Why

The Python-setup success panel ("View Details" log) derived its wording from `result.mode`, which encodes only the **databricks-connect** axis (`default` vs `constraints-only`) — not whether dependency pins were written. So it misreported two of the three presets:

- A **DB Connect** run (`--no-constraints`) is byte-identical to **Full** in `mode`, so the panel always printed `• Added matching Databricks constraints to pyproject.toml` — false; DB Connect writes no pins.
- The **Python** preset (`--no-constraints --no-dbconnect`) maps to `constraints-only`, which the headline mislabeled "constraints applied" — backwards.

## What

Thread the run's resolved skip flags (`skipConstraints`/`skipDbconnect`, from `presetToFlags`) through `showSuccess` into `formatSetupLog`, and key the panel off those axes instead of `result.mode` (which it no longer reads):

- headline: `Python environment ready.` when databricks-connect is skipped, else `… ready for Databricks Connect.`
- databricks-connect version line: only when the run kept databricks-connect
- constraints bullet: only when pins were actually written

| Preset | Headline | `databricks-connect` line | Constraints bullet |
|---|---|---|---|
| Full | for Databricks Connect | yes | yes |
| DB Connect (`--no-constraints`) | for Databricks Connect | yes | **no** |
| Python (`--no-constraints --no-dbconnect`) | plain "ready" | no | no |

No persisted state or CLI-contract change — the panel is transient output.

## Testing

- Unit (42 passing): `formatSetupLog` three-preset matrix; per-preset flag wiring into `showSuccess`; and the Full→DB Connect **conflict-retry** case, asserting the panel describes the retry that actually ran (no pins), not the user's original Full pick.
- `tsc` typecheck, prettier, and eslint clean on the changed files.
- Not run locally: the full integration-test suite (covered by CI on this PR).

## Reviewer notes

- The panel now reports the run's *requested* flags rather than a CLI-confirmed "pins written" signal — deliberate, because the `--output json` contract exposes no such field (the premise of this fix). On a successful run the CLI honors the flags, so there is no realistic divergence; a future CLI that silently skipped pins on a Full run would make the bullet wrong, and warnings remain the escape hatch.

This pull request and its description were written by Isaac.
