### PR TITLE
feat(python-setup): widen conflict recovery to generic uv sync (E_PROVISION) failures

### DIFF
--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.test.ts
@@ -2234,4 +2234,136 @@ describe("PythonSetupEnvironmentSetup constraint-conflict recovery", () => {
         ]);
         expect(seenOptions[0]).to.equal(undefined);
     });
+
+    /**
+     * A Full-preset run whose uv sync fails with the *generic* E_PROVISION code
+     * (not the merge-phase E_PROVISION_CONFLICT) — e.g. a transitive conflict or
+     * a clash with databricks-connect's own dependency tree, which the CLI can
+     * only surface during the sync. Constraints were merged before the failure,
+     * so disk is mutated and a pre-merge backup exists — making the pinned
+     * cluster deps the prime suspect and the DB Connect retry a sensible offer.
+     */
+    function provisionFailureResult(): PythonSetupResult {
+        return {
+            ...conflictResult(),
+            error: {
+                code: "E_PROVISION",
+                failurePhase: "provision",
+                message:
+                    "error: No solution found when resolving dependencies: " +
+                    "databricks-connect depends on grpcio<1.60 but your project " +
+                    "requires grpcio==1.62",
+                diskMutated: true,
+            },
+        };
+    }
+
+    it("offers the same DB Connect recovery on a generic E_PROVISION failure of a Full run", async () => {
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
+        const seenOptions: Array<{includeShowLogs?: boolean} | undefined> = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: provisionFailureResult()}),
+                pickSetupPreset: async () => "full",
+                showError: async (_message, _detail, actions, options) => {
+                    shown.push({actions});
+                    seenOptions.push(options);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        // Identical recovery to the provable conflict: the same two buttons…
+        expect(shown[0].actions?.map((a) => a.label)).to.deep.equal([
+            "Retry DB Connect setup",
+            "Open pyproject.toml",
+        ]);
+        // …and the same self-service treatment (Show Logs hidden).
+        expect(seenOptions[0]).to.deep.equal({includeShowLogs: false});
+    });
+
+    it("re-runs with --no-constraints (and adopts) when Retry is picked after a generic E_PROVISION failure", async () => {
+        const cli = makeScriptedCli([
+            provisionFailureResult(),
+            SUCCESS_REAL_RUN,
+        ]);
+        const adopted: string[] = [];
+        let retryAction: PythonSetupErrorAction | undefined;
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli,
+                pickSetupPreset: async () => "full",
+                adoptInterpreter: async (venvPath) => {
+                    adopted.push(venvPath);
+                },
+                showError: async (_message, _detail, actions) => {
+                    retryAction = actions?.find(
+                        (a) => a.label === "Retry DB Connect setup"
+                    );
+                },
+            })
+        );
+
+        await setup.setup();
+        expect(retryAction).to.not.equal(undefined);
+        await (retryAction as {run: () => Promise<void>}).run();
+
+        expect(cli.calls).to.have.length(2);
+        expect(cli.calls[1].skipConstraints).to.equal(true);
+        expect(adopted).to.have.length(1);
+    });
+
+    it("does not offer the generic-E_PROVISION recovery on a run that already dropped the pins", async () => {
+        // A dbconnect run already passed --no-constraints, so the pins aren't the
+        // suspect and a "Retry DB Connect setup" would be a no-op that could loop.
+        // Fall through to the ordinary handling and keep Show Logs.
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
+        const seenOptions: Array<{includeShowLogs?: boolean} | undefined> = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: provisionFailureResult()}),
+                pickSetupPreset: async () => "dbconnect",
+                showError: async (_message, _detail, actions, options) => {
+                    shown.push({actions});
+                    seenOptions.push(options);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(
+            shown[0].actions?.some((a) => a.label === "Retry DB Connect setup")
+        ).to.equal(false);
+        expect(seenOptions[0]).to.equal(undefined);
+    });
+
+    it("does not offer the generic-E_PROVISION recovery when there is no backup to restore", async () => {
+        // Greenfield (no pre-existing pyproject) → no backupPath → nothing to roll
+        // the merged pins back to, so fall through to ordinary handling.
+        const noBackup: PythonSetupResult = {
+            ...provisionFailureResult(),
+            backupPath: undefined,
+        };
+        const shown: {actions?: PythonSetupErrorAction[]}[] = [];
+        const seenOptions: Array<{includeShowLogs?: boolean} | undefined> = [];
+        const setup = new PythonSetupEnvironmentSetup(
+            makeDeps({
+                cli: makeCli({resolve: noBackup}),
+                pickSetupPreset: async () => "full",
+                showError: async (_message, _detail, actions, options) => {
+                    shown.push({actions});
+                    seenOptions.push(options);
+                },
+            })
+        );
+
+        await setup.setup();
+
+        expect(
+            shown[0].actions?.some((a) => a.label === "Retry DB Connect setup")
+        ).to.equal(false);
+        expect(seenOptions[0]).to.equal(undefined);
+    });
 });

