### PR TITLE
test(ssh): catch bundled CLI truncation and reconnect regressions

### DIFF
--- a/packages/databricks-vscode/package.json
+++ b/packages/databricks-vscode/package.json
@@ -1943,6 +1943,7 @@
         "@types/tmp": "^0.2.6",
         "@types/triple-beam": "^1.3.5",
         "@types/vscode": "1.86.0",
+        "@types/ws": "^8.5.11",
         "@types/yargs": "^17.0.32",
         "@typescript-eslint/eslint-plugin": "^8.62.0",
         "@typescript-eslint/parser": "^8.62.0",
@@ -1972,6 +1973,7 @@
         "vsce": "^2.15.0",
         "wdio-video-reporter": "^6.2.0",
         "wdio-vscode-service": "^8.0.0",
+        "ws": "^8.18.0",
         "yargs": "^17.7.2"
     },
     "nyc": {

--- a/packages/databricks-vscode/src/ssh/SshCommands.transfer.test.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.transfer.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import {spawn} from "node:child_process";
+import {randomBytes} from "node:crypto";
+import {mkdtemp, rm, writeFile} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {anything, instance, mock, reset, spy, verify, when} from "ts-mockito";
+import {env, EventEmitter, window} from "vscode";
+import type {
+    ExtensionContext,
+    QuickPick,
+    QuickPickItem,
+    Terminal,
+    TerminalOptions,
+} from "vscode";
+import {CliWrapper} from "../cli/CliWrapper";
+import {ClusterModel} from "../cluster/ClusterModel";
+import {ConnectionManager} from "../configuration/ConnectionManager";
+import {DatabricksWorkspace} from "../configuration/DatabricksWorkspace";
+import type {AuthProvider} from "../configuration/auth/AuthProvider";
+import {LoggerManager} from "../logger";
+import {Cluster} from "../sdk-extensions/Cluster";
+import {createSshTunnelTestServer} from "../test/sshTunnelTestServer";
+import {SshCommands} from "./SshCommands";
+
+// Remote VS Code startup transfers several MiB; CLI 1.16.0 cut streams off at 1 MiB.
+const PAYLOAD_BYTES = 8 * 1024 * 1024;
+
+describe("SSH tunnel command transfer", function () {
+    this.timeout(30_000);
+
+    it("transfers the complete IDE-sized payload through the bundled CLI without reconnecting", async () => {
+        const directory = await mkdtemp(
+            path.join(os.tmpdir(), "ssh-transfer-")
+        );
+        const peer = await createSshTunnelTestServer();
+        const accept = new EventEmitter<void>();
+        const hide = new EventEmitter<void>();
+        const changed = new EventEmitter<void>();
+        const windowSpy = spy(window);
+        const envSpy = spy(env);
+        const pickerMock = mock<QuickPick<QuickPickItem>>();
+        const picker = instance(pickerMock);
+        let ssh: SshCommands | undefined;
+        try {
+            const configFile = path.join(directory, "databrickscfg");
+            await writeFile(
+                configFile,
+                `[ssh-test]\nhost = ${peer.host}\ntoken = local-test-token\nauth_type = pat\n`
+            );
+            const context = mock<ExtensionContext>();
+            when(context.asAbsolutePath(anything())).thenCall(
+                (relative: string) => path.resolve(__dirname, "../..", relative)
+            );
+            const cli = new CliWrapper(
+                instance(context),
+                instance(mock(LoggerManager))
+            );
+            const auth = mock<AuthProvider>();
+            /* eslint-disable @typescript-eslint/naming-convention */
+            when(auth.toEnv()).thenReturn({
+                DATABRICKS_HOST: peer.host,
+                DATABRICKS_TOKEN: "local-test-token",
+                DATABRICKS_AUTH_TYPE: "pat",
+                DATABRICKS_CONFIG_PROFILE: "ssh-test",
+                DATABRICKS_CONFIG_FILE: configFile,
+            });
+            /* eslint-enable @typescript-eslint/naming-convention */
+            const workspace = mock(DatabricksWorkspace);
+            when(workspace.authProvider).thenReturn(instance(auth));
+            when(workspace.userName).thenReturn("ssh-test");
+            const connection = mock(ConnectionManager);
+            when(connection.isInitialized).thenReturn(true);
+            when(connection.state).thenReturn("CONNECTED");
+            when(connection.databricksWorkspace).thenReturn(
+                instance(workspace)
+            );
+            const cluster = mock(Cluster);
+            when(cluster.id).thenReturn("test-cluster");
+            when(cluster.name).thenReturn("Test cluster");
+            when(cluster.state).thenReturn("RUNNING");
+            when(cluster.isValidSingleUser("ssh-test")).thenReturn(true);
+            const clusters = mock(ClusterModel);
+            when(clusters.allRoots).thenReturn([instance(cluster)]);
+            when(clusters.onDidChange).thenReturn(changed.event);
+
+            when(pickerMock.onDidAccept).thenReturn(accept.event);
+            when(pickerMock.onDidHide).thenReturn(hide.event);
+            let disposed = false;
+            when(pickerMock.dispose()).thenCall(() => {
+                if (!disposed) {
+                    disposed = true;
+                    hide.fire();
+                }
+            });
+            const shown = new Promise<void>((resolve) => {
+                when(pickerMock.show()).thenCall(resolve);
+            });
+            when(windowSpy.createQuickPick()).thenReturn(picker);
+            when(windowSpy.showErrorMessage(anything())).thenResolve(undefined);
+            when(
+                windowSpy.showWarningMessage(anything(), anything())
+            ).thenResolve(undefined);
+            const terminal = mock<Terminal>();
+            let command: string | undefined;
+            let terminalOptions: TerminalOptions | undefined;
+            when(terminal.sendText(anything())).thenCall((value: string) => {
+                command = value;
+            });
+            when(windowSpy.createTerminal(anything())).thenCall(
+                (value: TerminalOptions) => {
+                    terminalOptions = value;
+                    return instance(terminal);
+                }
+            );
+            const shell = process.platform === "win32" ? "cmd.exe" : "/bin/sh";
+            when(envSpy.shell).thenReturn(shell);
+            ssh = new SshCommands(
+                cli,
+                instance(connection),
+                instance(clusters)
+            );
+            const started = ssh.startTunnelCommand();
+            await shown;
+            const selected = picker.items.find((item) => "cluster" in item);
+            assert.ok(
+                selected,
+                "the compute picker must offer the test cluster"
+            );
+            picker.selectedItems = [selected];
+            accept.fire();
+            await started;
+            verify(windowSpy.showErrorMessage(anything())).never();
+            verify(terminal.sendText(anything())).once();
+            assert.ok(command, "accepting compute must launch the CLI");
+            assert.ok(terminalOptions);
+
+            // Enter the same ProxyCommand path Remote SSH uses after provisioning.
+            // Only cloud setup and the remote peer are replaced; the bundled CLI is real.
+            command +=
+                " --proxy --metadata=ssh-test,7772,test-cluster --profile=ssh-test";
+            const batch = path.join(directory, "launch.cmd");
+            await writeFile(batch, `@echo off\r\n${command}\r\n`);
+            const shellArgs =
+                process.platform === "win32"
+                    ? ["/d", "/c", batch]
+                    : ["-c", command];
+            const inherited = Object.fromEntries(
+                Object.entries(process.env).filter(
+                    ([key]) =>
+                        !key.startsWith("DATABRICKS_") &&
+                        !key.toLowerCase().includes("proxy")
+                )
+            );
+            /* eslint-disable @typescript-eslint/naming-convention */
+            const child = spawn(shell, shellArgs, {
+                cwd: directory,
+                detached: process.platform !== "win32",
+                env: {
+                    ...inherited,
+                    ...terminalOptions.env,
+                    HOME: directory,
+                    USERPROFILE: directory,
+                    LOCALAPPDATA: path.join(directory, "local-app-data"),
+                    APPDATA: path.join(directory, "app-data"),
+                    XDG_CACHE_HOME: path.join(directory, "cache"),
+                    NO_PROXY: "127.0.0.1",
+                } as NodeJS.ProcessEnv,
+            });
+            /* eslint-enable @typescript-eslint/naming-convention */
+            const payload = randomBytes(PAYLOAD_BYTES);
+            const output: Buffer[] = [];
+            let outputBytes = 0;
+            let stderr = "";
+            child.stdin.on("error", () => {});
+            child.stderr.on("data", (data: Buffer) => {
+                stderr = (stderr + data).slice(-16_384);
+            });
+            child.stdout.on("data", (data: Buffer) => {
+                output.push(data);
+                outputBytes += data.length;
+                if (outputBytes >= payload.length) {
+                    child.stdin.end();
+                }
+            });
+            const closed = new Promise<{
+                code: number | null;
+                signal: NodeJS.Signals | null;
+            }>((resolve, reject) => {
+                child.once("error", reject);
+                child.once("close", (code, signal) => resolve({code, signal}));
+            });
+            const timeout = setTimeout(() => {
+                if (!child.pid) {
+                    return;
+                }
+                if (process.platform === "win32") {
+                    spawn("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+                        stdio: "ignore",
+                    }).on("error", () => child.kill("SIGKILL"));
+                } else {
+                    process.kill(-child.pid, "SIGKILL");
+                }
+            }, 20_000);
+            child.stdin.write(payload);
+            const result = await closed.finally(() => clearTimeout(timeout));
+            const diagnostic = `CLI exit=${result.code}, signal=${result.signal}; uploaded=${peer.receivedBytes}, downloaded=${outputBytes}, expected=${PAYLOAD_BYTES}\n${stderr}`;
+            // The regressed CLI can exit successfully after truncating the stream.
+            assert.equal(peer.receivedBytes, PAYLOAD_BYTES, diagnostic);
+            assert.equal(outputBytes, PAYLOAD_BYTES, diagnostic);
+            assert.ok(
+                Buffer.concat(output).equals(payload),
+                "tunnel payload was corrupted"
+            );
+            assert.equal(result.code, 0, diagnostic);
+            assert.equal(peer.connections, 1, "transfer must not reconnect");
+            assert.deepEqual(peer.unexpectedRequests, []);
+        } finally {
+            picker.dispose();
+            ssh?.dispose();
+            reset(windowSpy);
+            reset(envSpy);
+            accept.dispose();
+            hide.dispose();
+            changed.dispose();
+            await peer.dispose();
+            await rm(directory, {
+                recursive: true,
+                force: true,
+                maxRetries: 5,
+                retryDelay: 200,
+            });
+        }
+    });
+});