--- a/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
+++ b/packages/databricks-vscode/src/python-setup/controllers/PythonSetupEnvironmentSetup.ts
@@ -527,13 +527,22 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 result.pythonResolution === "installed_fallback"
                     ? "manual_selection_requested"
                     : result.pythonResolution;
-            // A constraint conflict is recoverable only when this run carried the
-            // pins (Full preset) AND the CLI saved a pre-merge backup to roll them
-            // back to. Without either, fall through to the ordinary doc-link
-            // handling rather than offer a "retry as DB Connect" that can't work
-            // (nothing to restore) or would loop (a run that already skipped pins).
-            const conflictBackupPath =
-                result.error?.code === "E_PROVISION_CONFLICT" &&
+            // A Full-preset run (one that pinned cluster constraints) that fails
+            // provisioning is recoverable by retrying as DB Connect: the pinned
+            // deps are the prime suspect. This covers both the CLI's provable,
+            // pre-sync E_PROVISION_CONFLICT and a generic E_PROVISION uv-sync
+            // failure — a transitive clash, or one against databricks-connect's
+            // own dependency tree, that only surfaces during the sync. Both need
+            // the run to have carried the pins (Full, `!skipConstraints`) AND a
+            // pre-merge backup to roll them back to. Without either, fall through
+            // to the ordinary doc-link handling rather than offer a "retry as DB
+            // Connect" that can't work (nothing to restore) or would loop (a run
+            // that already skipped the pins). Gating on the specific `E_PROVISION`
+            // code, not just the provision phase, leaves `E_PYTHON_INSTALL` on its
+            // own "Select Python interpreter" remediation below.
+            const recoveryBackupPath =
+                (result.error?.code === "E_PROVISION_CONFLICT" ||
+                    result.error?.code === "E_PROVISION") &&
                 !invocation.skipConstraints &&
                 // Truthiness, not just `!== undefined`: a (contract-forbidden)
                 // empty backupPath has nothing to restore, so it must fall
@@ -541,12 +550,13 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                 result.backupPath
                     ? result.backupPath
                     : undefined;
-            const recoverableConflict = conflictBackupPath !== undefined;
-            const actions = recoverableConflict
+            const recoverableProvisionFailure =
+                recoveryBackupPath !== undefined;
+            const actions = recoverableProvisionFailure
                 ? this.buildConflictRecoveryActions(
                       compute,
                       cwd,
-                      conflictBackupPath
+                      recoveryBackupPath
                   )
                 : remediationActions.some(
                         (candidate) =>
@@ -576,11 +586,13 @@ export class PythonSetupEnvironmentSetup implements Disposable {
                         reportRepo ? reportLogLink(reportRepo) : undefined
                     ),
                     actions,
-                    // The recoverable conflict is self-service via its Retry /
-                    // Open buttons, so drop the trailing "Show Logs" to keep the
-                    // notification's button row short (the channel is revealed
-                    // regardless).
-                    recoverableConflict ? {includeShowLogs: false} : undefined
+                    // A recoverable provision failure is self-service via its
+                    // Retry / Open buttons, so drop the trailing "Show Logs" to
+                    // keep the notification's button row short (the channel is
+                    // revealed regardless).
+                    recoverableProvisionFailure
+                        ? {includeShowLogs: false}
+                        : undefined
                 )
             );
             return;
@@ -687,12 +699,14 @@ export class PythonSetupEnvironmentSetup implements Disposable {
     }
 
     /**
-     * The two recovery buttons for a Full-preset constraint conflict, both
+     * The two recovery buttons for a recoverable Full-preset provisioning
+     * failure — a provable `E_PROVISION_CONFLICT`, or a generic `E_PROVISION`
+     * uv-sync failure where the pinned cluster deps are the prime suspect — both
      * run-actions (their behavior needs the run's live compute/cwd):
      *
      * - "Retry DB Connect setup" restores pyproject.toml from the CLI's pre-merge
      *   `backupPath`, then re-runs as DB Connect (`--no-constraints`). The restore
-     *   is load-bearing: the conflict fails *after* the pins were merged to disk,
+     *   is load-bearing: provisioning fails *after* the pins were merged to disk,
      *   so `--no-constraints` alone would leave the conflicting pins in place and
      *   only skip re-adding them. It runs through {@link runGuarded} — so a click
      *   can't race an in-flight run, and the restore only fires when the retry


### PR DESCRIPTION
## What
Widen the Python-setup conflict recovery so a **Full**-preset run that fails `uv sync` with a generic `E_PROVISION` (not only the CLI's provable, pre-sync `E_PROVISION_CONFLICT`) offers the same recovery: restore the pre-merge `pyproject.toml`, then **Retry as DB Connect setup** (`--no-constraints`).

## Why
`E_PROVISION_CONFLICT` is raised at the merge phase for a *direct-pin* disjoint (a version pinned in both the user's `pyproject.toml` and the cluster constraints). Conflicts that only `uv`'s resolver finds — transitive dependencies, or clashes with `databricks-connect`'s own dependency tree — instead fail during the sync as a generic `E_PROVISION`, and today get no recovery button. The Full tier's pinned cluster deps are the prime suspect for such a failure, so offering the DB-Connect retry (which drops those pins) closes the gap for the motivating "uv sync failed on conflicting versions" users.

## How
- Recovery gate widened from `E_PROVISION_CONFLICT` to `(E_PROVISION_CONFLICT || E_PROVISION) && !skipConstraints && backupPath`.
- Reuses the existing recovery actions verbatim: `[Retry as DB Connect setup]` + `[Open pyproject.toml]`, with `Show Logs` hidden (self-service) — identical to the provable-conflict path.
- **Loop-safe**: the gate requires the run carried the pins (`!skipConstraints`), so the `--no-constraints` retry can never re-enter recovery.
- Gating on the specific `E_PROVISION` code (not merely the provision phase) leaves `E_PYTHON_INSTALL` on its own "Select Python interpreter" remediation.
- **Greenfield** projects (no `backupPath`) fall through to today's handling.

## Testing
- New unit tests: same recovery buttons on a generic `E_PROVISION` Full failure; the retry re-runs with `--no-constraints` and adopts the interpreter; no recovery on a pins-dropped (DB Connect) run; no recovery when there is no backup.
- `yarn test:unit` (1146 passing) and `yarn test:lint` both clean.

## Notes
- Telemetry: the widened retry reuses the existing `conflict_retry` trigger; the preceding failure's `errorCode` (`E_PROVISION` vs `E_PROVISION_CONFLICT`) distinguishes a provable conflict from a suspected one in the funnel.

This pull request and its description were written by Isaac.