--- a/packages/databricks-vscode/src/ssh/SshCommands.transfer.test.ts
+++ b/packages/databricks-vscode/src/ssh/SshCommands.transfer.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {spawn} from "node:child_process";
 import {randomBytes} from "node:crypto";
+import {existsSync} from "node:fs";
 import {mkdtemp, rm, writeFile} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -29,7 +30,22 @@ const PAYLOAD_BYTES = 8 * 1024 * 1024;
 describe("SSH tunnel command transfer", function () {
     this.timeout(30_000);
 
-    it("transfers the complete IDE-sized payload through the bundled CLI without reconnecting", async () => {
+    it("transfers the complete IDE-sized payload through the bundled CLI without reconnecting", async function () {
+        const context = mock<ExtensionContext>();
+        when(context.asAbsolutePath(anything())).thenCall((relative: string) =>
+            path.resolve(__dirname, "../..", relative)
+        );
+        const cli = new CliWrapper(
+            instance(context),
+            instance(mock(LoggerManager))
+        );
+        if (!existsSync(cli.cliPath)) {
+            assert(
+                !process.env.CI,
+                "Bundled CLI missing: run yarn workspace databricks run package:cli:fetch"
+            );
+            this.skip();
+        }
         const directory = await mkdtemp(
             path.join(os.tmpdir(), "ssh-transfer-")
         );
@@ -47,14 +63,6 @@ describe("SSH tunnel command transfer", function () {
             await writeFile(
                 configFile,
                 `[ssh-test]\nhost = ${peer.host}\ntoken = local-test-token\nauth_type = pat\n`
-            );
-            const context = mock<ExtensionContext>();
-            when(context.asAbsolutePath(anything())).thenCall(
-                (relative: string) => path.resolve(__dirname, "../..", relative)
-            );
-            const cli = new CliWrapper(
-                instance(context),
-                instance(mock(LoggerManager))
             );
             const auth = mock<AuthProvider>();
             /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/databricks-vscode/src/test/sshTunnelTestServer.ts
+++ b/packages/databricks-vscode/src/test/sshTunnelTestServer.ts
@@ -1,7 +1,7 @@
 import {generateKeyPairSync} from "node:crypto";
 import {createServer} from "node:http";
 import type {AddressInfo} from "node:net";
-import {WebSocket, WebSocketServer} from "ws";
+import {WebSocketServer} from "ws";
 
 /** Local workspace/driver-proxy peer; the CLI's byte-stream transport stays real. */
 export async function createSshTunnelTestServer() {
@@ -19,7 +19,6 @@ export async function createSshTunnelTestServer() {
         sshString(rawPublicKey),
     ]).toString("base64")}`;
     const unexpectedRequests: string[] = [];
-    const timers: NodeJS.Timeout[] = [];
     let receivedBytes = 0;
     let connections = 0;
 
@@ -84,8 +83,6 @@ export async function createSshTunnelTestServer() {
         if (request.headers.authorization !== "Bearer local-test-token") {
             unexpectedRequests.push("WebSocket auth was not forwarded");
         }
-        const resumable = url.searchParams.has("delivered");
-        let acknowledgedBytes = 0;
         socket.on("error", (error) =>
             unexpectedRequests.push(`WebSocket error: ${error.message}`)
         );
@@ -100,19 +97,6 @@ export async function createSshTunnelTestServer() {
                   : Buffer.from(data);
             receivedBytes += bytes.length;
             socket.send(bytes, {binary: true});
-            if (resumable && receivedBytes - acknowledgedBytes >= 64 * 1024) {
-                acknowledgedBytes = receivedBytes;
-                const delivered = receivedBytes;
-                // Match the protocol's 64 KiB acknowledgements with 50 ms latency.
-                // Healthy in-flight data must not be mistaken for a dead peer.
-                timers.push(
-                    setTimeout(() => {
-                        if (socket.readyState === WebSocket.OPEN) {
-                            socket.send(JSON.stringify({delivered}));
-                        }
-                    }, 50)
-                );
-            }
         });
     });
     await new Promise<void>((resolve, reject) => {
@@ -129,7 +113,6 @@ export async function createSshTunnelTestServer() {
             return connections;
         },
         async dispose() {
-            timers.forEach(clearTimeout);
             sockets.clients.forEach((socket) => socket.terminate());
             sockets.close();
             server.closeAllConnections();

--- a/packages/databricks-vscode/src/test/sshTunnelTestServer.ts
+++ b/packages/databricks-vscode/src/test/sshTunnelTestServer.ts
@@ -1,0 +1,141 @@
+import {generateKeyPairSync} from "node:crypto";
+import {createServer} from "node:http";
+import type {AddressInfo} from "node:net";
+import {WebSocket, WebSocketServer} from "ws";
+
+/** Local workspace/driver-proxy peer; the CLI's byte-stream transport stays real. */
+export async function createSshTunnelTestServer() {
+    const {privateKey, publicKey} = generateKeyPairSync("ed25519");
+    const rawPublicKey = publicKey
+        .export({type: "spki", format: "der"})
+        .subarray(-32);
+    const sshString = (value: Buffer) => {
+        const length = Buffer.alloc(4);
+        length.writeUInt32BE(value.length);
+        return Buffer.concat([length, value]);
+    };
+    const authorizedKey = `ssh-ed25519 ${Buffer.concat([
+        sshString(Buffer.from("ssh-ed25519")),
+        sshString(rawPublicKey),
+    ]).toString("base64")}`;
+    const unexpectedRequests: string[] = [];
+    const timers: NodeJS.Timeout[] = [];
+    let receivedBytes = 0;
+    let connections = 0;
+
+    const server = createServer((request, response) => {
+        const url = new URL(request.url!, "http://localhost");
+        let body: unknown;
+        /* eslint-disable @typescript-eslint/naming-convention */
+        switch (url.pathname) {
+            case "/.well-known/databricks-config":
+                response.statusCode = 404;
+                body = {};
+                break;
+            case "/api/2.0/preview/scim/v2/Me":
+                body = {userName: "ssh-test", id: "1"};
+                break;
+            case "/api/2.0/clusters/get":
+            case "/api/2.1/clusters/get":
+                body = {
+                    cluster_id: "test-cluster",
+                    state: "RUNNING",
+                    data_security_mode: "SINGLE_USER",
+                    single_user_name: "ssh-test",
+                };
+                break;
+            case "/api/2.0/secrets/list":
+                body = {secrets: []};
+                break;
+            case "/api/2.0/secrets/get": {
+                const value =
+                    url.searchParams.get("key") === "client-private-key"
+                        ? privateKey.export({type: "pkcs8", format: "pem"})
+                        : authorizedKey;
+                body = {value: Buffer.from(value).toString("base64")};
+                break;
+            }
+            case "/telemetry-ext":
+                body = {};
+                break;
+            case "/driver-proxy-api/o/1/test-cluster/7772/capabilities":
+                body = {resume: true};
+                break;
+            default:
+                unexpectedRequests.push(`${request.method} ${url.pathname}`);
+                response.statusCode = 404;
+                body = {
+                    error_code: "NOT_FOUND",
+                    message: "Unexpected test request",
+                };
+        }
+        /* eslint-enable @typescript-eslint/naming-convention */
+        response.setHeader("Content-Type", "application/json");
+        response.setHeader("X-Databricks-Org-Id", "1");
+        response.end(JSON.stringify(body));
+    });
+    const sockets = new WebSocketServer({server});
+    sockets.on("connection", (socket, request) => {
+        connections++;
+        const url = new URL(request.url!, "http://localhost");
+        if (url.pathname !== "/driver-proxy-api/o/1/test-cluster/7772/ssh") {
+            unexpectedRequests.push(`WebSocket ${url.pathname}`);
+        }
+        if (request.headers.authorization !== "Bearer local-test-token") {
+            unexpectedRequests.push("WebSocket auth was not forwarded");
+        }
+        const resumable = url.searchParams.has("delivered");
+        let acknowledgedBytes = 0;
+        socket.on("error", (error) =>
+            unexpectedRequests.push(`WebSocket error: ${error.message}`)
+        );
+        socket.on("message", (data, binary) => {
+            if (!binary) {
+                return;
+            }
+            const bytes = Buffer.isBuffer(data)
+                ? data
+                : Array.isArray(data)
+                  ? Buffer.concat(data)
+                  : Buffer.from(data);
+            receivedBytes += bytes.length;
+            socket.send(bytes, {binary: true});
+            if (resumable && receivedBytes - acknowledgedBytes >= 64 * 1024) {
+                acknowledgedBytes = receivedBytes;
+                const delivered = receivedBytes;
+                // Match the protocol's 64 KiB acknowledgements with 50 ms latency.
+                // Healthy in-flight data must not be mistaken for a dead peer.
+                timers.push(
+                    setTimeout(() => {
+                        if (socket.readyState === WebSocket.OPEN) {
+                            socket.send(JSON.stringify({delivered}));
+                        }
+                    }, 50)
+                );
+            }
+        });
+    });
+    await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    return {
+        host: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+        unexpectedRequests,
+        get receivedBytes() {
+            return receivedBytes;
+        },
+        get connections() {
+            return connections;
+        },
+        async dispose() {
+            timers.forEach(clearTimeout);
+            sockets.clients.forEach((socket) => socket.terminate());
+            sockets.close();
+            server.closeAllConnections();
+            await new Promise<void>((resolve, reject) =>
+                server.close((error) => (error ? reject(error) : resolve()))
+            );
+        },
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4017,6 +4017,7 @@ __metadata:
     "@types/tmp": ^0.2.6
     "@types/triple-beam": ^1.3.5
     "@types/vscode": 1.86.0
+    "@types/ws": ^8.5.11
     "@types/yargs": ^17.0.32
     "@typescript-eslint/eslint-plugin": ^8.62.0
     "@typescript-eslint/parser": ^8.62.0
@@ -4060,6 +4061,7 @@ __metadata:
     wdio-video-reporter: ^6.2.0
     wdio-vscode-service: ^8.0.0
     winston: ^3.11.0
+    ws: ^8.18.0
     yaml: ^2.8.3
     yargs: ^17.7.2
   languageName: unknown


### PR DESCRIPTION
## Changes

Add a regression test to the unit-test suite that exercises the real bundled CLI through the extension's SSH command construction. A localhost HTTP/WebSocket peer replaces workspace provisioning and echoes an 8 MiB payload.

Assert complete upload and download, byte equality, successful exit, and a single connection. Checking payload completeness catches CLI 1.16.0's truncated streams even when it exits zero. The test requires no workspace credentials and adds explicit WebSocket test dependencies.

The peer advertises resume capability to exercise CLI 1.16.0's affected transport, but does not send ACK control frames. CLI 1.16.1 does not support those frames. A missing bundled binary skips the test locally and fails with a fetch instruction in CI.

## Tests

- Revised test: CLI 1.16.0 fails on an incomplete transfer; 1.16.1 and 1.12.1 pass.
- Verified missing-binary behavior: one skipped test locally, explicit failure in CI.
- Lint, formatting, and diff checks passed for the revised sources.
- Previous PR revision passed the full Linux and Windows unit-test jobs, including this regression test. The latest revision awaits fresh CI.
- Earlier regression validation also confirmed CLI 1.16.0 fails and 1.16.1 passes on Windows and against extension v2.17.0 source.
